### PR TITLE
feat: 优化清除上下文按钮的功能逻辑

### DIFF
--- a/app/src/main/java/me/rerere/rikkahub/ui/components/chat/ChatInput.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/chat/ChatInput.kt
@@ -197,6 +197,7 @@ fun ChatInput(
     onClearContext: () -> Unit,
     onCancelClick: () -> Unit,
     onSendClick: () -> Unit,
+    isContextTruncated: Boolean = false,
 ) {
     val text =
         state.messageContent.filterIsInstance<UIMessagePart.Text>().firstOrNull()
@@ -400,7 +401,8 @@ fun ChatInput(
                 }
 
                 MoreOptionsButton(
-                    onClearContext = onClearContext
+                    onClearContext = onClearContext,
+                    isContextTruncated = isContextTruncated
                 )
 
                 Spacer(Modifier.weight(1f))
@@ -460,6 +462,7 @@ fun ChatInput(
 @Composable
 private fun MoreOptionsButton(
     onClearContext: () -> Unit = {},
+    isContextTruncated: Boolean = false,
 ) {
     var showMoreOptions by remember { mutableStateOf(false) }
     ExposedDropdownMenuBox(
@@ -480,14 +483,22 @@ private fun MoreOptionsButton(
         ) {
             DropdownMenuItem(
                 text = {
-                    Text(stringResource(R.string.chat_page_clear_context))
+                    Text(
+                        stringResource(
+                            if (isContextTruncated) R.string.chat_page_restore_context
+                            else R.string.chat_page_clear_context
+                        )
+                    )
                 },
                 onClick = {
                     showMoreOptions = false
                     onClearContext()
                 },
                 leadingIcon = {
-                    Icon(Lucide.Eraser, null)
+                    Icon(
+                        if (isContextTruncated) Lucide.ArrowUp else Lucide.Eraser,
+                        null
+                    )
                 }
             )
         }

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -37,6 +37,8 @@
     <string name="chat_page_edit_title_warning">まずチャットしてからタイトルを編集してください</string>
     <string name="chat_page_search_placeholder">会話を検索</string>
     <string name="chat_page_clear_context">コンテキストをクリア</string>
+    <string name="chat_page_restore_context">コンテキストを復元</string>
+    <string name="chat_page_context_truncated">コンテキストが切り詰められました</string>
 
     <!-- Export Chat -->
     <string name="chat_page_export_format">エクスポート形式</string>
@@ -71,14 +73,14 @@
     <string name="setting_page_config_api_title">APIとモデルを設定してください</string>
     <string name="setting_page_config_api_desc">APIとモデルを設定してください</string>
     <string name="setting_page_config">設定</string>
-    
+
 
     <!-- Setting Model Page -->
     <string name="setting_model_page_title">モデル設定</string>
     <string name="setting_model_page_chat_model">チャットモデル</string>
     <string name="setting_model_page_title_model">タイトル要約モデル</string>
     <string name="setting_model_page_translate_model">翻訳モデル</string>
-    
+
     <!-- Translator Page -->
     <string name="translator_page_title">翻訳</string>
     <string name="translator_page_input_text">入力テキスト</string>
@@ -88,7 +90,7 @@
     <string name="translator_page_target_language">対象言語:</string>
     <string name="translator_page_translate">翻訳</string>
     <string name="translator_page_cancel">キャンセル</string>
-    
+
     <!-- Assistant Page -->
     <string name="assistant_page_title">アシスタント設定</string>
     <string name="assistant_page_add">追加</string>
@@ -124,7 +126,7 @@
     <string name="assistant_page_thinking_budget_tokens">%s トークン</string>
     <string name="assistant_page_thinking_budget_default">デフォルト</string>
     <string name="assistant_page_thinking_budget_warning">注意：異なるプロバイダーは様々な思考バジェットAPIフォーマットを定義しており、アプリはすべてに対応できないため、このオプションが機能しない場合があります。機能しない場合は、下のカスタムボディを使用してリクエストをカスタマイズすることをお勧めします。</string>
-    
+
     <!-- Custom Headers and Bodies -->
     <string name="assistant_page_custom_headers">カスタムヘッダー</string>
     <string name="assistant_page_header_name">ヘッダー名</string>
@@ -137,10 +139,10 @@
     <string name="assistant_page_invalid_json">無効なJSON: %s</string>
     <string name="assistant_page_delete_body">ボディを削除</string>
     <string name="assistant_page_add_body">ボディを追加</string>
-    
+
     <!-- Notification -->
     <string name="notification_channel_chat_completed">チャット完了</string>
-    
+
     <!-- Theme Types -->
     <string name="setting_page_theme_type_standard">標準</string>
     <string name="setting_page_theme_type_medium_contrast">中コントラスト</string>
@@ -171,7 +173,7 @@
     <!-- Code Block -->
     <string name="code_block_copy">コードをコピー</string>
     <string name="code_block_preview">プレビュー</string>
-    
+
     <!-- Mermaid Diagram -->
     <string name="mermaid_export">エクスポート</string>
     <string name="mermaid_export_success">エクスポートに成功しました</string>
@@ -187,7 +189,7 @@
     <string name="setting_display_page_auto_collapse_thinking_desc">思考が完了したら思考内容を自動的に折りたたむ</string>
     <string name="setting_display_page_show_updates_title">アップデートを表示</string>
     <string name="setting_display_page_show_updates_desc">アプリのアップデート通知を表示するかどうか</string>
-    
+
     <!-- Color Mode -->
     <string name="setting_page_color_mode">カラーモード</string>
     <string name="setting_page_color_mode_system">システム設定に従う</string>
@@ -201,4 +203,4 @@
     <string name="assistant_page_tab_request">カスタムリクエスト</string>
     <string name="assistant_page_stream_output">ストリーミング出力</string>
     <string name="assistant_page_stream_output_desc">メッセージをストリーミング出力するかどうか</string>
-</resources> 
+</resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -37,6 +37,8 @@
     <string name="chat_page_edit_title_warning">請先聊天再編輯標題吧</string>
     <string name="chat_page_search_placeholder">搜尋對話記錄</string>
     <string name="chat_page_clear_context">清空上下文</string>
+    <string name="chat_page_restore_context">恢復上下文</string>
+    <string name="chat_page_context_truncated">上下文已截斷</string>
 
     <!-- Export Chat -->
     <string name="chat_page_export_format">匯出格式</string>
@@ -71,13 +73,13 @@
     <string name="setting_page_config_api_title">請配置API和模型</string>
     <string name="setting_page_config_api_desc">你還沒有配置API和模型，請先配置</string>
     <string name="setting_page_config">配置</string>
-    
+
     <!-- Setting Model Page -->
     <string name="setting_model_page_title">模型設定</string>
     <string name="setting_model_page_chat_model">聊天模型</string>
     <string name="setting_model_page_title_model">標題摘要模型</string>
     <string name="setting_model_page_translate_model">翻譯模型</string>
-    
+
     <!-- Translator Page -->
     <string name="translator_page_title">翻譯</string>
     <string name="translator_page_input_text">輸入文字</string>
@@ -87,7 +89,7 @@
     <string name="translator_page_target_language">目標語言:</string>
     <string name="translator_page_translate">翻譯</string>
     <string name="translator_page_cancel">取消</string>
-    
+
     <!-- Assistant Page -->
     <string name="assistant_page_title">助手設定</string>
     <string name="assistant_page_add">添加</string>
@@ -123,7 +125,7 @@
     <string name="assistant_page_thinking_budget_tokens">%s token</string>
     <string name="assistant_page_thinking_budget_default">預設</string>
     <string name="assistant_page_thinking_budget_warning">注意，由於不同提供商定義了各種不同的思考預算API格式，APP無法考慮到，因此這個選項不一定起作用，如果不起作用，推薦使用下面的自定義body來自定義請求</string>
-    
+
     <!-- Custom Headers and Bodies -->
     <string name="assistant_page_custom_headers">自定義 Headers</string>
     <string name="assistant_page_header_name">Header 名稱</string>
@@ -136,10 +138,10 @@
     <string name="assistant_page_invalid_json">無效的 JSON: %s</string>
     <string name="assistant_page_delete_body">刪除 Body</string>
     <string name="assistant_page_add_body">添加 Body</string>
-    
+
     <!-- Notification -->
     <string name="notification_channel_chat_completed">聊天完成</string>
-    
+
     <!-- Theme Types -->
     <string name="setting_page_theme_type_standard">標準</string>
     <string name="setting_page_theme_type_medium_contrast">中對比</string>
@@ -170,7 +172,7 @@
     <!-- Code Block -->
     <string name="code_block_copy">複製代碼</string>
     <string name="code_block_preview">預覽</string>
-    
+
     <!-- Mermaid Diagram -->
     <string name="mermaid_export">匯出</string>
     <string name="mermaid_export_success">匯出成功</string>
@@ -186,7 +188,7 @@
     <string name="setting_display_page_show_updates_title">顯示更新</string>
     <string name="setting_display_page_show_updates_desc">是否顯示應用更新通知</string>
     <string name="setting_display_page_title">顯示設定</string>
-    
+
     <!-- Color Mode -->
     <string name="setting_page_color_mode">顏色模式</string>
     <string name="setting_page_color_mode_system">跟隨系統</string>
@@ -200,4 +202,4 @@
     <string name="assistant_page_tab_request">自定義請求</string>
     <string name="assistant_page_stream_output">串流輸出</string>
     <string name="assistant_page_stream_output_desc">是否啟用訊息的串流輸出</string>
-</resources> 
+</resources>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -37,6 +37,8 @@
     <string name="chat_page_edit_title_warning">请先聊天再编辑标题吧</string>
     <string name="chat_page_search_placeholder">搜索聊天记录</string>
     <string name="chat_page_clear_context">清空上下文</string>
+    <string name="chat_page_restore_context">恢复上下文</string>
+    <string name="chat_page_context_truncated">上下文已截断</string>
 
     <!-- Export Chat -->
     <string name="chat_page_export_format">导出格式</string>
@@ -71,13 +73,13 @@
     <string name="setting_page_config_api_title">请配置API和模型</string>
     <string name="setting_page_config_api_desc">你还没有配置API和模型，请先配置</string>
     <string name="setting_page_config">配置</string>
-    
+
     <!-- Setting Model Page -->
     <string name="setting_model_page_title">模型设置</string>
     <string name="setting_model_page_chat_model">聊天模型</string>
     <string name="setting_model_page_title_model">标题总结模型</string>
     <string name="setting_model_page_translate_model">翻译模型</string>
-    
+
     <!-- Translator Page -->
     <string name="translator_page_title">翻译</string>
     <string name="translator_page_input_text">输入文本</string>
@@ -87,7 +89,7 @@
     <string name="translator_page_target_language">目标语言:</string>
     <string name="translator_page_translate">翻译</string>
     <string name="translator_page_cancel">取消</string>
-    
+
     <!-- Assistant Page -->
     <string name="assistant_page_title">助手设置</string>
     <string name="assistant_page_add">添加</string>
@@ -123,7 +125,7 @@
     <string name="assistant_page_thinking_budget_tokens">%s token</string>
     <string name="assistant_page_thinking_budget_default">默认</string>
     <string name="assistant_page_thinking_budget_warning">注意，由于不同提供商定义了各种不同的思考预算API格式，APP无法考虑到，因此这个选项不一定起作用，如果不起作用，推荐使用下面的自定义body来自定义请求</string>
-    
+
     <!-- Custom Headers and Bodies -->
     <string name="assistant_page_custom_headers">自定义 Headers</string>
     <string name="assistant_page_header_name">Header 名称</string>
@@ -136,21 +138,21 @@
     <string name="assistant_page_invalid_json">无效的 JSON: %s</string>
     <string name="assistant_page_delete_body">删除 Body</string>
     <string name="assistant_page_add_body">添加 Body</string>
-    
+
     <!-- Notification -->
     <string name="notification_channel_chat_completed">聊天完成</string>
-    
+
     <!-- Theme Types -->
     <string name="setting_page_theme_type_standard">标准</string>
     <string name="setting_page_theme_type_medium_contrast">中对比</string>
     <string name="setting_page_theme_type_high_contrast">高对比</string>
-    
+
     <!-- Theme Names -->
     <string name="theme_name_black">中性黑</string>
     <string name="theme_name_sakura">樱花粉</string>
     <string name="theme_name_ocean">海湾蓝</string>
     <string name="theme_name_spring">原野绿</string>
-    
+
     <!-- Menu Page -->
     <string name="menu_page_morning_greeting">早上好\uD83D\uDC4B</string>
     <string name="menu_page_afternoon_greeting">下午好\uD83D\uDC4B</string>
@@ -159,18 +161,18 @@
     <string name="menu_page_ai_translator">AI翻译</string>
     <string name="menu_page_knowledge_base">知识库 (施工中)</string>
     <string name="menu_page_llm_leaderboard">LLM排行榜</string>
-    
+
     <!-- ModelList Page -->
     <string name="model_list_select_model">选择模型</string>
     <string name="model_list_no_providers">没有可用AI提供商, 请在设置添加</string>
     <string name="model_list_favorite">收藏</string>
     <string name="model_list_chat">聊天</string>
     <string name="model_list_embedding">嵌入</string>
-    
+
     <!-- Code Block -->
     <string name="code_block_copy">复制代码</string>
     <string name="code_block_preview">预览</string>
-    
+
     <!-- Mermaid Diagram -->
     <string name="mermaid_export">导出</string>
     <string name="mermaid_export_success">导出成功</string>
@@ -186,7 +188,7 @@
     <string name="setting_display_page_show_updates_title">显示更新</string>
     <string name="setting_display_page_show_updates_desc">是否显示应用更新通知</string>
     <string name="setting_display_page_title">显示设置</string>
-    
+
     <!-- Color Mode -->
     <string name="setting_page_color_mode">颜色模式</string>
     <string name="setting_page_color_mode_system">跟随系统</string>
@@ -200,4 +202,4 @@
     <string name="assistant_page_tab_request">自定义请求</string>
     <string name="assistant_page_stream_output">流式输出</string>
     <string name="assistant_page_stream_output_desc">是否启用消息的流式输出</string>
-</resources> 
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -36,6 +36,8 @@
     <string name="chat_page_edit_title_warning">Please chat first before editing the title</string>
     <string name="chat_page_search_placeholder">Search conversations</string>
     <string name="chat_page_clear_context">Clear Context</string>
+    <string name="chat_page_restore_context">Restore Context</string>
+    <string name="chat_page_context_truncated">Context Truncated</string>
 
     <!-- Export Chat -->
     <string name="chat_page_export_format">Export Format</string>
@@ -86,7 +88,7 @@
     <string name="translator_page_target_language">Target Language:</string>
     <string name="translator_page_translate">Translate</string>
     <string name="translator_page_cancel">Cancel</string>
-    
+
     <!-- Assistant Page -->
     <string name="assistant_page_title">Assistant Settings</string>
     <string name="assistant_page_add">Add</string>
@@ -122,7 +124,7 @@
     <string name="assistant_page_thinking_budget_tokens">%s tokens</string>
     <string name="assistant_page_thinking_budget_default">Default</string>
     <string name="assistant_page_thinking_budget_warning">Note: Different providers define various thinking budget API formats that the APP cannot accommodate for all, so this option may not work. If it doesn\'t work, we recommend using the custom body below to customize your request.</string>
-    
+
     <!-- Custom Headers and Bodies -->
     <string name="assistant_page_custom_headers">Custom Headers</string>
     <string name="assistant_page_header_name">Header Name</string>
@@ -135,21 +137,21 @@
     <string name="assistant_page_invalid_json">Invalid JSON: %s</string>
     <string name="assistant_page_delete_body">Delete Body</string>
     <string name="assistant_page_add_body">Add Body</string>
-    
+
     <!-- Notification -->
     <string name="notification_channel_chat_completed">Chat Completed</string>
-    
+
     <!-- Theme Types -->
     <string name="setting_page_theme_type_standard">Standard</string>
     <string name="setting_page_theme_type_medium_contrast">Medium Contrast</string>
     <string name="setting_page_theme_type_high_contrast">High Contrast</string>
-    
+
     <!-- Theme Names -->
     <string name="theme_name_black">Neutral Black</string>
     <string name="theme_name_sakura">Sakura Pink</string>
     <string name="theme_name_ocean">Ocean Blue</string>
     <string name="theme_name_spring">Meadow Green</string>
-    
+
     <!-- Menu Page -->
     <string name="menu_page_morning_greeting">Good morning\uD83D\uDC4B</string>
     <string name="menu_page_afternoon_greeting">Good afternoon\uD83D\uDC4B</string>
@@ -165,11 +167,11 @@
     <string name="model_list_favorite">Favorites</string>
     <string name="model_list_chat">Chat</string>
     <string name="model_list_embedding">Embedding</string>
-    
+
     <!-- Code Block -->
     <string name="code_block_copy">Copy Code</string>
     <string name="code_block_preview">Preview</string>
-    
+
     <!-- Mermaid Diagram -->
     <string name="mermaid_export">Export</string>
     <string name="mermaid_export_success">Export successful</string>
@@ -185,7 +187,7 @@
     <string name="setting_display_page_show_updates_title">Show Updates</string>
     <string name="setting_display_page_show_updates_desc">Whether to display app update notifications</string>
     <string name="setting_display_page_title">Display Settings</string>
-    
+
     <!-- Color Mode -->
     <string name="setting_page_color_mode">Color Mode</string>
     <string name="setting_page_color_mode_system">System</string>


### PR DESCRIPTION
### 清除上下文按钮功能逻辑优化

- **原来的功能**：点击"清除上下文"直接删除所有历史消息
- **改进后**：点击后发送消息不携带历史上下文，但保留消息显示
  - **第一次点击**：记录当前消息数量作为截断点，截断点之前的消息将不作为历史消息携带
  - **第二次点击**：恢复正常上下文，所有消息都会被正常携带

### 1. UI 交互更新

- 更新了 `ChatInput` 组件来接收和显示上下文截断状态
- 修改了`MoreOptionsButton`来根据状态显示不同的文本和图标：
  - 截断状态：显示"恢复上下文"和向上箭头图标
  - 正常状态：显示"清空上下文"和橡皮擦图标
- 添加了视觉指示器，当上下文被截断时显示"上下文已截断"标签，截断指示器作为消息流的一部分，不干扰正常的聊天体验

### 2. 功能逻辑

- ChatVM 状态管理

  - 添加了 `isContextTruncated` 状态变量来跟踪上下文是否被截断

  - 添加了 `contextTruncationIndex` 来记录截断的位置

  - 实现了 `toggleContextTruncation()` 方法来切换上下文截断状态

- 消息发送逻辑

  - 修改了`handleMessageComplete()`方法，根据上下文截断状态决定发送哪些消息：
    - 如果上下文被截断，只发送从截断点开始的消息
    - 如果上下文正常，发送所有消息

- 示例

  - 消息1 (被截断)
    消息2 (被截断)
    ━━━━━ 上下文已截断 ━━━━━  ← 截断指示器
    消息3 (AI可访问)
    消息4 (AI可访问)

  

  