### PR TITLE
feat: 允许ReasoningCard在加载时自适应内容高度

### DIFF
--- a/app/src/main/java/me/rerere/rikkahub/data/datastore/PreferencesStore.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/datastore/PreferencesStore.kt
@@ -212,6 +212,7 @@ data class DisplaySetting(
     val showTokenUsage: Boolean = true,
     val autoCloseThinking: Boolean = true,
     val showUpdates: Boolean = true,
+    val limitReasoningHeightDuringLoading: Boolean = true
 )
 
 fun Settings.isNotConfigured() = providers.all { it.models.isEmpty() }

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ChatPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ChatPage.kt
@@ -244,7 +244,8 @@ fun ChatPage(id: Uuid, vm: ChatVM = koinViewModel()) {
                 },
                 onDelete = {
                     vm.deleteMessage(it)
-                }
+                },
+                onMessageListClick = {} // Add the missing parameter
             )
         }
     }
@@ -259,13 +260,14 @@ private const val ContextUsageItemKey = "ContextUsageItemKey"
 private fun ChatList(
     innerPadding: PaddingValues,
     conversation: Conversation,
-    loading: Boolean,
+    loading: Boolean, // 这个 loading 代表整个会话是否在等待AI回复
     model: Model,
     settings: Settings,
     onRegenerate: (UIMessage) -> Unit = {},
     onEdit: (UIMessage) -> Unit = {},
     onForkMessage: (UIMessage) -> Unit = {},
     onDelete: (UIMessage) -> Unit = {},
+    onMessageListClick: () -> Unit // 保留这个参数
 ) {
     val state = rememberLazyListState()
     val scope = rememberCoroutineScope()
@@ -344,6 +346,7 @@ private fun ChatList(
                             message = message,
                             showIcon = settings.displaySetting.showModelIcon,
                             model = message.modelId?.let { settings.providers.findModelById(it) },
+                            isLoadingConversation = loading, // <--- 传递会话加载状态
                             onRegenerate = {
                                 onRegenerate(message)
                             },

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingDisplayPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingDisplayPage.kt
@@ -113,6 +113,25 @@ fun SettingDisplayPage(vm: SettingVM = koinViewModel()) {
             item {
                 ListItem(
                     headlineContent = {
+                        Text(stringResource(R.string.setting_display_page_limit_reasoning_height_title))
+                    },
+                    supportingContent = {
+                        Text(stringResource(R.string.setting_display_page_limit_reasoning_height_desc))
+                    },
+                    trailingContent = {
+                        Switch(
+                            checked = displaySetting.limitReasoningHeightDuringLoading,
+                            onCheckedChange = {
+                                updateDisplaySetting(displaySetting.copy(limitReasoningHeightDuringLoading = it))
+                            }
+                        )
+                    },
+                )
+            }
+
+            item {
+                ListItem(
+                    headlineContent = {
                         Text(stringResource(R.string.setting_display_page_show_updates_title))
                     },
                     supportingContent = {

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -185,6 +185,8 @@
     <string name="setting_display_page_show_token_usage_desc">会話の下部にトークン使用量を表示</string>
     <string name="setting_display_page_auto_collapse_thinking_title">思考を自動折りたたむ</string>
     <string name="setting_display_page_auto_collapse_thinking_desc">思考が完了したら思考内容を自動的に折りたたむ</string>
+    <string name="setting_display_page_limit_reasoning_height_title">思考中の高さ制限</string>
+    <string name="setting_display_page_limit_reasoning_height_desc">AIが思考中に思考内容領域の最大高さを制限するかどうか。</string>
     <string name="setting_display_page_show_updates_title">アップデートを表示</string>
     <string name="setting_display_page_show_updates_desc">アプリのアップデート通知を表示するかどうか</string>
     

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -183,6 +183,8 @@
     <string name="setting_display_page_show_token_usage_desc">在對話底部顯示Token消耗</string>
     <string name="setting_display_page_auto_collapse_thinking_title">自動折疊思考</string>
     <string name="setting_display_page_auto_collapse_thinking_desc">思考完成自動折疊思考內容</string>
+    <string name="setting_display_page_limit_reasoning_height_title">限制思考時高度</string>
+    <string name="setting_display_page_limit_reasoning_height_desc">在AI思考過程中是否限制思考內容區域的最大高度。</string>
     <string name="setting_display_page_show_updates_title">顯示更新</string>
     <string name="setting_display_page_show_updates_desc">是否顯示應用更新通知</string>
     <string name="setting_display_page_title">顯示設定</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -183,6 +183,8 @@
     <string name="setting_display_page_show_token_usage_desc">在对话底部显示Token消耗</string>
     <string name="setting_display_page_auto_collapse_thinking_title">自动折叠思考</string>
     <string name="setting_display_page_auto_collapse_thinking_desc">思考完成自动折叠思考内容</string>
+    <string name="setting_display_page_limit_reasoning_height_title">限制思考时高度</string>
+    <string name="setting_display_page_limit_reasoning_height_desc">在AI思考过程中是否限制思考内容区域的最大高度。</string>
     <string name="setting_display_page_show_updates_title">显示更新</string>
     <string name="setting_display_page_show_updates_desc">是否显示应用更新通知</string>
     <string name="setting_display_page_title">显示设置</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -182,6 +182,8 @@
     <string name="setting_display_page_show_token_usage_desc">Display token usage at the bottom of the conversation</string>
     <string name="setting_display_page_auto_collapse_thinking_title">Auto Collapse Thinking</string>
     <string name="setting_display_page_auto_collapse_thinking_desc">Automatically collapse thinking content after thinking is complete</string>
+    <string name="setting_display_page_limit_reasoning_height_title">Limit Reasoning Height During Loading</string>
+    <string name="setting_display_page_limit_reasoning_height_desc">Limit the height of reasoning content during loading to prevent it from taking up too much space</string>
     <string name="setting_display_page_show_updates_title">Show Updates</string>
     <string name="setting_display_page_show_updates_desc">Whether to display app update notifications</string>
     <string name="setting_display_page_title">Display Settings</string>


### PR DESCRIPTION
**描述:**

引入了一个新选项，允许 `ReasoningCard`（用于显示AI思考步骤的组件）在加载过程中也能根据内容完全展开高度。此举旨在解决先前固定的最大高度（`100.dp`）在AI思考内容较多或流式输出较快时，可能导致用户来不及阅读完整思考过程的问题。

**主要变更:**

1.  **在 `DisplaySetting` 中新增 `limitReasoningHeightDuringLoading` 配置项:**
    *   增加了一个布尔类型的设置项（默认为 `true`，以保持现有行为），用户可以通过此设置控制在AI思考加载阶段是否限制思考卡片的高度。
    *   文件: `data/datastore/PreferencesStore.kt`

2.  **修改 `ChatMessage.kt` 中的 `ReasoningCard` 组件:**
    *   现在，`heightIn(max = 100.dp)` 修饰符会根据新的 `limitReasoningHeightDuringLoading` 设置项和当前的 `loading` 状态条件性地应用于思考内容的 `Column`。
    *   关键改动：`Modifier.verticalScroll()` 现在*仅*在思考内容 `Column` 的高度*被限制*时才应用。如果高度不受限制（即 `limitReasoningHeightDuringLoading` 为 `false`），内部 `Column` 将不再具有内部滚动能力，允许其完全展开，并依赖外部的 `LazyColumn` 进行滚动。这解决了因嵌套可滚动组件高度约束未定义而导致的 `IllegalStateException` 错误。

3.  **更新 `SettingDisplayPage.kt`:**
    *   在显示设置界面为新的 `limitReasoningHeightDuringLoading` 选项添加了一个 `Switch` 开关，方便用户配置。

4.  **添加字符串资源:**
    *   为新设置项的标题和描述添加了相应的英文、简体中文、繁体中文和日文的字符串资源。

**变更原因:**

之前固定的加载时高度限制，可能使得用户在AI思考内容较多或流式输出较快时难以完整追踪其思考过程。本次修改为用户提供了更大的灵活性，提升了思考步骤的可读性。同时，对 `IllegalStateException` 的修复确保了在不限制高度时布局行为的正确性。

**测试情况:**

*   已测试 `limitReasoningHeightDuringLoading = true` (默认行为): `ReasoningCard` 在加载时行为与之前一致，高度限制为 `100.dp`，内部可滚动。
*   已测试 `limitReasoningHeightDuringLoading = false`: `ReasoningCard` 在加载时能根据内容完全展开高度，无内部滚动，未出现 `IllegalStateException`。外部 `LazyColumn` 负责滚动。
*   设置界面的开关功能正常。

![c6c4352870e4f11c88f06246dd9b9f40](https://github.com/user-attachments/assets/4079c31b-a895-42e8-8db9-98876ee8ad02)
