### PR TITLE
优化：聊天消息操作按钮在消息加载完成后显示

### DIFF
--- a/app/src/main/java/me/rerere/rikkahub/ui/components/chat/ChatMessage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/chat/ChatMessage.kt
@@ -2,6 +2,10 @@ package me.rerere.rikkahub.ui.components.chat
 
 import android.speech.tts.TextToSpeech
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
 import androidx.compose.animation.animateContentSize
 import androidx.compose.foundation.LocalIndication
 import androidx.compose.foundation.background
@@ -122,6 +126,7 @@ fun ChatMessage(
     modifier: Modifier = Modifier,
     showIcon: Boolean = true,
     model: Model? = null,
+    isFullyLoaded: Boolean, // New parameter
     onFork: () -> Unit,
     onRegenerate: () -> Unit,
     onEdit: () -> Unit,
@@ -129,7 +134,9 @@ fun ChatMessage(
     onDelete: () -> Unit
 ) {
     Column(
-        modifier = modifier.fillMaxWidth(),
+        modifier = modifier
+            .fillMaxWidth()
+            .animateContentSize(), // Add this to the root Column of ChatMessage
         horizontalAlignment = if (message.role == MessageRole.USER) Alignment.End else Alignment.Start,
         verticalArrangement = Arrangement.spacedBy(4.dp)
     ) {
@@ -139,16 +146,26 @@ fun ChatMessage(
             message.parts,
             message.annotations,
         )
-        if (message.isValidToShowActions()) {
-            Actions(
-                message = message,
-                model = model,
-                onRegenerate = onRegenerate,
-                onEdit = onEdit,
-                onFork = onFork,
-                onShare = onShare,
-                onDelete = onDelete
-            )
+        AnimatedVisibility(
+            visible = message.isValidToShowActions() && isFullyLoaded,
+            enter = slideInVertically { it / 2 } + fadeIn(),
+            exit = slideOutVertically { it / 2 } + fadeOut()
+        ) {
+            // Wrap Actions content in its own Column to ensure it's a distinct layout block
+            // that AnimatedVisibility can properly manage.
+            Column(
+                modifier = Modifier.animateContentSize() // Also animate size changes within Actions
+            ) {
+                Actions( // Actions is a ColumnScope extension, so it adds its children here
+                    message = message,
+                    model = model,
+                    onRegenerate = onRegenerate,
+                    onEdit = onEdit,
+                    onFork = onFork,
+                    onShare = onShare,
+                    onDelete = onDelete
+                )
+            }
         }
     }
 }


### PR DESCRIPTION
**需求背景:**

当前聊天界面中，消息的操作按钮（如复制、编辑、重试等）会在消息体开始渲染时立即显示。对于正在流式加载的助手消息，这可能导致在消息内容尚未完全接收和渲染完成时，用户就能看到并可能尝试操作这些按钮，体验上不够清爽。

**本次优化目标:**

为了提升用户体验，本次修改旨在确保消息的操作按钮仅在该消息（特别是最后一条助手消息）完全加载和渲染完成后才显示。

**主要变更点:**

1.  **`ChatList.kt` (`me.rerere.rikkahub.ui.pages.chat.ChatPage.kt`):**
    *   在 `itemsIndexed` 循环中，为每条消息增加了一个 `isMessageFullyLoaded` 状态判断。
    *   该状态的逻辑是：
        *   如果消息是最后一条助手消息，则其加载完成状态取决于全局的 `loading` 标志（表示是否有正在进行的生成任务）。
        *   对于其他消息（历史消息、用户消息），则认为它们是已加载完成的。
    *   将此 `isMessageFullyLoaded` 状态作为新参数传递给 `ChatMessage` 组件。

2.  **`ChatMessage.kt` (`me.rerere.rikkahub.ui.components.chat.ChatMessage.kt`):**
    *   `ChatMessage` 组件接收新的 `isFullyLoaded` 参数。
    *   使用 `AnimatedVisibility` 组件包裹原有的 `Actions` 按钮行。
    *   `AnimatedVisibility` 的 `visible` 条件更新为 `message.isValidToShowActions() && isFullyLoaded`，确保只有在消息有效且完全加载后才显示操作按钮。
    *   `AnimatedVisibility` 提供了平滑的出现/消失动画，改善了UI因布局变化可能产生的跳动问题。

**预期效果:**

*   对于正在流式生成的助手消息，其操作按钮将在消息流结束、内容完全展示后才出现。
*   对于历史消息或用户消息，操作按钮的行为保持不变（如果消息有效则立即显示）。
*   通过动画效果，操作按钮的显隐过渡更加自然，提升了界面的流畅性和视觉效果。


https://github.com/user-attachments/assets/6a697f38-1b30-422b-bd5b-322293e439a8

