### PR TITLE
Refactor: 统一聊天界面统计信息显示控制

### DIFF
--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ChatPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ChatPage.kt
@@ -390,36 +390,36 @@ private fun ChatList(
             }
 
             // NEW: Combined Token and Context Usage Item
-            item(ContextUsageItemKey) { // 仍然使用 ContextUsageItemKey 作为这个合并项的键
-                val configuredContextSize = settings.getCurrentAssistant().contextMessageSize
-                val effectiveMessagesAfterTruncation =
-                    conversation.messages.size - conversation.truncateIndex.coerceAtLeast(0)
-                val actualContextMessageCount =
-                    minOf(effectiveMessagesAfterTruncation, configuredContextSize)
-                Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = 8.dp),
-                    verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.spacedBy(
-                        8.dp,
-                        Alignment.CenterHorizontally
-                    ), // 居中对齐，并提供间距
-                ) {
-                    // 只有当设置允许显示Token使用量且实际有Token数据时才显示
-                    if (settings.displaySetting.showTokenUsage && conversation.tokenUsage != null) {
+            // Combined Token and Context Usage Item
+            item(ContextUsageItemKey) {
+                // 当设置允许显示统计信息，并且聊天记录不为空时才显示
+                if (settings.displaySetting.showTokenUsage && conversation.messages.isNotEmpty()) {
+                    val configuredContextSize = settings.getCurrentAssistant().contextMessageSize
+                    val effectiveMessagesAfterTruncation = conversation.messages.size - conversation.truncateIndex.coerceAtLeast(0)
+                    val actualContextMessageCount = minOf(effectiveMessagesAfterTruncation, configuredContextSize)
+
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 8.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.CenterHorizontally),
+                    ) {
+                        // Token使用量统计 (仅当有数据时)
+                        if (conversation.tokenUsage != null) {
+                            Text(
+                                text = "Tokens: ${conversation.tokenUsage.totalTokens} (${conversation.tokenUsage.promptTokens} -> ${conversation.tokenUsage.completionTokens})",
+                                style = MaterialTheme.typography.labelSmall,
+                                color = MaterialTheme.colorScheme.outlineVariant,
+                            )
+                        }
+                        // 上下文消息数量统计
                         Text(
-                            text = "Tokens: ${conversation.tokenUsage.totalTokens} (${conversation.tokenUsage.promptTokens} -> ${conversation.tokenUsage.completionTokens})",
+                            text = "Context: $actualContextMessageCount/$configuredContextSize",
                             style = MaterialTheme.typography.labelSmall,
                             color = MaterialTheme.colorScheme.outlineVariant,
                         )
                     }
-                    // 始终显示上下文数量
-                    Text(
-                        text = "Context: $actualContextMessageCount/$configuredContextSize",
-                        style = MaterialTheme.typography.labelSmall,
-                        color = MaterialTheme.colorScheme.outlineVariant,
-                    )
                 }
             }
 

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -184,8 +184,8 @@
     <string name="setting_display_page_title">表示設定</string>
     <string name="setting_display_page_chat_list_model_icon_title">チャットリストのモデルアイコン</string>
     <string name="setting_display_page_chat_list_model_icon_desc">チャットリストのメッセージにモデルアイコンを表示するかどうか</string>
-    <string name="setting_display_page_show_token_usage_title">トークン使用量を表示</string>
-    <string name="setting_display_page_show_token_usage_desc">会話の下部にトークン使用量を表示</string>
+    <string name="setting_display_page_show_token_usage_title">トークンとコンテキスト統計を表示</string>
+    <string name="setting_display_page_show_token_usage_desc">会話の下部にトークン使用量とコンテキスト数を表示</string>
     <string name="setting_display_page_auto_collapse_thinking_title">思考を自動折りたたむ</string>
     <string name="setting_display_page_auto_collapse_thinking_desc">思考が完了したら思考内容を自動的に折りたたむ</string>
     <string name="setting_display_page_show_updates_title">アップデートを表示</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -182,8 +182,8 @@
     <!-- Setting Display Page -->
     <string name="setting_display_page_chat_list_model_icon_title">聊天列表模型圖標</string>
     <string name="setting_display_page_chat_list_model_icon_desc">是否在聊天列表消息中顯示模型圖標</string>
-    <string name="setting_display_page_show_token_usage_title">顯示Token消耗</string>
-    <string name="setting_display_page_show_token_usage_desc">在對話底部顯示Token消耗</string>
+    <string name="setting_display_page_show_token_usage_title">顯示Token和上下文統計</string>
+    <string name="setting_display_page_show_token_usage_desc">在對話底部顯示Token消耗和上下文數量</string>
     <string name="setting_display_page_auto_collapse_thinking_title">自動折疊思考</string>
     <string name="setting_display_page_auto_collapse_thinking_desc">思考完成自動折疊思考內容</string>
     <string name="setting_display_page_show_updates_title">顯示更新</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -182,8 +182,8 @@
     <!-- Setting Display Page -->
     <string name="setting_display_page_chat_list_model_icon_title">聊天列表模型图标</string>
     <string name="setting_display_page_chat_list_model_icon_desc">是否在聊天列表消息中显示模型图标</string>
-    <string name="setting_display_page_show_token_usage_title">显示Token消耗</string>
-    <string name="setting_display_page_show_token_usage_desc">在对话底部显示Token消耗</string>
+    <string name="setting_display_page_show_token_usage_title">显示Token和上下文统计</string>
+    <string name="setting_display_page_show_token_usage_desc">在对话底部显示Token消耗和上下文数量</string>
     <string name="setting_display_page_auto_collapse_thinking_title">自动折叠思考</string>
     <string name="setting_display_page_auto_collapse_thinking_desc">思考完成自动折叠思考内容</string>
     <string name="setting_display_page_show_updates_title">显示更新</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -181,8 +181,8 @@
     <!-- Setting Display Page -->
     <string name="setting_display_page_chat_list_model_icon_title">Chat List Model Icon</string>
     <string name="setting_display_page_chat_list_model_icon_desc">Whether to display model icons in chat list messages</string>
-    <string name="setting_display_page_show_token_usage_title">Show Token Usage</string>
-    <string name="setting_display_page_show_token_usage_desc">Display token usage at the bottom of the conversation</string>
+    <string name="setting_display_page_show_token_usage_title">Show Token &amp; Context Stats</string>
+    <string name="setting_display_page_show_token_usage_desc">Display token usage and context count at the bottom of the conversation</string>
     <string name="setting_display_page_auto_collapse_thinking_title">Auto Collapse Thinking</string>
     <string name="setting_display_page_auto_collapse_thinking_desc">Automatically collapse thinking content after thinking is complete</string>
     <string name="setting_display_page_show_updates_title">Show Updates</string>


### PR DESCRIPTION
**主要变更:**

*   将显示设置中的 "显示Token消耗" 选项更新为 "显示Token和上下文统计"。
*   现在，此设置项统一控制聊天界面底部 "Token消耗" 和 "上下文消息数量" 两项统计信息的可见性。
*   当聊天记录为空时，即使该设置项已开启，统计信息也不会显示。

此前，Token消耗和上下文统计的显示逻辑部分独立。本次修改旨在简化用户设置，并确保在没有聊天内容时不显示不必要的统计信息，提升界面整洁度。