### PR TITLE
fix: 优化助手消息操作菜单的显示逻辑

### DIFF
--- a/app/src/main/java/me/rerere/rikkahub/ui/components/chat/ChatMessage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/chat/ChatMessage.kt
@@ -139,7 +139,7 @@ fun ChatMessage(
     modifier: Modifier = Modifier,
     showIcon: Boolean = true,
     model: Model? = null,
-    isFullyLoaded: Boolean,
+    showActions: Boolean, 
     onFork: () -> Unit,
     onRegenerate: () -> Unit,
     onEdit: () -> Unit,
@@ -147,10 +147,10 @@ fun ChatMessage(
     onDelete: () -> Unit,
     onUpdate: (MessageNode) -> Unit
 ) {
-    val message = node.messages[node.selectIndex]
+    val message = node.messages[node.selectIndex] 
     Column(
         modifier = modifier
-            .fillMaxWidth(), // Add this to the root Column of ChatMessage
+            .fillMaxWidth(),
         horizontalAlignment = if (message.role == MessageRole.USER) Alignment.End else Alignment.Start,
         verticalArrangement = Arrangement.spacedBy(4.dp)
     ) {
@@ -178,7 +178,7 @@ fun ChatMessage(
             annotations = message.annotations,
         )
         AnimatedVisibility(
-            visible = message.isValidToShowActions() && isFullyLoaded,
+            visible = showActions, 
             enter = slideInVertically { it / 2 } + fadeIn(),
             exit = slideOutVertically { it / 2 } + fadeOut()
         ) {
@@ -186,7 +186,7 @@ fun ChatMessage(
                 modifier = Modifier.animateContentSize()
             ) {
                 Actions(
-                    message = message,
+                    message = message, 
                     model = model,
                     onRegenerate = onRegenerate,
                     onEdit = onEdit,

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ChatPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ChatPage.kt
@@ -357,24 +357,21 @@ private fun ChatList(
                         selectedKeys = selectedItems,
                         enabled = selecting && node.currentMessage.isValidToShowActions(),
                     ) {
-                        // Determine if the current message is fully loaded
                         val isLastMessage = index == conversation.messageNodes.lastIndex
                         val isAssistantMessage = node.role == MessageRole.ASSISTANT
-                        // The message is considered fully loaded if:
-                        // 1. It's not the last assistant message (i.e., it's a historical message).
-                        // 2. Or, it IS the last assistant message, AND the global 'loading' (generation job) is false.
-                        // 3. Or, it's a user message.
-                        val isMessageFullyLoaded = if (isLastMessage && isAssistantMessage) {
+
+                        // 计算是否显示操作菜单的最终标志
+                        val showActionsForThisMessage = if (isLastMessage && isAssistantMessage) {
                             !loading
                         } else {
-                            true
+                            node.currentMessage.isValidToShowActions()
                         }
 
                         ChatMessage(
                             node = node,
                             showIcon = settings.displaySetting.showModelIcon,
                             model = node.currentMessage.modelId?.let { settings.findModelById(it) },
-                            isFullyLoaded = isMessageFullyLoaded, // Pass the new parameter
+                            showActions = showActionsForThisMessage, 
                             onRegenerate = {
                                 onRegenerate(node.currentMessage)
                             },


### PR DESCRIPTION
变更内容：
本次更新修改了聊天界面中，最后一条助手消息操作菜单（如复制、编辑等）的显示逻辑。
- 原逻辑： 最后一条助手消息的操作菜单，在消息生成完毕后，还需要消息内容本身有效（例如，非空、非临时占位符）才会显示。
- 新逻辑： 对于最后一条助手消息，只要其生成过程结束（即全局加载动画消失），操作菜单就会立即显示，不再受消息内容是否“有效”的限制。