### PR TITLE
Feat: 用户发送消息后自动滚动到底部

### DIFF
--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ChatPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ChatPage.kt
@@ -322,6 +322,19 @@ private fun ChatList(
             }
         }
 
+        // 用户发送消息后滚动到底部
+        LaunchedEffect(conversation.messageNodes.lastOrNull()?.id) {
+            val lastNode = conversation.messageNodes.lastOrNull()
+            // 检查最后一条消息是否是用户发送的
+            if (lastNode?.currentMessage?.role == MessageRole.USER) {
+                if (conversation.messageNodes.isNotEmpty()) {
+                    scope.launch { 
+                        state.animateScrollToItem(conversation.messageNodes.lastIndex)
+                    }
+                }
+            }
+        }
+
         // 判断最近是否滚动
         LaunchedEffect(state.isScrollInProgress) {
             if (state.isScrollInProgress) {


### PR DESCRIPTION
### 功能改进：用户发送消息后自动滚动到底部
#### 问题描述
用户发送消息后，聊天列表不会自动滚动到底部显示刚发送的消息，用户需要手动滚动才能看到自己的消息。

#### 解决方案
在 ChatList 组件中新增 LaunchedEffect，监听消息列表变化，当检测到用户发送新消息时自动滚动到底部。

#### 主要变更
在 ChatPage.kt 的 ChatList 函数中添加用户消息滚动逻辑
使用 conversation.messageNodes.lastOrNull()?.id 作为触发条件
仅对用户消息（MessageRole.USER）执行滚动，不影响AI回复的滚动逻辑
采用 animateScrollToItem 提供平滑的滚动动画

https://github.com/user-attachments/assets/42aa3b21-1c1a-430e-b8ee-2b11ebde2fdd