### PR TITLE
feat: Add conversation export functionality

### DIFF
--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingPage.kt
@@ -2,7 +2,10 @@ package me.rerere.rikkahub.ui.pages.setting
 
 import android.content.ActivityNotFoundException
 import android.content.Intent
+import android.net.Uri
 import android.widget.Toast
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
@@ -40,6 +43,7 @@ import com.composables.icons.lucide.BadgeInfo
 import com.composables.icons.lucide.Bot
 import com.composables.icons.lucide.Boxes
 import com.composables.icons.lucide.Compass
+import com.composables.icons.lucide.Download
 import com.composables.icons.lucide.HardDrive
 import com.composables.icons.lucide.Heart
 import com.composables.icons.lucide.Lucide
@@ -63,6 +67,18 @@ import org.koin.androidx.compose.koinViewModel
 
 @Composable
 fun SettingPage(vm: SettingVM = koinViewModel()) {
+    val context = LocalContext.current
+    val exportLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.CreateDocument("application/json"),
+        onResult = { uri: Uri? ->
+            if (uri != null) {
+                vm.exportConversations(context, uri)
+            } else {
+                Toast.makeText(context, context.getString(R.string.export_conversations_cancelled), Toast.LENGTH_SHORT).show()
+            }
+        }
+    )
+
     val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior()
     val navController = LocalNavController.current
     val settings by vm.settings.collectAsStateWithLifecycle()
@@ -284,6 +300,18 @@ fun SettingPage(vm: SettingVM = koinViewModel()) {
                     icon = {
                         Icon(Lucide.HardDrive, "Storage")
                     },
+                )
+            }
+
+            item {
+                SettingItem(
+                    navController = navController,
+                    title = { Text(stringResource(R.string.setting_page_export_conversations_title)) },
+                    description = { Text(stringResource(R.string.setting_page_export_conversations_desc)) },
+                    icon = { Icon(Lucide.Download, "Export Conversations") },
+                    onClick = {
+                        exportLauncher.launch("conversations-export.json")
+                    }
                 )
             }
 

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingVM.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingVM.kt
@@ -1,18 +1,30 @@
 package me.rerere.rikkahub.ui.pages.setting
 
+import android.content.Context
+import android.net.Uri
+import android.util.Log
+import android.widget.Toast
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import me.rerere.rikkahub.R
+import java.io.OutputStream
 import me.rerere.rikkahub.data.datastore.Settings
 import me.rerere.rikkahub.data.datastore.SettingsStore
 import me.rerere.rikkahub.data.mcp.McpManager
+import me.rerere.rikkahub.data.model.Conversation
+import me.rerere.rikkahub.data.repository.ConversationRepository
 
 class SettingVM(
     private val settingsStore: SettingsStore,
-    private val mcpManager: McpManager
+    private val mcpManager: McpManager,
+    private val conversationRepository: ConversationRepository
 ) :
     ViewModel() {
     val settings: StateFlow<Settings> = settingsStore.settingsFlow
@@ -21,6 +33,30 @@ class SettingVM(
     fun updateSettings(settings: Settings) {
         viewModelScope.launch {
             settingsStore.update(settings)
+        }
+    }
+
+    fun exportConversations(context: Context, uri: Uri?) {
+        viewModelScope.launch {
+            try {
+                if (uri == null) {
+                    Toast.makeText(context, context.getString(R.string.export_conversations_uri_null), Toast.LENGTH_LONG).show()
+                    return@launch
+                }
+                val conversations = conversationRepository.getAllConversations().first()
+                val jsonString = Json.encodeToString(conversations)
+                Log.d("Export", "JSON: $jsonString") // Log the JSON string for debugging
+
+                context.contentResolver.openOutputStream(uri)?.use { outputStream ->
+                    outputStream.write(jsonString.toByteArray())
+                    Toast.makeText(context, context.getString(R.string.export_conversations_success, uri.path), Toast.LENGTH_LONG).show()
+                } ?: run {
+                    Toast.makeText(context, "Failed to open output stream for ${uri.path}", Toast.LENGTH_LONG).show()
+                }
+            } catch (e: Exception) {
+                Log.e("Export", "Export failed", e)
+                Toast.makeText(context, context.getString(R.string.export_conversations_failed), Toast.LENGTH_LONG).show()
+            }
         }
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -236,4 +236,12 @@
     <!-- MCP Picker -->
     <string name="mcp_picker_title">MCP Servers</string>
     <string name="mcp_picker_syncing">Syncing MCP servers...</string>
+
+    <!-- Export Conversations -->
+    <string name="setting_page_export_conversations_title">Export Conversations</string>
+    <string name="setting_page_export_conversations_desc">Export all your conversations to a JSON file.</string>
+    <string name="export_conversations_success">Conversations exported successfully to %1$s</string>
+    <string name="export_conversations_cancelled">Export cancelled</string>
+    <string name="export_conversations_failed">Export failed</string>
+    <string name="export_conversations_uri_null">Export cancelled or failed to get file location.</string>
 </resources>


### PR DESCRIPTION
主要变化：

在设置屏幕中添加了“导出对话”选项。
实现从存储库中获取所有对话并将其序列化为 JSON 格式的逻辑。
利用 Android 的存储访问框架，您可以指定导出数据的目标和文件名（默认为“conversations-export.json”）。
为UI元素和反馈信息添加了必要的字符串资源。
