### PR TITLE
Feat: 优化聊天界面交互体验（1.新增消息导航按钮显示开关; 2.新增删除消息的内联确认机制）

### DIFF
--- a/app/src/main/java/me/rerere/rikkahub/data/datastore/PreferencesStore.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/datastore/PreferencesStore.kt
@@ -211,6 +211,7 @@ data class DisplaySetting(
     val showTokenUsage: Boolean = true,
     val autoCloseThinking: Boolean = true,
     val showUpdates: Boolean = true,
+    val showMessageJumper: Boolean = true,
 )
 
 fun Settings.isNotConfigured() = providers.all { it.models.isEmpty() }

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ChatList.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ChatList.kt
@@ -324,7 +324,11 @@ fun ChatList(
         MessageQuickBottom(state = state, isAtBottom = isAtBottom, scrollToBottom = scrollToBottom)
 
         // 消息快速跳转
-        MessageJumper(isRecentScroll = isRecentScroll, scope = scope, state = state)
+        MessageJumper(
+            isRecentScroll = isRecentScroll && settings.displaySetting.showMessageJumper,
+            scope = scope,
+            state = state
+        )
     }
 }
 

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ChatList.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ChatList.kt
@@ -85,6 +85,7 @@ fun ChatList(
 ) {
     val state = rememberLazyListState()
     val scope = rememberCoroutineScope()
+    var pendingDeleteMessageId by remember { mutableStateOf<Uuid?>(null) }
 
     val viewPortSize by remember { derivedStateOf { state.layoutInfo.viewportSize } }
     var isRecentScroll by remember { mutableStateOf(false) }
@@ -195,6 +196,14 @@ fun ChatList(
                             },
                             onDelete = {
                                 onDelete(node.currentMessage)
+                                pendingDeleteMessageId = null
+                            },
+                            isPendingDelete = pendingDeleteMessageId == node.currentMessage.id,
+                            onRequestDelete = {
+                                pendingDeleteMessageId = node.currentMessage.id
+                            },
+                            onCancelDelete = {
+                                pendingDeleteMessageId = null
                             },
                             onShare = {
                                 selecting = true

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingDisplayPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingDisplayPage.kt
@@ -128,6 +128,25 @@ fun SettingDisplayPage(vm: SettingVM = koinViewModel()) {
                     },
                 )
             }
+
+            item {
+                ListItem(
+                    headlineContent = {
+                        Text(stringResource(R.string.setting_display_page_show_message_jumper_title))
+                    },
+                    supportingContent = {
+                        Text(stringResource(R.string.setting_display_page_show_message_jumper_desc))
+                    },
+                    trailingContent = {
+                        Switch(
+                            checked = displaySetting.showMessageJumper,
+                            onCheckedChange = {
+                                updateDisplaySetting(displaySetting.copy(showMessageJumper = it))
+                            }
+                        )
+                    },
+                )
+            }
         }
     }
 }

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -20,6 +20,7 @@
     <string name="settings">設定</string>
     <string name="confirm">確認</string>
     <string name="cancel">キャンセル</string>
+    <string name="confirm_delete">削除を確認</string>
 
     <!-- Chat Page -->
     <string name="chat_page_no_conversations">会話がありません</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -191,8 +191,10 @@
     <string name="setting_display_page_auto_collapse_thinking_desc">思考完成自动折叠思考内容</string>
     <string name="setting_display_page_show_updates_title">显示更新</string>
     <string name="setting_display_page_show_updates_desc">是否显示应用更新通知</string>
+    <string name="setting_display_page_show_message_jumper_title">消息导航按钮</string>
+    <string name="setting_display_page_show_message_jumper_desc">在滚动聊天列表时，在右侧显示快速跳转按钮</string>
     <string name="setting_display_page_title">显示设置</string>
-    
+
     <!-- Color Mode -->
     <string name="setting_page_color_mode">颜色模式</string>
     <string name="setting_page_color_mode_system">跟随系统</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -20,6 +20,7 @@
     <string name="settings">设置</string>
     <string name="confirm">确认</string>
     <string name="cancel">取消</string>
+    <string name="confirm_delete">确认删除</string>
 
     <!-- Chat Page -->
     <string name="chat_page_no_conversations">没有对话记录</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -190,8 +190,10 @@
     <string name="setting_display_page_auto_collapse_thinking_desc">Automatically collapse thinking content after thinking is complete</string>
     <string name="setting_display_page_show_updates_title">Show Updates</string>
     <string name="setting_display_page_show_updates_desc">Whether to display app update notifications</string>
+    <string name="setting_display_page_show_message_jumper_title">Show Message Jumper</string>
+    <string name="setting_display_page_show_message_jumper_desc">Display quick jump buttons on the right when scrolling the chat list</string>
     <string name="setting_display_page_title">Display Settings</string>
-    
+
     <!-- Color Mode -->
     <string name="setting_page_color_mode">Color Mode</string>
     <string name="setting_page_color_mode_system">System</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -19,6 +19,7 @@
     <string name="settings">Settings</string>
     <string name="confirm">Confirm</string>
     <string name="cancel">Cancel</string>
+    <string name="confirm_delete">Confirm Delete</string>
 
     <!-- Chat Page -->
     <string name="chat_page_no_conversations">No conversations</string>


### PR DESCRIPTION
### **内容：**

本次更新主要包含两项针对聊天界面的用户体验优化，旨在提供更灵活的控制选项并防止误操作。

#### **1. 新增：消息导航按钮显示开关 (Message Jumper Toggle)**

**背景:**
部分用户可能不希望在滚动列表时看到右侧的快速消息跳转按钮 (`MessageJumper`)。为此功能增加了一个开关。

**核心改动:**

*   **`data/datastore/PreferencesStore.kt`**: 在 `DisplaySetting` 数据类中新增 `showMessageJumper: Boolean` 字段，默认为 `true`。
*   **`ui/pages/setting/SettingDisplayPage.kt`**: 在“显示设置”页面添加了一个新的 `Switch` 组件，允许用户开启或关闭此功能。
*   **`ui/pages/chat/ChatList.kt`**: `MessageJumper` 的可见性逻辑 (`AnimatedVisibility`) 现在会同时检查 `isRecentScroll` 和新增的 `settings.displaySetting.showMessageJumper` 配置项。

**效果:**
用户现在可以在 **设置 -> 显示设置** 中自由控制是否显示消息快速跳转按钮。

---

#### **2. 新增：删除消息的内联确认机制 (Inline Delete Confirmation)**

**背景:**
为了防止用户误触删除按钮导致消息丢失，我们引入了一个轻量级的内联确认步骤。

**核心改动:**

*   **状态管理 (`ui/pages/chat/ChatList.kt`)**: 在 `ChatList` 中引入了 `pendingDeleteMessageId: Uuid?` 状态，用于追踪哪个消息正在等待删除确认。
*   **UI与交互 (`ui/pages/chat/ChatMessage.kt`)**:
    *   当用户首次点击“删除”图标时，`onRequestDelete` 回调被触发，`ChatList` 更新 `pendingDeleteMessageId` 状态。
    *   `ChatMessage` 根据 `isPendingDelete` 状态（`pendingDeleteMessageId == message.id`）动态改变UI。原删除图标被一个带有“确认”和“取消”按钮的扩展面板平滑替换（通过 `animateContentSize` 实现）。
*   **回调逻辑**:
    *   再次点击“确认”图标会触发 `onDelete` 回调，执行真正的删除操作。
    *   点击“取消”或超时则触发 `onCancelDelete`，将 `pendingDeleteMessageId` 重置为 `null`。

**效果:**
删除操作现在需要二次确认，显著降低了误操作的风险，同时通过优雅的动画效果保证了优秀的用户体验。

https://github.com/user-attachments/assets/2e736d22-c0e4-48aa-ba66-00f6285efb75


