### PR TITLE
Feat: 单击消息时显示操作菜单，优化界面整洁度

### DIFF
--- a/app/src/main/java/me/rerere/rikkahub/ui/components/chat/ChatMessage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/chat/ChatMessage.kt
@@ -150,6 +150,7 @@ fun ChatMessage(
     showIcon: Boolean = true,
     model: Model? = null,
     showActions: Boolean,
+    onClick: () -> Unit, // 新增：接收点击事件的回调
     onFork: () -> Unit,
     onRegenerate: () -> Unit,
     onEdit: () -> Unit,
@@ -160,7 +161,12 @@ fun ChatMessage(
     val message = node.messages[node.selectIndex]
     Column(
         modifier = modifier
-            .fillMaxWidth(),
+            .fillMaxWidth()
+            .clickable(
+                interactionSource = remember { MutableInteractionSource() },
+                indication = null, // 设置为 null 以禁用点击时的视觉效果
+                onClick = onClick
+            ),
         horizontalAlignment = if (message.role == MessageRole.USER) Alignment.End else Alignment.Start,
         verticalArrangement = Arrangement.spacedBy(4.dp)
     ) {

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/assistant/detail/AssistantDetailPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/assistant/detail/AssistantDetailPage.kt
@@ -701,6 +701,7 @@ private fun AssistantPromptSettings(
                         ChatMessage(
                             node = message.toMessageNode(),
                             showActions = true,
+                            onClick = {}, 
                             onFork = {},
                             onRegenerate = {},
                             onEdit = {},

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ChatList.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ChatList.kt
@@ -86,6 +86,8 @@ fun ChatList(
     val state = rememberLazyListState()
     val scope = rememberCoroutineScope()
 
+    var expandedMessageId by remember { mutableStateOf<Uuid?>(null) }
+
     val viewPortSize by remember { derivedStateOf { state.layoutInfo.viewportSize } }
     var isRecentScroll by remember { mutableStateOf(false) }
 
@@ -173,17 +175,25 @@ fun ChatList(
                         val isAssistantMessage = node.role == MessageRole.ASSISTANT
 
                         // 计算是否显示操作菜单的最终标志
-                        val showActionsForThisMessage = if (isLastMessage && isAssistantMessage) {
-                            !loading
-                        } else {
-                            node.currentMessage.isValidToShowActions()
-                        }
+                        // 修改：计算操作菜单可见性的逻辑
+                        val showActions = (expandedMessageId == node.id) ||
+                                (isLastMessage && isAssistantMessage && !loading)
 
                         ChatMessage(
                             node = node,
                             showIcon = settings.displaySetting.showModelIcon,
                             model = node.currentMessage.modelId?.let { settings.findModelById(it) },
-                            showActions = showActionsForThisMessage,
+                            showActions = showActions, 
+
+                            onClick = {
+                                if (!selecting) {
+                                    expandedMessageId = if (expandedMessageId == node.id) {
+                                        null 
+                                    } else {
+                                        node.id 
+                                    }
+                                }
+                            },
                             onRegenerate = {
                                 onRegenerate(node.currentMessage)
                             },


### PR DESCRIPTION
### **变更背景 (Motivation)**

当前聊天界面中，除了最新生成的消息外，所有历史消息下方的操作菜单（复制、编辑、删除等）都是默认常驻显示的。这在消息较多的对话中，会导致界面显得杂乱，不够简洁，影响了用户的阅读体验。
https://github.com/rikkahub/rikkahub/issues/88

### **实现方案 (Implementation)**

1.  在 `ChatList.kt` 中，引入一个新的状态变量 `expandedMessageId: Uuid?`，用于追踪当前哪个消息的操作菜单被展开了。
2.  为 `ChatMessage` 组件增加了 `onClick` 回调，并将其整个区域设置为可点击。
3.  当用户单击某条消息时：
    *   如果该消息的菜单未展开，则更新 `expandedMessageId` 为该消息的 ID，从而显示其菜单。
    *   如果该消息的菜单已展开，则将 `expandedMessageId` 设为 `null`，从而收起菜单。
4.  `ChatMessage` 的 `showActions` 可见性逻辑更新为：`expandedMessageId` 匹配当前消息 ID 时为 `true`。

### **效果演示 (Demonstration)**

**变更前:**
![Screenshot_20250613_230328](https://github.com/user-attachments/assets/b492f7d8-101a-4bcc-abac-b057839eb05e)

**变更后:**

https://github.com/user-attachments/assets/24577efc-1916-43a0-a156-d117ccc16d44




