### PR TITLE
fix: 一些Markdown渲染相关问题的修复

### DIFF
--- a/app/src/main/java/me/rerere/rikkahub/ui/components/richtext/Markdown.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/richtext/Markdown.kt
@@ -126,9 +126,9 @@ private fun MarkdownPreview() {
                         * the slings and arrows of outrageous fortune, Or to take arms against a sea of troubles,
                         * by opposing end them.
                             * How many times must a man look up, Before he can see the sky?
+                            * How many times $ f(x) = \sum_{n=0}^{\infty} \frac{f^{(n)}(a)}{n!}(x-a)^n$
                     2. How many times must a man look up, Before he can see the sky?  
                     * Before they're allowed to be free? Yes, 'n' how many times can a man turn his head
-                    How many times $ f(x) = \sum_{n=0}^{\infty} \frac{f^{(n)}(a)}{n!}(x-a)^n$
 
                     4. For in that sleep of death what dreams may come [citation](1)
                     

--- a/app/src/main/java/me/rerere/rikkahub/ui/components/richtext/Markdown.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/richtext/Markdown.kt
@@ -282,7 +282,7 @@ fun MarkdownNode(
                 node = node,
                 content = content,
                 onClickCitation = onClickCitation,
-                modifier = modifier,
+                modifier = modifier.padding(vertical = 16.dp),
                 trim = true,
               )
             }
@@ -404,8 +404,9 @@ fun MarkdownNode(
 
     MarkdownTokenTypes.HORIZONTAL_RULE -> {
       HorizontalDivider(
-        modifier = Modifier.padding(vertical = 8.dp),
-        color = MaterialTheme.colorScheme.primary
+        modifier = Modifier.padding(vertical = 16.dp),
+        color = MaterialTheme.colorScheme.primary.copy(alpha = 0.5f),
+        thickness = 0.5.dp
       )
     }
 


### PR DESCRIPTION
## AlignByBaseline前
<img src="https://github.com/user-attachments/assets/0ea10b97-8312-48f8-a711-29b1cdbcc775" width="300" />

***

## AlignByBaseline后
<img src="https://github.com/user-attachments/assets/ad7d03cc-842e-450a-b67b-c3cc97873038" width="300" />
