### PR TITLE
Feat: #277启动时自动新建新对话

### DIFF
--- a/app/src/main/java/me/rerere/rikkahub/RouteActivity.kt
+++ b/app/src/main/java/me/rerere/rikkahub/RouteActivity.kt
@@ -99,12 +99,17 @@ class RouteActivity : ComponentActivity() {
         disableNavigationBarContrast()
         super.onCreate(savedInstanceState)
         setContent {
+            val settings by settingsStore.settingsFlow.collectAsStateWithLifecycle()
             val navStack = rememberNavBackStack(
                 Screen.Chat(
-                    id = readStringPreference(
-                        "lastConversationId",
+                    id = if (settings.displaySetting.createNewConversationOnStart) {
                         Uuid.random().toString()
-                    ) ?: Uuid.random().toString(),
+                    } else {
+                        readStringPreference(
+                            "lastConversationId",
+                            Uuid.random().toString()
+                        ) ?: Uuid.random().toString()
+                    }
                 )
             )
             ShareHandler(navStack)

--- a/app/src/main/java/me/rerere/rikkahub/data/datastore/PreferencesStore.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/datastore/PreferencesStore.kt
@@ -307,6 +307,7 @@ data class DisplaySetting(
     val showUpdates: Boolean = true,
     val showMessageJumper: Boolean = true,
     val fontSizeRatio: Float = 1.0f,
+    val createNewConversationOnStart: Boolean = false,
 )
 
 @Serializable

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingDisplayPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingDisplayPage.kt
@@ -200,6 +200,28 @@ fun SettingDisplayPage(vm: SettingVM = koinViewModel()) {
             item {
                 Card {
                     ListItem(
+                        colors = ListItemDefaults.colors(containerColor = Color.Transparent),
+                        headlineContent = {
+                            Text(stringResource(R.string.setting_display_page_create_new_conversation_on_start_title))
+                        },
+                        supportingContent = {
+                            Text(stringResource(R.string.setting_display_page_create_new_conversation_on_start_desc))
+                        },
+                        trailingContent = {
+                            Switch(
+                                checked = displaySetting.createNewConversationOnStart,
+                                onCheckedChange = {
+                                    updateDisplaySetting(displaySetting.copy(createNewConversationOnStart = it))
+                                }
+                            )
+                        },
+                    )
+                }
+            }
+
+            item {
+                Card {
+                    ListItem(
                         headlineContent = {
                             Text(stringResource(R.string.setting_display_page_font_size_title))
                         },

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -285,8 +285,10 @@
   <string name="setting_display_page_show_updates_title">显示更新</string>
   <string name="setting_display_page_show_updates_desc">是否显示应用更新通知</string>
   <string name="setting_display_page_show_message_jumper_title">消息导航按钮</string>
-  <string name="setting_display_page_show_message_jumper_desc">在滚动聊天列表时，在右侧显示快速跳转按钮</string>
-  <string name="setting_display_page_font_size_title">聊天字体大小</string>
+    <string name="setting_display_page_show_message_jumper_desc">在滚动聊天列表时，在右侧显示快速跳转按钮</string>
+    <string name="setting_display_page_create_new_conversation_on_start_title">启动时新建对话</string>
+    <string name="setting_display_page_create_new_conversation_on_start_desc">当应用启动时，自动创建一个新的对话</string>
+    <string name="setting_display_page_font_size_title">聊天字体大小</string>
   <string name="setting_display_page_font_size_preview">这是一个**示例**的聊天文本</string>
   <string name="setting_display_page_title">显示设置</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -295,8 +295,10 @@
   <string name="setting_display_page_show_updates_title">Show Updates</string>
   <string name="setting_display_page_show_updates_desc">Whether to display app update notifications</string>
   <string name="setting_display_page_show_message_jumper_title">Show Message Jumper</string>
-  <string name="setting_display_page_show_message_jumper_desc">Display quick jump buttons on the right when scrolling the chat list</string>
-  <string name="setting_display_page_font_size_title">Chat Font Size</string>
+    <string name="setting_display_page_show_message_jumper_desc">Display quick jump buttons on the right when scrolling the chat list</string>
+    <string name="setting_display_page_create_new_conversation_on_start_title">New chat on launch</string>
+    <string name="setting_display_page_create_new_conversation_on_start_desc">Create a new conversation when the app starts</string>
+    <string name="setting_display_page_font_size_title">Chat Font Size</string>
   <string name="setting_display_page_font_size_preview">This is a **sample** chat text</string>
   <string name="setting_display_page_title">Display Settings</string>
 


### PR DESCRIPTION
### 解决了什么问题 (What problem does this solve?)
Issue #277 ，为应用增加了“启动时行为”的设置选项，允许用户选择启动时是“保留上次状态”还是“新建对话”。

### 主要变更 (Key changes)
- 在设置页面增加了新的选项。
- 修改了 RouteActivity 的启动逻辑，根据新的设置项来决定启动行为。
- 更新了中英文的字符串资源。

### 如何测试 (How to test)
1. 进入设置 -> 显示 -> 启动时行为
2. 选择“新建对话”
3. 彻底关闭并重启应用
4. 应用应该会直接进入一个新的、空白的对话界面

Closes #277
