### PR TITLE
Fix: #300 增强Markdown粗体显示效果，使其更易区分

### DIFF
--- a/app/src/main/java/me/rerere/rikkahub/ui/components/richtext/Markdown.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/richtext/Markdown.kt
@@ -372,7 +372,7 @@ fun MarkdownNode(
         }
 
         MarkdownElementTypes.STRONG -> {
-            ProvideTextStyle(TextStyle(fontWeight = FontWeight.Bold)) {
+            ProvideTextStyle(TextStyle(fontWeight = FontWeight.ExtraBold)) {
                 node.children.fastForEach { child ->
                     MarkdownNode(
                         node = child,
@@ -790,7 +790,7 @@ private fun AnnotatedString.Builder.appendMarkdownNodeContent(
         }
 
         node.type == MarkdownElementTypes.STRONG -> {
-            withStyle(SpanStyle(fontWeight = FontWeight.Bold)) {
+            withStyle(SpanStyle(fontWeight = FontWeight.ExtraBold)) {
                 node.children
                     .trim(MarkdownTokenTypes.EMPH, 2)
                     .fastForEach {


### PR DESCRIPTION
Closes #300
 
根据议题反馈，本次提交修复了 Markdown 粗体文本在视觉上不够突出的问题。
 
### 主要变更
*   **文件**: `app/src/main/java/me/rerere/rikkahub/ui/components/richtext/Markdown.kt`
*   **修改**: 将处理粗体文本的 `fontWeight` 从 `FontWeight.Bold` 提升至 `FontWeight.ExtraBold`。
 
### 效果
此项修改显著增强了粗体文本与普通文本的视觉区分度，提升了内容的可读性。