### PR TITLE
修复Markdown图片问题

### DIFF
--- a/app/src/main/java/me/rerere/rikkahub/ui/components/richtext/Markdown.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/richtext/Markdown.kt
@@ -70,7 +70,6 @@ import org.intellij.markdown.MarkdownElementTypes
 import org.intellij.markdown.MarkdownTokenTypes
 import org.intellij.markdown.ast.ASTNode
 import org.intellij.markdown.ast.LeafASTNode
-import org.intellij.markdown.ast.findChildOfType
 import org.intellij.markdown.flavours.gfm.GFMElementTypes
 import org.intellij.markdown.flavours.gfm.GFMFlavourDescriptor
 import org.intellij.markdown.flavours.gfm.GFMTokenTypes


### PR DESCRIPTION
修复Markdown图片问题，最好将自定义的函数名重命名，否则IDE自动导包时容易误导入。
fix https://github.com/rikkahub/rikkahub/issues/421