### PR TITLE
feat: Add option to skip image cropping

### DIFF
--- a/app/src/main/java/me/rerere/rikkahub/data/datastore/PreferencesStore.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/datastore/PreferencesStore.kt
@@ -329,6 +329,7 @@ data class DisplaySetting(
     val showMessageJumper: Boolean = true,
     val fontSizeRatio: Float = 1.0f,
     val enableMessageGenerationHapticEffect: Boolean = false,
+    val skipCropImage: Boolean = false,
 )
 
 @Serializable

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingDisplayPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingDisplayPage.kt
@@ -310,6 +310,28 @@ fun SettingDisplayPage(vm: SettingVM = koinViewModel()) {
             }
 
             item {
+                Card {
+                    ListItem(
+                        colors = ListItemDefaults.colors(containerColor = Color.Transparent),
+                        headlineContent = {
+                            Text(stringResource(R.string.setting_display_page_skip_crop_image_title))
+                        },
+                        supportingContent = {
+                            Text(stringResource(R.string.setting_display_page_skip_crop_image_desc))
+                        },
+                        trailingContent = {
+                            Switch(
+                                checked = displaySetting.skipCropImage,
+                                onCheckedChange = {
+                                    updateDisplaySetting(displaySetting.copy(skipCropImage = it))
+                                }
+                            )
+                        },
+                    )
+                }
+            }
+
+            item {
                 var createNewConversationOnStart by rememberSharedPreferenceBoolean(
                     "create_new_conversation_on_start",
                     true

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -328,6 +328,8 @@
   <string name="setting_display_page_create_new_conversation_on_start_title">啟動時新建對話</string>
   <string name="setting_display_page_enable_message_generation_haptic_effect_desc">訊息生成時啟用觸覺回饋效果</string>
   <string name="setting_display_page_enable_message_generation_haptic_effect_title">訊息生成觸覺回饋</string>
+  <string name="setting_display_page_skip_crop_image_title">跳過圖片編輯</string>
+  <string name="setting_display_page_skip_crop_image_desc">匯入圖片或拍照後跳過裁剪介面</string>
   <string name="setting_display_page_font_size_preview">這是一個**示例**的聊天文本</string>
   <string name="setting_display_page_font_size_title">聊天字體大小</string>
   <string name="setting_display_page_show_message_jumper_desc">在捲動聊天列表時，在右側顯示快速跳轉按鈕</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -328,6 +328,8 @@
   <string name="setting_display_page_create_new_conversation_on_start_title">启动时新建对话</string>
   <string name="setting_display_page_enable_message_generation_haptic_effect_desc">消息生成时启用触觉反馈效果</string>
   <string name="setting_display_page_enable_message_generation_haptic_effect_title">消息生成触觉反馈</string>
+  <string name="setting_display_page_skip_crop_image_title">跳过图片编辑</string>
+  <string name="setting_display_page_skip_crop_image_desc">导入图片或拍照后跳过裁剪界面</string>
   <string name="setting_display_page_font_size_preview">这是一个**示例**的聊天文本</string>
   <string name="setting_display_page_font_size_title">聊天字体大小</string>
   <string name="setting_display_page_show_message_jumper_desc">在滚动聊天列表时，在右侧显示快速跳转按钮</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -329,6 +329,8 @@
   <string name="setting_display_page_font_size_preview">This is a **sample** chat text</string>
   <string name="setting_display_page_enable_message_generation_haptic_effect_title">Message Generation Haptic Effect</string>
   <string name="setting_display_page_enable_message_generation_haptic_effect_desc">Enable haptic feedback when messages are being generated</string>
+  <string name="setting_display_page_skip_crop_image_title">Skip Image Editing</string>
+  <string name="setting_display_page_skip_crop_image_desc">Skip crop interface after importing images or taking photos</string>
   <string name="setting_display_page_amoled_dark_mode_title">AMOLED Dark Mode</string>
   <string name="setting_display_page_amoled_dark_mode_desc">Use pure black background in dark theme, suitable for AMOLED screens</string>
   <string name="setting_display_page_title">Display Settings</string>


### PR DESCRIPTION
This commit introduces a new setting that allows users to skip the image cropping interface when importing images or taking photos.

Key Changes:
- Added `skipCropImage` field to the `DisplaySetting` data structure in `PreferencesStore.kt`
- Modified `ChatInput.kt` to conditionally skip image cropping based on the new setting
- Added a "Skip Image Editing" toggle switch in `SettingDisplayPage.kt`
- Added corresponding string resources for the new setting in `strings.xml` files

https://discord.com/channels/1363906401902002656/1371869195490427070/1409527324025815081