### PR TITLE
fix: auto select model for provider test

### DIFF
--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingProviderDetailPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingProviderDetailPage.kt
@@ -305,7 +305,6 @@ private fun SettingProviderConfigPage(
             verticalAlignment = Alignment.CenterVertically
         ) {
             ConnectionTester(
-                provider = provider,
                 internalProvider = internalProvider,
                 scope = scope
             )
@@ -490,7 +489,6 @@ private fun SettingProviderProxyPage(
 
 @Composable
 private fun ConnectionTester(
-    provider: ProviderSetting,
     internalProvider: ProviderSetting,
     scope: CoroutineScope
 ) {
@@ -504,7 +502,9 @@ private fun ConnectionTester(
         Icon(Lucide.Cable, null)
     }
     if (showTestDialog) {
-        var model by remember { mutableStateOf<Model?>(null) }
+        var model by remember(internalProvider) {
+            mutableStateOf(internalProvider.models.firstOrNull { it.type == ModelType.CHAT })
+        }
         var testState: UiState<String> by remember { mutableStateOf(UiState.Idle) }
         AlertDialog(
             onDismissRequest = { showTestDialog = false },
@@ -518,7 +518,7 @@ private fun ConnectionTester(
                 ) {
                     ModelSelector(
                         modelId = model?.id,
-                        providers = listOf(provider),
+                        providers = listOf(internalProvider),
                         type = ModelType.CHAT,
                         modifier = Modifier.fillMaxWidth()
                     ) {


### PR DESCRIPTION
## Summary
- default connection test to first chat model of internal provider
- drop unused provider argument from `ConnectionTester`

## Testing
- `./gradlew test lint` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68b8f513c22c8320beaf7845fbcd87ea