### PR TITLE
fix: extend MCP tool call timeout

### DIFF
--- a/app/src/main/java/me/rerere/rikkahub/data/mcp/McpManager.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/mcp/McpManager.kt
@@ -110,7 +110,7 @@ class McpManager(
                 name = tool.name,
                 arguments = args,
             ),
-            options = RequestOptions(timeout = 30.seconds),
+            options = RequestOptions(timeout = 60.seconds),
             compatibility = true
         )
         require(result != null) {


### PR DESCRIPTION
## Summary
- increase MCP tool invocation timeout from 30s to 60s
- restore gradlew executable permission

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*
- `./gradlew lint` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68b8f8d374bc8320a16d851d075fbfce