### PR TITLE
feat: add quick messages support

### DIFF
--- a/app/src/main/java/me/rerere/rikkahub/data/model/Assistant.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/model/Assistant.kt
@@ -24,6 +24,7 @@ data class Assistant(
     val enableRecentChatsReference: Boolean = false,
     val messageTemplate: String = "{{ message }}",
     val presetMessages: List<UIMessage> = emptyList(),
+    val quickMessages: List<QuickMessage> = emptyList(),
     val thinkingBudget: Int? = 1024,
     val maxTokens: Int? = null,
     val customHeaders: List<CustomHeader> = emptyList(),
@@ -32,6 +33,12 @@ data class Assistant(
     val localTools: List<LocalToolOption> = emptyList(),
     val background: String? = null,
     val learningMode: Boolean = false,
+)
+
+@Serializable
+data class QuickMessage(
+    val title: String = "",
+    val content: String = "",
 )
 
 @Serializable

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/assistant/detail/AssistantPromptSubPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/assistant/detail/AssistantPromptSubPage.kt
@@ -71,6 +71,7 @@ import me.rerere.rikkahub.data.ai.transformers.PlaceholderTransformer
 import me.rerere.rikkahub.data.ai.transformers.TemplateTransformer
 import me.rerere.rikkahub.data.model.Assistant
 import me.rerere.rikkahub.data.model.Conversation
+import me.rerere.rikkahub.data.model.QuickMessage
 import me.rerere.rikkahub.data.model.toMessageNode
 import me.rerere.rikkahub.ui.components.message.ChatMessage
 import me.rerere.rikkahub.ui.components.ui.FormItem
@@ -392,6 +393,97 @@ fun AssistantPromptSubPage(
                                     role = nextRole,
                                     parts = listOf(UIMessagePart.Text(""))
                                 )
+                            )
+                        )
+                    },
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Icon(Lucide.Plus, null)
+                }
+            }
+        }
+
+        Card {
+            FormItem(
+                modifier = Modifier.padding(16.dp),
+                label = {
+                    Text("Quick Messages")
+                },
+                description = {
+                    Text("Configure quick message shortcuts")
+                }
+            )
+            Column(
+                verticalArrangement = Arrangement.spacedBy(16.dp),
+                modifier = Modifier.padding(16.dp)
+            ) {
+                assistant.quickMessages.fastForEachIndexed { index, quickMessage ->
+                    Column(
+                        verticalArrangement = Arrangement.spacedBy(4.dp)
+                    ) {
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.spacedBy(8.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                        ) {
+                            OutlinedTextField(
+                                value = quickMessage.title,
+                                onValueChange = { title ->
+                                    onUpdate(
+                                        assistant.copy(
+                                            quickMessages = assistant.quickMessages.mapIndexed { i, msg ->
+                                                if (i == index) {
+                                                    msg.copy(title = title)
+                                                } else {
+                                                    msg
+                                                }
+                                            }
+                                        )
+                                    )
+                                },
+                                modifier = Modifier.weight(1f),
+                                label = { Text("Title") }
+                            )
+                            IconButton(
+                                onClick = {
+                                    onUpdate(
+                                        assistant.copy(
+                                            quickMessages = assistant.quickMessages.filterIndexed { i, _ ->
+                                                i != index
+                                            }
+                                        )
+                                    )
+                                }
+                            ) {
+                                Icon(Lucide.X, null)
+                            }
+                        }
+                        OutlinedTextField(
+                            value = quickMessage.content,
+                            onValueChange = { text ->
+                                onUpdate(
+                                    assistant.copy(
+                                        quickMessages = assistant.quickMessages.mapIndexed { i, msg ->
+                                            if (i == index) {
+                                                msg.copy(content = text)
+                                            } else {
+                                                msg
+                                            }
+                                        }
+                                    )
+                                )
+                            },
+                            modifier = Modifier.fillMaxWidth(),
+                            maxLines = 6,
+                            label = { Text("Content") }
+                        )
+                    }
+                }
+                Button(
+                    onClick = {
+                        onUpdate(
+                            assistant.copy(
+                                quickMessages = assistant.quickMessages + QuickMessage()
                             )
                         )
                     },


### PR DESCRIPTION
## Summary
- add `QuickMessage` data class and `quickMessages` field to `Assistant`
- allow editing quick messages in `AssistantPromptSubPage`

## Testing
- `./gradlew lint` *(fails: Unable to tunnel through proxy)*
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68b906dcd04c8320a364febfc687b1eb