### PR TITLE
fix: show empty MCP server message only when list empty

### DIFF
--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingMcpPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingMcpPage.kt
@@ -168,16 +168,18 @@ fun SettingMcpPage(vm: SettingVM = koinViewModel()) {
                 }
             }
 
-            Column(
-                modifier = Modifier.align(Alignment.Center),
-                verticalArrangement = Arrangement.spacedBy(8.dp),
-                horizontalAlignment = Alignment.CenterHorizontally,
-            ) {
-                Text(text = stringResource(R.string.setting_mcp_page_no_mcp_servers_found))
-                Text(
-                    text = stringResource(R.string.setting_mcp_page_add_one_to_get_started),
-                    style = MaterialTheme.typography.bodySmall,
-                )
+            if (mcpConfigs.isEmpty()) {
+                Column(
+                    modifier = Modifier.align(Alignment.Center),
+                    verticalArrangement = Arrangement.spacedBy(8.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                ) {
+                    Text(text = stringResource(R.string.setting_mcp_page_no_mcp_servers_found))
+                    Text(
+                        text = stringResource(R.string.setting_mcp_page_add_one_to_get_started),
+                        style = MaterialTheme.typography.bodySmall,
+                    )
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- display "no MCP servers found" only when the list is empty

## Testing
- `bash ./gradlew test lint` *(failed: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68bd995b70308320a2f674d2554f2d9b