### PR TITLE
feat: allow custom overrides in image generation

### DIFF
--- a/ai/src/main/java/me/rerere/ai/provider/Provider.kt
+++ b/ai/src/main/java/me/rerere/ai/provider/Provider.kt
@@ -55,6 +55,8 @@ data class ImageGenerationParams(
     val prompt: String,
     val numOfImages: Int = 1,
     val aspectRatio: ImageAspectRatio = ImageAspectRatio.SQUARE,
+    val customHeaders: List<CustomHeader> = emptyList(),
+    val customBody: List<CustomBody> = emptyList(),
 )
 
 @Serializable

--- a/ai/src/main/java/me/rerere/ai/provider/providers/GoogleProvider.kt
+++ b/ai/src/main/java/me/rerere/ai/provider/providers/GoogleProvider.kt
@@ -650,7 +650,7 @@ class GoogleProvider(private val client: OkHttpClient) : Provider<ProviderSettin
                     ImageAspectRatio.PORTRAIT -> "9:16"
                 })
             }
-        }
+        }.mergeCustomBody(params.customBody)
 
         val url = buildUrl(
             providerSetting = providerSetting,
@@ -665,6 +665,7 @@ class GoogleProvider(private val client: OkHttpClient) : Provider<ProviderSettin
             providerSetting = providerSetting,
             request = Request.Builder()
                 .url(url)
+                .headers(params.customHeaders.toHeaders())
                 .post(
                     json.encodeToString(requestBody).toRequestBody("application/json".toMediaType())
                 )

--- a/ai/src/main/java/me/rerere/ai/provider/providers/OpenAIProvider.kt
+++ b/ai/src/main/java/me/rerere/ai/provider/providers/OpenAIProvider.kt
@@ -24,6 +24,8 @@ import me.rerere.ai.ui.UIMessage
 import me.rerere.ai.util.KeyRoulette
 import me.rerere.ai.util.configureClientWithProxy
 import me.rerere.ai.util.json
+import me.rerere.ai.util.mergeCustomBody
+import me.rerere.ai.util.toHeaders
 import me.rerere.common.http.await
 import me.rerere.common.http.getByKey
 import me.rerere.common.http.jsonPrimitiveOrNull
@@ -159,11 +161,12 @@ class OpenAIProvider(
                         ImageAspectRatio.PORTRAIT -> "1024x1536"
                     }
                 )
-            }
+            }.mergeCustomBody(params.customBody)
         )
 
         val request = Request.Builder()
             .url("${providerSetting.baseUrl}/images/generations")
+            .headers(params.customHeaders.toHeaders())
             .addHeader("Authorization", "Bearer $key")
             .addHeader("Content-Type", "application/json")
             .post(requestBody.toRequestBody("application/json".toMediaType()))

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/imggen/ImgGenVM.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/imggen/ImgGenVM.kt
@@ -127,7 +127,9 @@ class ImgGenVM(
                     model = model,
                     prompt = _prompt.value,
                     numOfImages = _numberOfImages.value,
-                    aspectRatio = _aspectRatio.value
+                    aspectRatio = _aspectRatio.value,
+                    customHeaders = model.customHeaders,
+                    customBody = model.customBodies
                 )
 
                 val result = providerManager.getProviderByType(provider)


### PR DESCRIPTION
This pull request enables image generation requests to honor per-model custom headers and body overrides, mirroring the existing text-generation implementation.

Key Changes:
- extend `ImageGenerationParams` to carry override data and pass it through `ImgGenVM`
- apply custom headers and merged body payloads in OpenAI image generation requests
- apply custom headers and merged body payloads in Google image generation requests
