### PR TITLE
feat: add Ollama search provider

### DIFF
--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingSearchPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingSearchPage.kt
@@ -299,6 +299,13 @@ private fun SearchProviderCard(
                     }
                 }
 
+                is SearchServiceOptions.OllamaOptions -> {
+                    OllamaOptions(options as SearchServiceOptions.OllamaOptions) {
+                        options = it
+                        onUpdateService(options)
+                    }
+                }
+
                 is SearchServiceOptions.BingLocalOptions -> {}
             }
 
@@ -650,6 +657,30 @@ private fun BraveOptions(
 private fun MetasoOptions(
     options: SearchServiceOptions.MetasoOptions,
     onUpdateOptions: (SearchServiceOptions.MetasoOptions) -> Unit
+) {
+    FormItem(
+        label = {
+            Text("API Key")
+        }
+    ) {
+        OutlinedTextField(
+            value = options.apiKey,
+            onValueChange = {
+                onUpdateOptions(
+                    options.copy(
+                        apiKey = it
+                    )
+                )
+            },
+            modifier = Modifier.fillMaxWidth()
+        )
+    }
+}
+
+@Composable
+private fun OllamaOptions(
+    options: SearchServiceOptions.OllamaOptions,
+    onUpdateOptions: (SearchServiceOptions.OllamaOptions) -> Unit
 ) {
     FormItem(
         label = {

--- a/search/src/main/java/me/rerere/search/OllamaSearchService.kt
+++ b/search/src/main/java/me/rerere/search/OllamaSearchService.kt
@@ -1,0 +1,99 @@
+package me.rerere.search
+
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.res.stringResource
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+import me.rerere.ai.core.InputSchema
+import me.rerere.search.SearchResult.SearchResultItem
+import me.rerere.search.SearchService.Companion.httpClient
+import me.rerere.search.SearchService.Companion.json
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+
+private const val TAG = "OllamaSearchService"
+
+object OllamaSearchService : SearchService<SearchServiceOptions.OllamaOptions> {
+    override val name: String = "Ollama"
+
+    @Composable
+    override fun Description() {
+        val uriHandler = LocalUriHandler.current
+        TextButton(onClick = { uriHandler.openUri("https://ollama.com/") }) {
+            Text(stringResource(R.string.click_to_get_api_key))
+        }
+    }
+
+    override val parameters: InputSchema?
+        get() = InputSchema.Obj(
+            properties = buildJsonObject {
+                put("query", buildJsonObject {
+                    put("type", "string")
+                    put("description", "search keyword")
+                })
+            },
+            required = listOf("query")
+        )
+
+    override suspend fun search(
+        params: JsonObject,
+        commonOptions: SearchCommonOptions,
+        serviceOptions: SearchServiceOptions.OllamaOptions
+    ): Result<SearchResult> = withContext(Dispatchers.IO) {
+        runCatching {
+            val query = params["query"]?.jsonPrimitive?.content ?: error("query is required")
+
+            val body = buildJsonObject {
+                put("query", query)
+                put("max_results", commonOptions.resultSize)
+            }
+
+            val request = Request.Builder()
+                .url("https://ollama.com/api/web_search")
+                .post(body.toString().toRequestBody("application/json".toMediaType()))
+                .addHeader("Authorization", "Bearer ${serviceOptions.apiKey}")
+                .build()
+
+            val response = httpClient.newCall(request).await()
+            if (response.isSuccessful) {
+                val responseBody = response.body.string()
+                val searchResponse = json.decodeFromString<OllamaSearchResponse>(responseBody)
+
+                return@withContext Result.success(
+                    SearchResult(
+                        items = searchResponse.results.map {
+                            SearchResultItem(
+                                title = it.title,
+                                url = it.url,
+                                text = it.content
+                            )
+                        }
+                    )
+                )
+            } else {
+                error("Ollama search failed with code ${response.code}: ${response.message}")
+            }
+        }
+    }
+
+    @Serializable
+    private data class OllamaSearchResponse(
+        val results: List<OllamaSearchResult>
+    )
+
+    @Serializable
+    private data class OllamaSearchResult(
+        val title: String,
+        val url: String,
+        val content: String
+    )
+}

--- a/search/src/main/java/me/rerere/search/SearchService.kt
+++ b/search/src/main/java/me/rerere/search/SearchService.kt
@@ -42,6 +42,7 @@ interface SearchService<T : SearchServiceOptions> {
                 is SearchServiceOptions.LinkUpOptions -> LinkUpService
                 is SearchServiceOptions.BraveOptions -> BraveSearchService
                 is SearchServiceOptions.MetasoOptions -> MetasoSearchService
+                is SearchServiceOptions.OllamaOptions -> OllamaSearchService
             } as SearchService<T>
         }
 
@@ -92,7 +93,8 @@ sealed class SearchServiceOptions {
             SearXNGOptions::class to "SearXNG",
             LinkUpOptions::class to "LinkUp",
             BraveOptions::class to "Brave",
-            MetasoOptions::class to "秘塔"
+            MetasoOptions::class to "秘塔",
+            OllamaOptions::class to "Ollama",
         )
     }
 
@@ -153,6 +155,13 @@ sealed class SearchServiceOptions {
     @Serializable
     @SerialName("metaso")
     data class MetasoOptions(
+        override val id: Uuid = Uuid.random(),
+        val apiKey: String = "",
+    ) : SearchServiceOptions()
+
+    @Serializable
+    @SerialName("ollama")
+    data class OllamaOptions(
         override val id: Uuid = Uuid.random(),
         val apiKey: String = "",
     ) : SearchServiceOptions()


### PR DESCRIPTION
## Summary
- add a new Ollama web search integration with request/response handling
- expose Ollama configuration in the search provider settings UI

## Testing
- `bash ./gradlew :search:test` *(fails: Unable to tunnel through proxy, HTTP 403 when downloading Gradle)*

------
https://chatgpt.com/codex/tasks/task_e_68d5f543ac2883209daafacb1ace2f3b