### PR TITLE
feat(search): add Perplexity search provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Click to join our Discord server 👉 [【RikkaHub】](https://discord.gg/9weBqx
 - 🛠️ MCP support
 - 📝 Markdown Rendering (with code highlighting, Latex formulas, tables, Mermaid)
 - 🪾 Message Branching
-- 🔍 Search capabilities (Exa, Tavily, Zhipu, LinkUp, Brave, etc.)
+- 🔍 Search capabilities (Exa, Tavily, Zhipu, LinkUp, Brave, Perplexity, etc.)
 - 🧩 Prompt variables (model name, time, etc.)
 - 🤳 QR code export and import for providers
 - 🤖 Agent customization

--- a/README_ZH_CN.md
+++ b/README_ZH_CN.md
@@ -30,7 +30,7 @@
 - 🔄 多种类型的供应商支持，自定义 API / URL / 模型（目前支持 OpenAI、Google、Anthropic）
 - 🖼️ 多模态输入支持
 - 📝 Markdown 渲染（支持代码高亮、数学公式、表格、Mermaid）
-- 🔍 搜索功能（Exa、Tavily、Zhipu、LinkUp、Brave、..）
+- 🔍 搜索功能（Exa、Tavily、Zhipu、LinkUp、Brave、Perplexity、..）
 - 🧩 Prompt 变量（模型名称、时间等）
 - 🤳 二维码导出和导入提供商
 - 🤖 智能体自定义

--- a/README_ZH_TW.md
+++ b/README_ZH_TW.md
@@ -30,7 +30,7 @@
 - 🔄 多種類型的供應商支持，自定義 API / URL / 模型（目前支持 OpenAI、Google、Anthropic）
 - 🖼️ 多模態輸入支持
 - 📝 Markdown 渲染（支持代碼高亮、數學公式、表格、Mermaid）
-- 🔍 搜尋功能（Exa、Tavily、Zhipu、LinkUp、Brave、..）
+- 🔍 搜尋功能（Exa、Tavily、Zhipu、LinkUp、Brave、Perplexity、..）
 - 🧩 Prompt 變量（模型名稱、時間等）
 - 🤳 二維碼導出和導入提供商
 - 🤖 智能體自定義

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingSearchPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingSearchPage.kt
@@ -38,6 +38,8 @@ import androidx.compose.ui.draw.scale
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.KeyboardOptions
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.composables.icons.lucide.GripHorizontal
@@ -301,6 +303,13 @@ private fun SearchProviderCard(
 
                 is SearchServiceOptions.OllamaOptions -> {
                     OllamaOptions(options as SearchServiceOptions.OllamaOptions) {
+                        options = it
+                        onUpdateService(options)
+                    }
+                }
+
+                is SearchServiceOptions.PerplexityOptions -> {
+                    PerplexityOptions(options as SearchServiceOptions.PerplexityOptions) {
                         options = it
                         onUpdateService(options)
                     }
@@ -697,6 +706,49 @@ private fun OllamaOptions(
                 )
             },
             modifier = Modifier.fillMaxWidth()
+        )
+    }
+}
+
+@Composable
+private fun PerplexityOptions(
+    options: SearchServiceOptions.PerplexityOptions,
+    onUpdateOptions: (SearchServiceOptions.PerplexityOptions) -> Unit
+) {
+    FormItem(
+        label = {
+            Text("API Key")
+        }
+    ) {
+        OutlinedTextField(
+            value = options.apiKey,
+            onValueChange = {
+                onUpdateOptions(
+                    options.copy(
+                        apiKey = it
+                    )
+                )
+            },
+            modifier = Modifier.fillMaxWidth()
+        )
+    }
+
+    FormItem(
+        label = {
+            Text("Max Tokens / Page")
+        }
+    ) {
+        OutlinedTextField(
+            value = options.maxTokensPerPage?.takeIf { it > 0 }?.toString() ?: "",
+            onValueChange = { value ->
+                onUpdateOptions(
+                    options.copy(
+                        maxTokensPerPage = value.toIntOrNull()
+                    )
+                )
+            },
+            modifier = Modifier.fillMaxWidth(),
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number)
         )
     }
 }

--- a/search/src/main/java/me/rerere/search/PerplexitySearchService.kt
+++ b/search/src/main/java/me/rerere/search/PerplexitySearchService.kt
@@ -1,0 +1,124 @@
+package me.rerere.search
+
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.res.stringResource
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+import me.rerere.ai.core.InputSchema
+import me.rerere.search.SearchResult.SearchResultItem
+import me.rerere.search.SearchService.Companion.httpClient
+import me.rerere.search.SearchService.Companion.json
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+
+private const val PERPLEXITY_ENDPOINT = "https://api.perplexity.ai/search"
+
+object PerplexitySearchService : SearchService<SearchServiceOptions.PerplexityOptions> {
+    override val name: String = "Perplexity"
+
+    @Composable
+    override fun Description() {
+        val uriHandler = LocalUriHandler.current
+        TextButton(
+            onClick = {
+                uriHandler.openUri("https://www.perplexity.ai/settings/api")
+            }
+        ) {
+            Text(stringResource(R.string.click_to_get_api_key))
+        }
+    }
+
+    override val parameters: InputSchema?
+        get() = InputSchema.Obj(
+            properties = buildJsonObject {
+                put("query", buildJsonObject {
+                    put("type", "string")
+                    put("description", "search keyword")
+                })
+            },
+            required = listOf("query")
+        )
+
+    override suspend fun search(
+        params: JsonObject,
+        commonOptions: SearchCommonOptions,
+        serviceOptions: SearchServiceOptions.PerplexityOptions
+    ): Result<SearchResult> = withContext(Dispatchers.IO) {
+        runCatching {
+            if (serviceOptions.apiKey.isBlank()) {
+                error("Perplexity API key is required")
+            }
+
+            val query = params["query"]?.jsonPrimitive?.content
+                ?: error("query is required")
+
+            val body = buildJsonObject {
+                put("query", JsonPrimitive(query))
+                put("max_results", JsonPrimitive(commonOptions.resultSize))
+                serviceOptions.maxTokensPerPage?.let {
+                    if (it > 0) {
+                        put("max_tokens_per_page", JsonPrimitive(it))
+                    }
+                }
+            }
+
+            val request = Request.Builder()
+                .url(PERPLEXITY_ENDPOINT)
+                .post(body.toString().toRequestBody())
+                .addHeader("Authorization", "Bearer ${serviceOptions.apiKey}")
+                .addHeader("Content-Type", "application/json")
+                .build()
+
+            val response = httpClient.newCall(request).await()
+            if (response.isSuccessful) {
+                val responseBody = response.body.string().let {
+                    json.decodeFromString<PerplexityResponse>(it)
+                }
+
+                val items = responseBody.results
+                    .filter { !it.title.isNullOrBlank() && !it.url.isNullOrBlank() }
+                    .take(commonOptions.resultSize)
+                    .map {
+                        SearchResultItem(
+                            title = it.title!!,
+                            url = it.url!!,
+                            text = it.snippet ?: it.text ?: ""
+                        )
+                    }
+
+                return@withContext Result.success(
+                    SearchResult(
+                        answer = responseBody.answer,
+                        items = items
+                    )
+                )
+            } else {
+                error("response failed #${response.code}: ${response.body?.string()}")
+            }
+        }
+    }
+
+    @Serializable
+    private data class PerplexityResponse(
+        val answer: String? = null,
+        val results: List<ResultItem> = emptyList()
+    ) {
+        @Serializable
+        data class ResultItem(
+            val title: String? = null,
+            val url: String? = null,
+            val snippet: String? = null,
+            @SerialName("text") val text: String? = null,
+        )
+    }
+}

--- a/search/src/main/java/me/rerere/search/SearchService.kt
+++ b/search/src/main/java/me/rerere/search/SearchService.kt
@@ -43,6 +43,7 @@ interface SearchService<T : SearchServiceOptions> {
                 is SearchServiceOptions.BraveOptions -> BraveSearchService
                 is SearchServiceOptions.MetasoOptions -> MetasoSearchService
                 is SearchServiceOptions.OllamaOptions -> OllamaSearchService
+                is SearchServiceOptions.PerplexityOptions -> PerplexitySearchService
             } as SearchService<T>
         }
 
@@ -95,6 +96,7 @@ sealed class SearchServiceOptions {
             BraveOptions::class to "Brave",
             MetasoOptions::class to "秘塔",
             OllamaOptions::class to "Ollama",
+            PerplexityOptions::class to "Perplexity",
         )
     }
 
@@ -164,6 +166,14 @@ sealed class SearchServiceOptions {
     data class OllamaOptions(
         override val id: Uuid = Uuid.random(),
         val apiKey: String = "",
+    ) : SearchServiceOptions()
+
+    @Serializable
+    @SerialName("perplexity")
+    data class PerplexityOptions(
+        override val id: Uuid = Uuid.random(),
+        val apiKey: String = "",
+        val maxTokensPerPage: Int? = 1024,
     ) : SearchServiceOptions()
 }
 


### PR DESCRIPTION
## Summary
- add a Perplexity search service implementation with configurable API key and page token limits
- expose the new provider in the search settings UI so it can be selected and configured
- document Perplexity as an available web search integration in the READMEs

## Testing
- bash ./gradlew :search:lint *(fails: unable to download Gradle due to proxy restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68d74e7f58908320a5cd5d9eee12c329