### PR TITLE
fix: rename google provider system instruction key

### DIFF
--- a/ai/src/main/java/me/rerere/ai/provider/providers/GoogleProvider.kt
+++ b/ai/src/main/java/me/rerere/ai/provider/providers/GoogleProvider.kt
@@ -336,7 +336,7 @@ class GoogleProvider(private val client: OkHttpClient) : Provider<ProviderSettin
         // System message if available
         val systemMessage = messages.firstOrNull { it.role == MessageRole.SYSTEM }
         if (systemMessage != null && !params.model.outputModalities.contains(Modality.IMAGE)) {
-            put("system_instruction", buildJsonObject {
+            put("systemInstruction", buildJsonObject {
                 putJsonArray("parts") {
                     add(buildJsonObject {
                         put(


### PR DESCRIPTION
## Summary
- rename the Google provider completion payload field from `system_instruction` to `systemInstruction`

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0b3611f8883208ef558f4e8bccd4d