### PR TITLE
Move MessageJumper to the left side

### DIFF
--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ChatList.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ChatList.kt
@@ -386,12 +386,12 @@ private fun BoxScope.MessageJumper(
 ) {
     AnimatedVisibility(
         visible = show,
-        modifier = Modifier.align(Alignment.CenterEnd),
+        modifier = Modifier.align(Alignment.CenterStart),
         enter = slideInHorizontally(
-            initialOffsetX = { it * 2 },
+            initialOffsetX = { -it * 2 },
         ),
         exit = slideOutHorizontally(
-            targetOffsetX = { it * 2 },
+            targetOffsetX = { -it * 2 },
         )
     ) {
         Column(


### PR DESCRIPTION
Repositioned the message navigation arrows (MessageJumper component) from right (Alignment.CenterEnd) to left (Alignment.CenterStart) in ChatPage to prevent users from accidentally triggering copy or preview buttons during navigation.