### PR TITLE
feat(chat): 为发送按钮增加长按无应答功能

### DIFF
--- a/app/src/main/java/me/rerere/rikkahub/service/ChatService.kt
+++ b/app/src/main/java/me/rerere/rikkahub/service/ChatService.kt
@@ -255,7 +255,7 @@ class ChatService(
     }
 
     // 发送消息
-    fun sendMessage(conversationId: Uuid, content: List<UIMessagePart>) {
+    fun sendMessage(conversationId: Uuid, content: List<UIMessagePart>, answer: Boolean=true) {
         // 取消现有的生成任务
         getGenerationJob(conversationId)?.cancel()
 
@@ -273,7 +273,9 @@ class ChatService(
                 saveConversation(conversationId, newConversation)
 
                 // 开始补全
-                handleMessageComplete(conversationId)
+                if(answer){
+                    handleMessageComplete(conversationId)
+                }
 
                 _generationDoneFlow.emit(conversationId)
             } catch (e: Exception) {
@@ -281,7 +283,6 @@ class ChatService(
                 _errorFlow.emit(e)
             }
         }
-
         setGenerationJob(conversationId, job)
         job.invokeOnCompletion {
             setGenerationJob(conversationId, null)

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ChatPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ChatPage.kt
@@ -289,6 +289,20 @@ private fun ChatPageContent(
                         }
                         inputState.clearInput()
                     },
+                    onLongSendClick = {
+                        if (inputState.isEditing()) {
+                            vm.handleMessageEdit(
+                                parts = inputState.getContents(),
+                                messageId = inputState.editingMessage!!,
+                            )
+                        } else {
+                            vm.handleMessageSend(inputState.getContents(),false)
+                            scope.launch {
+                                chatListState.requestScrollToItem(conversation.currentMessages.size + 5)
+                            }
+                        }
+                        inputState.clearInput()
+                    },
                     onUpdateChatModel = {
                         vm.setChatModel(assistant = setting.getCurrentAssistant(), model = it)
                     },

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ChatVM.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ChatVM.kt
@@ -247,7 +247,7 @@ class ChatVM(
     val updateState =
         updateChecker.checkUpdate().stateIn(viewModelScope, SharingStarted.Eagerly, UiState.Loading)
 
-    fun handleMessageSend(content: List<UIMessagePart>) {
+    fun handleMessageSend(content: List<UIMessagePart>,answer: Boolean=true) {
         if (content.isEmptyInputMessage()) return
         analytics.logEvent("ai_send_message", null)
 
@@ -272,7 +272,7 @@ class ChatVM(
             content
         }
 
-        chatService.sendMessage(_conversationId, processedContent)
+        chatService.sendMessage(_conversationId, processedContent, answer)
     }
 
     fun handleMessageEdit(parts: List<UIMessagePart>, messageId: Uuid) {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.11.0"
+agp = "8.13.0"
 barcodeScanning = "17.3.0"
 cameraCore = "1.5.0-rc01"
 dav4jvm = "main-SNAPSHOT"


### PR DESCRIPTION
1.  **ChatInput.kt**:
    *   将原有的 `IconButton` 发送按钮替换为了一个使用 `Box` 构建的、功能完全相同的自定义组件，从根本上解决了 `IconButton` 与长按手势的事件冲突问题。
    *   为这个新的发送按钮实现了**单击**和**长按**两种交互：
        *   **单击**：保留原有行为，发送消息并请求 AI 回复。
        *   **长按**：发送消息到对话列表，但**不**向 AI 发出请求。
    *   优化了按钮的视觉反馈：加载中为红色，输入为空时为灰色（禁用），可发送时为主题色。

2.  **ChatService.kt**:
    *   为 `sendMessage` 函数增加了一个可选的 `answer: Boolean` 参数，默认值为 `true`。
    *   当 `answer` 参数为 `false` 时，函数将只保存用户消息，并跳过调用 `handleMessageComplete()`，从而实现不向 AI 发出请求的功能。
