### PR TITLE
fix: consume response body in SSE send() to prevent connection pool issues

### DIFF
--- a/app/src/main/java/me/rerere/rikkahub/data/ai/mcp/transport/SseClientTransport.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/ai/mcp/transport/SseClientTransport.kt
@@ -105,9 +105,13 @@ class SseClientTransport(
                 setBody(McpJson.encodeToString(message))
             }
 
+            // Always consume the response body to properly release the connection
+            // Without this, the unconsumed response can cause connection pool issues
+            // that terminate the SSE stream sharing the same HttpClient
+            val bodyText = response.bodyAsText()
+
             if (!response.status.isSuccess()) {
-                val text = response.bodyAsText()
-                error("Error POSTing to endpoint (HTTP ${response.status}): $text")
+                error("Error POSTing to endpoint (HTTP ${response.status}): $bodyText")
             }
 
             Log.d(TAG, "Client successfully sent message via SSE $endpoint")


### PR DESCRIPTION
## 问题描述

使用 SSE 协议连接 MCP 服务时，第一次工具调用成功后，第二次调用**必定**失败，报错 `SseClientTransport is not initialized!`

## 根本原因

在 `SseClientTransport.kt` 的 `send()` 方法中，当 POST 请求成功时，响应体没有被消费：

```kotlin
// 修复前
if (!response.status.isSuccess()) {
    val text = response.bodyAsText()  // 只在失败时消费
    error("Error POSTing to endpoint (HTTP ${response.status}): $text")
}
// 成功时 response body 未被消费！
```

**问题链条：**
1. 第一次工具调用，POST 请求成功
2. 成功时 `response.bodyAsText()` 没有被调用，HTTP 响应体未被消费
3. 在 Ktor/OkHttp 中，未消费的响应体会导致底层 TCP 连接泄漏或被提前关闭
4. SSE 流和 POST 请求共用同一个 `HttpClient` 连接池
5. 连接被重置 → SSE 流断开 → `session.incoming.collect` 结束
6. `collectMessages()` 的 `finally` 块执行 `closeResources()` → `initialized = false`
7. 第二次调用时检查 `initialized` 为 false，抛出异常

## 修复方案

确保响应体始终被消费，无论请求成功还是失败：

```kotlin
// 修复后
// Always consume the response body to properly release the connection
val bodyText = response.bodyAsText()

if (!response.status.isSuccess()) {
    error("Error POSTing to endpoint (HTTP ${response.status}): $bodyText")
}
```

## 测试

- 配置 SSE 协议的 MCP 服务
- 连续多次调用工具
- 验证不再出现 `SseClientTransport is not initialized!` 错误