### PR TITLE
fix: 修复请求头覆盖User-Agent字段

### DIFF
--- a/app/src/main/java/me/rerere/rikkahub/di/DataSourceModule.kt
+++ b/app/src/main/java/me/rerere/rikkahub/di/DataSourceModule.kt
@@ -97,11 +97,15 @@ val dataSourceModule = module {
             .followRedirects(true)
             .retryOnConnectionFailure(true)
             .addInterceptor { chain ->
-                val request = chain.request().newBuilder()
+                val originalRequest = chain.request()
+                val requestBuilder = originalRequest.newBuilder()
                     .addHeader(HttpHeaders.AcceptLanguage, acceptLang)
-                    .addHeader(HttpHeaders.UserAgent, "RikkaHub-Android/${BuildConfig.VERSION_NAME}")
-                    .build()
-                chain.proceed(request)
+
+                if (originalRequest.header(HttpHeaders.UserAgent) == null) {
+                    requestBuilder.addHeader(HttpHeaders.UserAgent, "RikkaHub-Android/${BuildConfig.VERSION_NAME}")
+                }
+
+                chain.proceed(requestBuilder.build())
             }
             .addInterceptor(RequestLoggingInterceptor())
             .addInterceptor(AIRequestInterceptor(remoteConfig = get()))


### PR DESCRIPTION
见Issue #742 

## 问题描述
在Provider-模型设置中，对模型设置请求头中的User-Agent字段不生效，会被覆盖为RikkaHub-Android/version

## 修复措施
`DataSourceModule.kt`中 interceptor 会无条件的运行 addHeader(User-Agent, "RikkaHub-Android/...")，导致自定义 UA 也会被再追加一个默认 UA
现在，仅在无UA覆盖的情况下追加默认UA