### PR TITLE
修复删除聊天后列表未立即刷新的问题 (#747)

### DIFF
--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ChatDrawer.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ChatDrawer.kt
@@ -190,6 +190,10 @@ fun ChatDrawerContent(
                 },
                 onDelete = {
                     vm.deleteConversation(it)
+                    // Refresh the conversation list to immediately remove the deleted item
+                    // This fixes the issue where deleted conversations sometimes remain visible
+                    // until manually clicked (issue #747)
+                    conversations.refresh()
                     if (it.id == current.id) {
                         navigateToChatPage(navController)
                     }


### PR DESCRIPTION
### 问题描述

在侧边栏删除聊天后,聊天的标题有时仍然显示在列表中,而不是立即消失。这是一个概率性bug,大约5次操作中会出现2-3次。用户需要额外点击一下才能让已删除的项目从列表中消失。

**复现步骤**:
1. 在侧边栏聊天列表中
2. 删除一个聊天(通常是最新的那条)
3. 观察到标题仍然显示
4. 需要再次点击才会消失

**影响版本**: v1.7.11及之前

---

### 根本原因

项目使用了Paging3的`LazyPagingItems`来管理聊天列表。当删除操作执行时:
1. ✅ 数据库正确删除了记录
2. ❌ 但Paging的内存缓存没有立即失效
3. 结果: UI显示的是缓存中的旧数据,直到手动触发刷新

---

### 解决方案

在`ChatDrawer.kt`的`onDelete`回调中,删除会话后立即调用`conversations.refresh()`:

```kotlin
onDelete = {
    vm.deleteConversation(it)
    // Refresh the conversation list to immediately remove the deleted item
    conversations.refresh()
    if (it.id == current.id) {
        navigateToChatPage(navController)
    }
},