### PR TITLE
fix: 避免在停止生成后上传空的消息(#807)

### DIFF
--- a/ai/src/main/java/me/rerere/ai/ui/Message.kt
+++ b/ai/src/main/java/me/rerere/ai/ui/Message.kt
@@ -171,7 +171,7 @@ data class UIMessage(
             is UIMessagePart.Video -> part.url.isNotBlank()
             is UIMessagePart.Audio -> part.url.isNotBlank()
             is UIMessagePart.Document -> part.url.isNotBlank()
-            is UIMessagePart.Reasoning -> false
+            is UIMessagePart.Reasoning -> part.reasoning.isNotBlank()
             else -> true
         }
     }

--- a/ai/src/test/java/me/rerere/ai/provider/providers/openai/ChatCompletionsAPIMessageTest.kt
+++ b/ai/src/test/java/me/rerere/ai/provider/providers/openai/ChatCompletionsAPIMessageTest.kt
@@ -324,6 +324,28 @@ class ChatCompletionsAPIMessageTest {
         assertEquals("Question 2", result[1].jsonObject["content"]?.jsonPrimitive?.content)
     }
 
+    @Test
+    fun `latest assistant with reasoning and empty text should keep reasoning content`() {
+        val messages = listOf(
+            UIMessage.user("Question 1"),
+            UIMessage(
+                role = MessageRole.ASSISTANT,
+                parts = listOf(
+                    UIMessagePart.Reasoning(reasoning = "thinking"),
+                    UIMessagePart.Text("")
+                )
+            )
+        )
+
+        val result = invokeBuildMessages(messages)
+
+        assertEquals(2, result.size)
+        assertEquals("user", result[0].jsonObject["role"]?.jsonPrimitive?.content)
+        assertEquals("assistant", result[1].jsonObject["role"]?.jsonPrimitive?.content)
+        assertEquals("thinking", result[1].jsonObject["reasoning_content"]?.jsonPrimitive?.content)
+        assertEquals("", result[1].jsonObject["content"]?.jsonPrimitive?.content)
+    }
+
     // ==================== Helper Functions ====================
 
     private fun createExecutedTool(

--- a/ai/src/test/java/me/rerere/ai/ui/MessageTest.kt
+++ b/ai/src/test/java/me/rerere/ai/ui/MessageTest.kt
@@ -124,11 +124,24 @@ class MessageTest {
     // ==================== isValidToUpload Tests ====================
 
     @Test
-    fun `isValidToUpload should be false for reasoning with empty text`() {
+    fun `isValidToUpload should be true for non-empty reasoning with empty text`() {
         val message = UIMessage(
             role = MessageRole.ASSISTANT,
             parts = listOf(
                 UIMessagePart.Reasoning(reasoning = "thinking"),
+                UIMessagePart.Text("")
+            )
+        )
+
+        assertTrue(message.isValidToUpload())
+    }
+
+    @Test
+    fun `isValidToUpload should be false for blank reasoning with empty text`() {
+        val message = UIMessage(
+            role = MessageRole.ASSISTANT,
+            parts = listOf(
+                UIMessagePart.Reasoning(reasoning = "   "),
                 UIMessagePart.Text("")
             )
         )


### PR DESCRIPTION
修复了在“停止上一条回复后继续发送”场景下，可能向模型上传空 assistant message 导致请求报错的问题（`Invalid request: ... role 'assistant' must not be empty`）。

原因
在部分中断/转换链路下，assistant 消息可能变成 `Reasoning + Text("")`。  
之前 `UIMessage.isValidToUpload()` 只排除了 `Reasoning`，导致空文本 assistant 仍被当作有效消息上传。

调整
- 调整 `UIMessage.isValidToUpload()` 判定逻辑：
  - `Text` 需要 `isNotBlank()`
  - `Image/Video/Audio/Document` 需要 `url.isNotBlank()`
  - `Reasoning` 不计入可上传内容
- 其他类型（如 `Tool`）保持可上传，避免影响工具调用流程

- `ai/src/main/java/me/rerere/ai/ui/Message.kt`
- `ai/src/test/java/me/rerere/ai/ui/MessageTest.kt`
- `ai/src/test/java/me/rerere/ai/provider/providers/openai/ChatCompletionsAPIMessageTest.kt`


Fixes #807
