### PR TITLE
fix(ai): 火山 🌋 volc Response API 移除 reasoning.summary（Issue #713）

### DIFF
--- a/ai/src/main/java/me/rerere/ai/provider/providers/openai/ResponseAPI.kt
+++ b/ai/src/main/java/me/rerere/ai/provider/providers/openai/ResponseAPI.kt
@@ -174,7 +174,7 @@ class ResponseAPI(private val client: OkHttpClient) : OpenAIImpl {
         }
     }
 
-    private fun buildRequestBody(
+    internal fun buildRequestBody(
         providerSetting: ProviderSetting.OpenAI,
         messages: List<UIMessage>,
         params: TextGenerationParams,
@@ -243,7 +243,7 @@ class ResponseAPI(private val client: OkHttpClient) : OpenAIImpl {
         }.mergeCustomBody(params.customBody)
     }
 
-    private fun buildMessages(messages: List<UIMessage>) = buildJsonArray {
+    internal fun buildMessages(messages: List<UIMessage>) = buildJsonArray {
         messages
             .filter { it.isValidToUpload() && it.role != MessageRole.SYSTEM }
             .forEach { message ->

--- a/ai/src/test/java/me/rerere/ai/provider/providers/openai/ResponseAPIMessageTest.kt
+++ b/ai/src/test/java/me/rerere/ai/provider/providers/openai/ResponseAPIMessageTest.kt
@@ -37,14 +37,9 @@ class ResponseAPIMessageTest {
         api = ResponseAPI(OkHttpClient())
     }
 
-    // Helper to invoke private buildMessages method via reflection
+    // Helper to invoke buildMessages method
     private fun invokeBuildMessages(messages: List<UIMessage>): JsonArray {
-        val method = ResponseAPI::class.java.getDeclaredMethod(
-            "buildMessages",
-            List::class.java
-        )
-        method.isAccessible = true
-        return method.invoke(api, messages) as JsonArray
+        return api.buildMessages(messages)
     }
 
     private fun invokeBuildRequestBody(
@@ -52,15 +47,7 @@ class ResponseAPIMessageTest {
         params: TextGenerationParams,
         stream: Boolean = false
     ): JsonObject {
-        val method = ResponseAPI::class.java.getDeclaredMethod(
-            "buildRequestBody",
-            ProviderSetting.OpenAI::class.java,
-            List::class.java,
-            TextGenerationParams::class.java,
-            Boolean::class.javaPrimitiveType
-        )
-        method.isAccessible = true
-        return method.invoke(api, providerSetting, listOf(UIMessage.user("hello")), params, stream) as JsonObject
+        return api.buildRequestBody(providerSetting, listOf(UIMessage.user("hello")), params, stream)
     }
 
     private fun createReasoningParams(thinkingBudget: Int? = null): TextGenerationParams {


### PR DESCRIPTION
### 问题
- Issue: https://github.com/rikkahub/rikkahub/issues/713
- 根因：火山引擎 `ark.cn-beijing.volces.com` 的 Response API 不支持 `reasoning.summary` 字段；当前实现默认发送该字段，导致兼容性问题。

### 本 PR 改动（Issue #713）
- 新增内部能力抽象：`ResponseProviderCapabilities`。
  - 文件：`ai/src/main/java/me/rerere/ai/provider/providers/openai/ResponseProviderCapabilities.kt`
  - 默认 `supportsReasoningSummary = true`
  - 当前仅对 `ark.cn-beijing.volces.com` 返回 `false`
- 接入 `ResponseAPI` 请求构建流程。
  - 文件：`ai/src/main/java/me/rerere/ai/provider/providers/openai/ResponseAPI.kt`
  - `buildRequestBody(...)` 新增 `providerSetting` 参数并基于 host 解析能力。
  - 仅在 `supportsReasoningSummary == true` 时写入 `reasoning.summary = "auto"`。
  - 非火山默认行为保持不变。
- 增加单测覆盖。
  - 文件：`ai/src/test/java/me/rerere/ai/provider/providers/openai/ResponseAPIMessageTest.kt`
  - 场景：
    - 火山 host 不包含 `reasoning.summary`
    - OpenAI host 包含 `reasoning.summary == "auto"`
    - 火山在非 AUTO 下仍保留 `reasoning.effort`

### 范围
- 对外 API：无变更。
- 内部实现：
  - 私有方法签名变更：`ResponseAPI.buildRequestBody(...)` 新增 `providerSetting` 参数。

### 测试
- 已通过：`./gradlew :ai:testDebugUnitTest --tests "*ResponseAPIMessageTest*"`
- 已通过：`./gradlew :ai:testDebugUnitTest`

----

### ps:以下内容不属于 Issue #713 变更

#### 全量测试中发现大量失败
- `app:testDebugUnitTest` 失败 7 项：
  - `ShareSheetTest`
    - `decode should restore OpenAI provider correctly`
    - 失败信息：`expected:<1> but was:<0>`
  - `PromptInjectionTransformerTest`（6 项）
    - 失败问题：期望注入内容为 `<system>...</system>` 包裹，实际为裸文本。
    - 失败：
      - `mode injection with TOP_OF_CHAT should insert before first user message`
      - `mode injection with BOTTOM_OF_CHAT should insert before last message`
      - `mode injection with AT_DEPTH should insert at specified depth from end`

- `highlight/search` 示例单测早前缺 `junit` 依赖导致 `ExampleUnitTest` 编译失败。



最后，本 PR 仅应包含 Issue #713 相关 commit：`cc1aaa34`。

