### PR TITLE
fix(richtext): 优化 Markdown 标题渲染并修复 Gemini 思考过程滚动显示

### DIFF
--- a/ai/src/main/java/me/rerere/ai/provider/providers/ClaudeProvider.kt
+++ b/ai/src/main/java/me/rerere/ai/provider/providers/ClaudeProvider.kt
@@ -438,6 +438,7 @@ class ClaudeProvider(private val client: OkHttpClient) : Provider<ProviderSettin
                         val reasoning = UIMessagePart.Reasoning(
                             reasoning = thinking,
                             createdAt = Clock.System.now(),
+                            finishedAt = null
                         )
                         if (signature != null) {
                             reasoning.metadata = buildJsonObject {

--- a/app/src/main/assets/html/mark.html
+++ b/app/src/main/assets/html/mark.html
@@ -32,19 +32,12 @@
         }
 
         /* Typography */
-        h1, h2, h3, h4, h5, h6 {
-            margin-top: 24px;
-            margin-bottom: 16px;
-            font-weight: 600;
-            line-height: 1.25;
-        }
-
-        h1 { font-size: 2em; border-bottom: 1px solid {{OUTLINE_VARIANT_COLOR}}; padding-bottom: 8px; }
-        h2 { font-size: 1.5em; border-bottom: 1px solid {{OUTLINE_VARIANT_COLOR}}; padding-bottom: 8px; }
-        h3 { font-size: 1.25em; }
-        h4 { font-size: 1em; }
-        h5 { font-size: 0.875em; }
-        h6 { font-size: 0.85em; color: {{ON_SURFACE_VARIANT_COLOR}}; }
+        h1 { margin-top: 24px; margin-bottom: 16px; font-weight: 600; line-height: 1.25; font-size: 2em; border-bottom: 1px solid {{OUTLINE_VARIANT_COLOR}}; padding-bottom: 8px; }
+        h2 { margin-top: 20px; margin-bottom: 14px; font-weight: 600; line-height: 1.25; font-size: 1.75em; border-bottom: 1px solid {{OUTLINE_VARIANT_COLOR}}; padding-bottom: 8px; }
+        h3 { margin-top: 18px; margin-bottom: 12px; font-weight: 600; line-height: 1.25; font-size: 1.5em; }
+        h4 { margin-top: 16px; margin-bottom: 10px; font-weight: 600; line-height: 1.25; font-size: 1.25em; }
+        h5 { margin-top: 14px; margin-bottom: 8px; font-weight: 600; line-height: 1.25; font-size: 1.1em; }
+        h6 { margin-top: 12px; margin-bottom: 6px; font-weight: 600; line-height: 1.25; font-size: 1em; color: {{ON_SURFACE_VARIANT_COLOR}}; }
 
         p {
             margin-bottom: 16px;

--- a/app/src/main/java/me/rerere/rikkahub/ui/components/richtext/Markdown.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/richtext/Markdown.kt
@@ -243,27 +243,27 @@ private fun dumpAst(node: ASTNode, text: String, indent: String = "") {
 
 object HeaderStyle {
     val H1 = TextStyle(
-        fontStyle = FontStyle.Normal, fontWeight = FontWeight.Bold, fontSize = 24.sp
+        fontStyle = FontStyle.Normal, fontWeight = FontWeight.Bold, fontSize = 30.sp
     )
 
     val H2 = TextStyle(
-        fontStyle = FontStyle.Normal, fontWeight = FontWeight.Bold, fontSize = 20.sp
+        fontStyle = FontStyle.Normal, fontWeight = FontWeight.Bold, fontSize = 26.sp
     )
 
     val H3 = TextStyle(
-        fontStyle = FontStyle.Normal, fontWeight = FontWeight.Bold, fontSize = 18.sp
+        fontStyle = FontStyle.Normal, fontWeight = FontWeight.Bold, fontSize = 22.sp
     )
 
     val H4 = TextStyle(
-        fontStyle = FontStyle.Normal, fontWeight = FontWeight.Bold, fontSize = 16.sp
+        fontStyle = FontStyle.Normal, fontWeight = FontWeight.Bold, fontSize = 20.sp
     )
 
     val H5 = TextStyle(
-        fontStyle = FontStyle.Normal, fontWeight = FontWeight.Bold, fontSize = 14.sp
+        fontStyle = FontStyle.Normal, fontWeight = FontWeight.Bold, fontSize = 18.sp
     )
 
     val H6 = TextStyle(
-        fontStyle = FontStyle.Normal, fontWeight = FontWeight.Bold, fontSize = 12.sp
+        fontStyle = FontStyle.Normal, fontWeight = FontWeight.Bold, fontSize = 16.sp
     )
 }
 
@@ -303,6 +303,15 @@ private fun MarkdownNode(
                 MarkdownElementTypes.ATX_6 -> HeaderStyle.H6
                 else -> throw IllegalArgumentException("Unknown header type")
             }
+            val headingPadding = when (node.type) {
+                MarkdownElementTypes.ATX_1 -> 16.dp
+                MarkdownElementTypes.ATX_2 -> 14.dp
+                MarkdownElementTypes.ATX_3 -> 12.dp
+                MarkdownElementTypes.ATX_4 -> 10.dp
+                MarkdownElementTypes.ATX_5 -> 8.dp
+                MarkdownElementTypes.ATX_6 -> 6.dp
+                else -> 8.dp
+            }
             ProvideTextStyle(value = style) {
                 FlowRow(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
                     node.children.fastForEach { node ->
@@ -311,7 +320,7 @@ private fun MarkdownNode(
                                 node = node,
                                 content = content,
                                 onClickCitation = onClickCitation,
-                                modifier = modifier.padding(vertical = 16.dp),
+                                modifier = modifier.padding(vertical = headingPadding),
                                 trim = true,
                             )
                         }


### PR DESCRIPTION
本次提交修复了以下问题：
1. 修复 v1/messages 下 Gemini thinking 的滚动显示异常（优化自动滚动触发时机，改用检测内容高度变化触发）。
2. 优化 Markdown 标题渲染的换行间距及字体大小层级，解决 H6 字号过小的问题。
3. 修复 ClaudeProvider 中 ReasoningPart 的 finishedAt 状态缺失导致的加载状态异常。