### PR TITLE
fix(setting): 修复切换服务商类型时的数据重置问题 (fix #580)

### DIFF
--- a/app/src/test/java/me/rerere/rikkahub/ui/pages/setting/components/ProviderConfigureConvertToTest.kt
+++ b/app/src/test/java/me/rerere/rikkahub/ui/pages/setting/components/ProviderConfigureConvertToTest.kt
@@ -1,0 +1,111 @@
+package me.rerere.rikkahub.ui.pages.setting.components
+
+import me.rerere.ai.provider.BalanceOption
+import me.rerere.ai.provider.Model
+import me.rerere.ai.provider.ProviderSetting
+import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import kotlin.uuid.Uuid
+
+class ProviderConfigureConvertToTest {
+    @Test
+    fun `convertTo should keep common fields and switch official endpoint to target default`() {
+        val model = Model(
+            id = Uuid.random(),
+            modelId = "gpt-custom",
+            displayName = "GPT Custom"
+        )
+        val balanceOption = BalanceOption(
+            enabled = true,
+            apiPath = "/custom/credits",
+            resultPath = "data.balance"
+        )
+        val original = ProviderSetting.OpenAI(
+            id = Uuid.random(),
+            enabled = false,
+            name = "My Provider",
+            models = listOf(model),
+            balanceOption = balanceOption,
+            apiKey = "sk-test",
+            baseUrl = "https://api.openai.com/v1"
+        )
+
+        val converted = original.convertTo(ProviderSetting.Google::class)
+        assertTrue(converted is ProviderSetting.Google)
+        val google = converted as ProviderSetting.Google
+
+        assertEquals(original.id, google.id)
+        assertEquals(original.enabled, google.enabled)
+        assertEquals(original.name, google.name)
+        assertEquals(original.models, google.models)
+        assertEquals(original.balanceOption, google.balanceOption)
+        assertEquals(original.apiKey, google.apiKey)
+        assertEquals("https://generativelanguage.googleapis.com/v1beta", google.baseUrl)
+    }
+
+    @Test
+    fun `convertTo should preserve third-party host and replace version suffix`() {
+        val original = ProviderSetting.OpenAI(
+            name = "Proxy OpenAI",
+            apiKey = "proxy-key",
+            baseUrl = "https://gateway.example.com/api/v1"
+        )
+
+        val converted = original.convertTo(ProviderSetting.Google::class) as ProviderSetting.Google
+        assertEquals("https://gateway.example.com/api/v1beta", converted.baseUrl)
+        assertEquals("gateway.example.com", converted.baseUrl.toHttpUrlOrNull()?.host)
+    }
+
+    @Test
+    fun `convertTo should preserve third-party host and append target path when needed`() {
+        val original = ProviderSetting.Google(
+            name = "Proxy Google",
+            apiKey = "proxy-google-key",
+            baseUrl = "https://proxy.example.com/vendor/gemini"
+        )
+
+        val converted = original.convertTo(ProviderSetting.OpenAI::class) as ProviderSetting.OpenAI
+        assertEquals("https://proxy.example.com/vendor/gemini/v1", converted.baseUrl)
+        assertEquals("proxy.example.com", converted.baseUrl.toHttpUrlOrNull()?.host)
+    }
+
+    @Test
+    fun `convertTo should preserve third-party host when switching to claude`() {
+        val original = ProviderSetting.OpenAI(
+            name = "Proxy OpenAI",
+            apiKey = "proxy-key",
+            baseUrl = "https://gateway.example.com/proxy/v1beta"
+        )
+
+        val converted = original.convertTo(ProviderSetting.Claude::class) as ProviderSetting.Claude
+        assertEquals("https://gateway.example.com/proxy/v1", converted.baseUrl)
+        assertEquals("gateway.example.com", converted.baseUrl.toHttpUrlOrNull()?.host)
+    }
+
+    @Test
+    fun `convertTo should return same instance for same type`() {
+        val original = ProviderSetting.OpenAI(
+            name = "Same Type",
+            apiKey = "same-key",
+            baseUrl = "https://api.openai.com/v1"
+        )
+
+        val converted = original.convertTo(ProviderSetting.OpenAI::class)
+        assertSame(original, converted)
+    }
+
+    @Test
+    fun `convertTo should keep original base url when source url is invalid`() {
+        val original = ProviderSetting.Claude(
+            name = "Invalid URL Provider",
+            apiKey = "invalid-key",
+            baseUrl = "not-a-url"
+        )
+
+        val converted = original.convertTo(ProviderSetting.OpenAI::class) as ProviderSetting.OpenAI
+        assertEquals("not-a-url", converted.baseUrl)
+    }
+}


### PR DESCRIPTION
修复了设置中切换服务商（Provider）类型时，端点（Endpoint）及相关数据被静默重置的问题。修复后，编辑现有服务商并重新打开时，数据将保持一致。

## 原因
在切换类型时，目标服务商仅使用部分字段进行重建，导致端点相关数值丢失，造成界面显示保存成功但持久化状态不一致的问题。

## 变更内容
- 增加“同类型”快速路径，避免不必要的重建。
- 显式保留通用字段（UID 等）及 UI 描述符（图标、标签等）。
- 端点转换策略：
  - 官方：自动切换为目标服务商的默认 Base URL。
  - 第三方：保留协议/主机/端口，并自动适配路径（如 `/v1` <-> `/v1/messages`）。
  - 异常：若 URL 无法解析，则保留原始值。
- 测试：新增测试覆盖了官方/第三方切换、路径追加、OpenAI 与 Claude 适配以及无效 URL 处理等场景。

Closes #580