### PR TITLE
fix(thinking): convert <think> tags to native reasoning parts

### DIFF
--- a/app/src/main/java/me/rerere/rikkahub/data/ai/transformers/ThinkTagTransformer.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/ai/transformers/ThinkTagTransformer.kt
@@ -1,11 +1,14 @@
 package me.rerere.rikkahub.data.ai.transformers
 
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toInstant
 import me.rerere.ai.core.MessageRole
 import me.rerere.ai.ui.UIMessage
 import me.rerere.ai.ui.UIMessagePart
 import kotlin.time.Clock
 
 private val THINKING_REGEX = Regex("<think>([\\s\\S]*?)(?:</think>|$)", RegexOption.DOT_MATCHES_ALL)
+private val CLOSING_TAG_REGEX = Regex("</think>")
 
 // 部分供应商不会返回reasoning parts, 所以需要这个transformer
 object ThinkTagTransformer : OutputMessageTransformer {
@@ -17,18 +20,50 @@ object ThinkTagTransformer : OutputMessageTransformer {
             if (message.role == MessageRole.ASSISTANT && message.hasPart<UIMessagePart.Text>()) {
                 message.copy(
                     parts = message.parts.flatMap { part ->
-                        if (part is UIMessagePart.Text && part.text.startsWith("<think>")) {
-                            // 提取 <think> 中的内容，并替换为空字串
+                        if (part is UIMessagePart.Text && THINKING_REGEX.containsMatchIn(part.text)) {
                             val stripped = part.text.replace(THINKING_REGEX, "")
                             val reasoning =
                                 THINKING_REGEX.find(part.text)?.groupValues?.getOrNull(1)?.trim()
                                     ?: ""
-                            val now = Clock.System.now()
+                            val hasClosingTag = CLOSING_TAG_REGEX.containsMatchIn(part.text)
                             listOf(
                                 UIMessagePart.Reasoning(
                                     reasoning = reasoning,
-                                    finishedAt = now, // 这是visual的, 没有思考时间, finishedAt = createdAt
-                                    createdAt = now,
+                                    createdAt = message.createdAt.toInstant(timeZone = TimeZone.currentSystemDefault()),
+                                    finishedAt = if (hasClosingTag) Clock.System.now() else null,
+                                ),
+                                part.copy(text = stripped),
+                            )
+                        } else {
+                            listOf(part)
+                        }
+                    }
+                )
+            } else {
+                message
+            }
+        }
+    }
+
+    override suspend fun onGenerationFinish(
+        ctx: TransformerContext,
+        messages: List<UIMessage>,
+    ): List<UIMessage> {
+        val now = Clock.System.now()
+        return messages.map { message ->
+            if (message.role == MessageRole.ASSISTANT && message.hasPart<UIMessagePart.Text>()) {
+                message.copy(
+                    parts = message.parts.flatMap { part ->
+                        if (part is UIMessagePart.Text && THINKING_REGEX.containsMatchIn(part.text)) {
+                            val stripped = part.text.replace(THINKING_REGEX, "")
+                            val reasoning =
+                                THINKING_REGEX.find(part.text)?.groupValues?.getOrNull(1)?.trim()
+                                    ?: ""
+                            listOf(
+                                UIMessagePart.Reasoning(
+                                    reasoning = reasoning,
+                                    createdAt = message.createdAt.toInstant(timeZone = TimeZone.currentSystemDefault()),
+                                    finishedAt = now,
                                 ),
                                 part.copy(text = stripped),
                             )

--- a/app/src/main/java/me/rerere/rikkahub/ui/components/message/ChatMessageReasoning.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/message/ChatMessageReasoning.kt
@@ -88,7 +88,7 @@ fun ChainOfThoughtScope.ChatMessageReasoningStep(
         }
     }
 
-    var duration by remember(reasoning.finishedAt, reasoning.createdAt) {
+    var duration by remember(reasoning.finishedAt != null, reasoning.createdAt) {
         mutableStateOf(
             value = reasoning.finishedAt?.let { endTime ->
                 endTime - reasoning.createdAt

--- a/app/src/main/java/me/rerere/rikkahub/ui/components/richtext/Markdown.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/richtext/Markdown.kt
@@ -134,11 +134,6 @@ private fun preProcess(content: String): String {
         }
     }
 
-    // 替换思考
-    result = result.replace(THINKING_REGEX) { matchResult ->
-        matchResult.groupValues[1].lines().filter { it.isNotBlank() }.joinToString("\n") { ">$it" }
-    }
-
     return result
 }
 


### PR DESCRIPTION
## Summary

- `ThinkTagTransformer` now implements `onGenerationFinish` to persist `<think>` tag content as `UIMessagePart.Reasoning` in the database (previously only applied during streaming visual transform)
- Use `message.createdAt` as reasoning start time instead of the transform moment, and detect `</think>` closing tag to correctly set `finishedAt` during streaming
- Fix thinking duration timer continuing to run after `</think>` by keying `remember` on `finishedAt != null` (boolean) instead of the `Instant` value itself — each streaming chunk was creating a new `Clock.System.now()` timestamp causing the `remember` key to change on every chunk
- Remove `<think>` → blockquote fallback from `Markdown.kt` `preProcess()` since the transformer now handles it properly

Closes #832

## Test plan

- [ ] Send a message to a model that returns `<think>` tags
- [ ] Verify thinking content is displayed as a collapsible reasoning card (not a blockquote)
- [ ] Verify thinking duration shows a reasonable elapsed time and stops when `</think>` is reached
- [ ] Reload the conversation and verify the reasoning card still appears correctly