### PR TITLE
feat(ui): 侧栏对话列表自动滚动至当前选中项附近 - 在 ConversationList 中增加 LaunchedEffect 监听当前对话 ID 变化 - 切换对话后自动调用 listState.scrollToItem 确保选中项可见 - 使用 peek() 在不触发 Paging 额外加载的情况下定位索引

### DIFF
--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ConversationList.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ConversationList.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.DropdownMenu
@@ -96,6 +97,27 @@ fun ColumnScope.ConversationList(
     onMoveToAssistant: (Conversation) -> Unit = {}
 ) {
     val navController = LocalNavController.current
+    val listState = rememberLazyListState()
+
+    // 当选中项 ID 改变时，触发滚动
+    LaunchedEffect(current.id, conversations.itemCount) {
+        if (conversations.itemCount > 0) {
+            // 在当前已加载的快照中寻找对应对话的索引
+            val index = (0 until conversations.itemCount).find { i ->
+                val item = conversations.peek(i) // 使用 peek 不会触发 Paging 的预加载
+                item is ConversationListItem.Item && item.conversation.id == current.id
+            }
+
+            if (index != null) {
+                val isVisible = listState.layoutInfo.visibleItemsInfo.any { it.index == index }
+
+                if (!isVisible) {
+                    // 滚动到该位置
+                    listState.scrollToItem(index = index, scrollOffset = -100)
+                }
+            }
+        }
+    }
 
     // fix: compose很奇怪，会自动聚焦到第一个文本框
     // 在这里放一个空的Box，防止自动聚焦到第一个文本框弹出IME
@@ -150,6 +172,7 @@ fun ColumnScope.ConversationList(
     }
 
     LazyColumn(
+        state = listState,
         modifier = modifier,
         verticalArrangement = Arrangement.spacedBy(8.dp),
     ) {


### PR DESCRIPTION
优化了侧栏对话列表的交互体验。此前，在切换对话或导航导致页面重建时，侧栏列表会丢失滚动位置。
先前尝试直接记忆侧栏滚动位置，发现 ViewModel 会在切换对话后会重新创建，需要重构的东西可能有点多，遂改为现在的实现方案。