### PR TITLE
feat: rikkarouter 原型（功能请求参考）

### DIFF
--- a/app/src/main/java/me/rerere/rikkahub/RouteActivity.kt
+++ b/app/src/main/java/me/rerere/rikkahub/RouteActivity.kt
@@ -85,6 +85,7 @@ import me.rerere.rikkahub.ui.pages.setting.SettingModelPage
 import me.rerere.rikkahub.ui.pages.setting.SettingPage
 import me.rerere.rikkahub.ui.pages.setting.SettingProviderDetailPage
 import me.rerere.rikkahub.ui.pages.setting.SettingProviderPage
+import me.rerere.rikkahub.ui.pages.setting.SettingRikkaRouterPage
 import me.rerere.rikkahub.ui.pages.setting.SettingSearchPage
 import me.rerere.rikkahub.ui.pages.setting.SettingTTSPage
 import me.rerere.rikkahub.ui.pages.setting.SettingWebPage
@@ -324,6 +325,10 @@ class RouteActivity : ComponentActivity() {
                                 SettingProviderPage()
                             }
 
+                            entry<Screen.SettingRikkaRouter> {
+                                SettingRikkaRouterPage()
+                            }
+
                             entry<Screen.SettingProviderDetail> { key ->
                                 val id = Uuid.parse(key.providerId)
                                 SettingProviderDetailPage(id = id)
@@ -459,6 +464,9 @@ sealed interface Screen : NavKey {
 
     @Serializable
     data object SettingProvider : Screen
+
+    @Serializable
+    data object SettingRikkaRouter : Screen
 
     @Serializable
     data class SettingProviderDetail(val providerId: String) : Screen

--- a/app/src/main/java/me/rerere/rikkahub/data/ai/ConversationProviderKeyStore.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/ai/ConversationProviderKeyStore.kt
@@ -1,0 +1,73 @@
+package me.rerere.rikkahub.data.ai
+
+import android.content.Context
+import java.security.MessageDigest
+import kotlin.uuid.Uuid
+
+class ConversationProviderKeyStore(context: Context) {
+    private val preferences = context.getSharedPreferences("conversation_provider_key_store", Context.MODE_PRIVATE)
+
+    fun resolvePinnedKey(conversationId: Uuid, providerId: Uuid, rawKeys: String): String {
+        val keyList = splitKeys(rawKeys)
+        if (keyList.isEmpty()) return rawKeys
+        if (keyList.size == 1) return keyList.first()
+
+        val hash = hashKeys(keyList)
+        val conversationKey = buildConversationKey(conversationId = conversationId, providerId = providerId, hash = hash)
+        val globalKey = buildGlobalKey(providerId = providerId, hash = hash)
+
+        val assignedIndex = if (preferences.contains(conversationKey)) {
+            Math.floorMod(preferences.getInt(conversationKey, 0), keyList.size)
+        } else {
+            val index = Math.floorMod(preferences.getInt(globalKey, 0), keyList.size)
+            preferences.edit()
+                .putInt(conversationKey, index)
+                .putInt(globalKey, (index + 1) % keyList.size)
+                .apply()
+            index
+        }
+        return keyList[assignedIndex]
+    }
+
+    fun advancePinnedKey(conversationId: Uuid, providerId: Uuid, rawKeys: String): String? {
+        val keyList = splitKeys(rawKeys)
+        if (keyList.size <= 1) return null
+
+        val hash = hashKeys(keyList)
+        val conversationKey = buildConversationKey(conversationId = conversationId, providerId = providerId, hash = hash)
+        val current = if (preferences.contains(conversationKey)) {
+            Math.floorMod(preferences.getInt(conversationKey, 0), keyList.size)
+        } else {
+            Math.floorMod(preferences.getInt(buildGlobalKey(providerId, hash), 0), keyList.size)
+        }
+        val next = (current + 1) % keyList.size
+        preferences.edit().putInt(conversationKey, next).apply()
+        return keyList[next]
+    }
+
+    private fun buildConversationKey(conversationId: Uuid, providerId: Uuid, hash: String): String {
+        return "c:$conversationId:$providerId:$hash"
+    }
+
+    private fun buildGlobalKey(providerId: Uuid, hash: String): String {
+        return "g:$providerId:$hash"
+    }
+
+    private fun hashKeys(keys: List<String>): String {
+        return MessageDigest.getInstance("SHA-256")
+            .digest(keys.joinToString("\n").toByteArray(Charsets.UTF_8))
+            .joinToString("") { "%02x".format(it) }
+    }
+
+    private fun splitKeys(keys: String): List<String> {
+        return keys
+            .split(KEY_SPLIT_REGEX)
+            .map { it.trim() }
+            .filter { it.isNotBlank() }
+            .distinct()
+    }
+
+    private companion object {
+        val KEY_SPLIT_REGEX = Regex("[\\s,]+")
+    }
+}

--- a/app/src/main/java/me/rerere/rikkahub/data/ai/GenerationHandler.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/ai/GenerationHandler.kt
@@ -67,6 +67,7 @@ class GenerationHandler(
     fun generateText(
         settings: Settings,
         model: Model,
+        providerOverride: ProviderSetting? = null,
         messages: List<UIMessage>,
         inputTransformers: List<InputMessageTransformer> = emptyList(),
         outputTransformers: List<OutputMessageTransformer> = emptyList(),
@@ -76,7 +77,7 @@ class GenerationHandler(
         truncateIndex: Int = -1,
         maxSteps: Int = 256,
     ): Flow<GenerationChunk> = flow {
-        val provider = model.findProvider(settings.providers) ?: error("Provider not found")
+        val provider = providerOverride ?: (model.findProvider(settings.providers) ?: error("Provider not found"))
         val providerImpl = providerManager.getProviderByType(provider)
 
         var messages: List<UIMessage> = messages

--- a/app/src/main/java/me/rerere/rikkahub/data/datastore/PreferencesStore.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/datastore/PreferencesStore.kt
@@ -31,9 +31,10 @@ import me.rerere.rikkahub.data.datastore.migration.PreferenceStoreV1Migration
 import me.rerere.rikkahub.data.model.Assistant
 import me.rerere.rikkahub.data.model.Avatar
 import me.rerere.rikkahub.data.model.InjectionPosition
-import me.rerere.rikkahub.data.model.PromptInjection
-import me.rerere.rikkahub.data.model.Tag
 import me.rerere.rikkahub.data.model.Lorebook
+import me.rerere.rikkahub.data.model.PromptInjection
+import me.rerere.rikkahub.data.model.RikkaRouterConfig
+import me.rerere.rikkahub.data.model.Tag
 import me.rerere.rikkahub.data.sync.s3.S3Config
 import me.rerere.rikkahub.ui.theme.PresetThemes
 import me.rerere.rikkahub.utils.JsonInstant
@@ -88,6 +89,7 @@ class SettingsStore(
 
         // 提供商
         val PROVIDERS = stringPreferencesKey("providers")
+        val RIKKA_ROUTER = stringPreferencesKey("rikka_router")
 
         // 助手
         val SELECT_ASSISTANT = stringPreferencesKey("select_assistant")
@@ -163,6 +165,9 @@ class SettingsStore(
                     JsonInstant.decodeFromString(it)
                 } ?: emptyList(),
                 providers = JsonInstant.decodeFromString(preferences[PROVIDERS] ?: "[]"),
+                rikkaRouter = preferences[RIKKA_ROUTER]?.let {
+                    JsonInstant.decodeFromString(it)
+                } ?: RikkaRouterConfig(),
                 assistants = JsonInstant.decodeFromString(preferences[ASSISTANTS] ?: "[]"),
                 dynamicColor = preferences[DYNAMIC_COLOR] != false,
                 themeId = preferences[THEME_ID] ?: PresetThemes[0].id,
@@ -233,10 +238,20 @@ class SettingsStore(
                     ttsProviders.add(defaultTTSProvider.copyProvider())
                 }
             }
+            val migratedSearchServices = it.searchServices.map { service ->
+                when (service) {
+                    is SearchServiceOptions.RikkaLocalOptions -> SearchServiceOptions.BingLocalOptions()
+                    else -> service
+                }
+            }.ifEmpty { listOf(SearchServiceOptions.DEFAULT) }
+            val migratedSearchServiceSelected =
+                it.searchServiceSelected.coerceIn(0, migratedSearchServices.size - 1)
             it.copy(
                 providers = providers,
                 assistants = assistants,
-                ttsProviders = ttsProviders
+                ttsProviders = ttsProviders,
+                searchServices = migratedSearchServices,
+                searchServiceSelected = migratedSearchServiceSelected,
             )
         }
         .map { settings ->
@@ -276,6 +291,15 @@ class SettingsStore(
                         }.toSet()
                     )
                 },
+                rikkaRouter = settings.rikkaRouter.copy(
+                    groups = settings.rikkaRouter.groups
+                        .distinctBy { it.id }
+                        .map { group ->
+                            group.copy(
+                                members = group.members.distinctBy { it.modelId }
+                            )
+                        }
+                ),
                 ttsProviders = settings.ttsProviders.distinctBy { it.id },
                 favoriteModels = settings.favoriteModels.filter { uuid ->
                     settings.providers.flatMap { it.models }.any { it.id == uuid }
@@ -320,6 +344,7 @@ class SettingsStore(
             preferences[COMPRESS_PROMPT] = settings.compressPrompt
 
             preferences[PROVIDERS] = JsonInstant.encodeToString(settings.providers)
+            preferences[RIKKA_ROUTER] = JsonInstant.encodeToString(settings.rikkaRouter)
 
             preferences[ASSISTANTS] = JsonInstant.encodeToString(settings.assistants)
             preferences[SELECT_ASSISTANT] = settings.assistantId.toString()
@@ -444,6 +469,7 @@ data class Settings(
     val compressPrompt: String = DEFAULT_COMPRESS_PROMPT,
     val assistantId: Uuid = DEFAULT_ASSISTANT_ID,
     val providers: List<ProviderSetting> = DEFAULT_PROVIDERS,
+    val rikkaRouter: RikkaRouterConfig = RikkaRouterConfig(),
     val assistants: List<Assistant> = DEFAULT_ASSISTANTS,
     val assistantTags: List<Tag> = emptyList(),
     val searchServices: List<SearchServiceOptions> = listOf(SearchServiceOptions.DEFAULT),
@@ -527,6 +553,7 @@ fun Settings.isNotConfigured() = providers.all { it.models.isEmpty() }
 
 fun Settings.findModelById(uuid: Uuid): Model? {
     return this.providers.findModelById(uuid)
+        ?: this.getRikkaRouterModels(includeDisabledGroups = true).firstOrNull { it.id == uuid }
 }
 
 fun List<ProviderSetting>.findModelById(uuid: Uuid): Model? {

--- a/app/src/main/java/me/rerere/rikkahub/data/datastore/RikkaRouterResolver.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/datastore/RikkaRouterResolver.kt
@@ -1,0 +1,119 @@
+package me.rerere.rikkahub.data.datastore
+
+import me.rerere.ai.provider.Modality
+import me.rerere.ai.provider.Model
+import me.rerere.ai.provider.ModelType
+import me.rerere.ai.provider.ProviderSetting
+import me.rerere.rikkahub.data.model.RikkaRouterGroup
+import kotlin.uuid.Uuid
+
+val RIKKA_ROUTER_PROVIDER_ID: Uuid = Uuid.parse("5f8ce857-8157-46ac-b8e7-d70f2107a7f8")
+const val RIKKA_ROUTER_PROVIDER_NAME = "rikkarouter"
+
+data class RikkaRouterCandidate(
+    val provider: ProviderSetting,
+    val model: Model,
+)
+
+fun Settings.getRikkaRouterModels(includeDisabledGroups: Boolean = true): List<Model> {
+    val groups = if (includeDisabledGroups) {
+        rikkaRouter.groups
+    } else {
+        rikkaRouter.groups.filter { it.enabled }
+    }
+    return groups.map { group ->
+        val candidates = resolveRikkaRouterCandidates(group)
+        val abilities = candidates.flatMap { it.model.abilities }.distinct()
+        val inputModalities = candidates.flatMap { it.model.inputModalities }.distinct().ifEmpty { listOf(Modality.TEXT) }
+        val outputModalities = candidates.flatMap { it.model.outputModalities }.distinct().ifEmpty { listOf(Modality.TEXT) }
+        Model(
+            id = group.id,
+            modelId = "rikkarouter/${group.name.ifBlank { group.id.toString() }}",
+            displayName = group.name.ifBlank { "rikkarouter" },
+            type = ModelType.CHAT,
+            abilities = abilities,
+            inputModalities = inputModalities,
+            outputModalities = outputModalities,
+        )
+    }
+}
+
+fun Settings.findRikkaRouterGroupByModelId(modelId: Uuid): RikkaRouterGroup? {
+    return rikkaRouter.groups.firstOrNull { it.id == modelId }
+}
+
+fun Settings.resolveRikkaRouterCandidatesByModelId(modelId: Uuid): List<RikkaRouterCandidate> {
+    val group = findRikkaRouterGroupByModelId(modelId) ?: return emptyList()
+    return resolveRikkaRouterCandidates(group)
+}
+
+fun Settings.resolveRikkaRouterCandidates(group: RikkaRouterGroup): List<RikkaRouterCandidate> {
+    if (!rikkaRouter.enabled || !group.enabled) return emptyList()
+
+    val modelProviderMap = buildMap<Uuid, Pair<ProviderSetting, Model>> {
+        providers.forEach { provider ->
+            provider.models.forEach { model ->
+                put(model.id, provider to model)
+            }
+        }
+    }
+
+    val orderedMembers = group.members
+        .filter { it.enabled }
+        .sortedWith(
+            compareBy(
+                { it.modelId != group.primaryModelId },
+                { it.order }
+            )
+        )
+
+    return orderedMembers
+        .mapNotNull { member ->
+            val pair = modelProviderMap[member.modelId] ?: return@mapNotNull null
+            val provider = pair.first
+            val model = pair.second
+            if (!provider.enabled || model.type != ModelType.CHAT) return@mapNotNull null
+            RikkaRouterCandidate(provider = provider, model = model)
+        }
+        .distinctBy { "${it.provider.id}:${it.model.id}" }
+}
+
+fun Settings.findRikkaRouterMatches(groupName: String): List<Pair<ProviderSetting, Model>> {
+    val target = normalizeModelKey(groupName)
+    if (target.isBlank()) return emptyList()
+    return buildList {
+        providers.forEach { provider ->
+            provider.models
+                .asSequence()
+                .filter { it.type == ModelType.CHAT }
+                .filter { model ->
+                    val display = normalizeModelKey(model.displayName)
+                    val modelId = normalizeModelKey(model.modelId)
+                    (display.isNotBlank() && (display.contains(target) || target.contains(display))) ||
+                        modelId.contains(target) || target.contains(modelId)
+                }
+                .forEach { model -> add(provider to model) }
+        }
+    }.distinctBy { (provider, model) -> "${provider.id}:${model.id}" }
+}
+
+fun Settings.buildRikkaRouterVirtualProvider(includeDisabledGroups: Boolean = false): ProviderSetting.OpenAI {
+    return ProviderSetting.OpenAI(
+        id = RIKKA_ROUTER_PROVIDER_ID,
+        enabled = rikkaRouter.enabled,
+        name = RIKKA_ROUTER_PROVIDER_NAME,
+        models = getRikkaRouterModels(includeDisabledGroups = includeDisabledGroups),
+        apiKey = "",
+        baseUrl = "",
+        builtIn = true,
+        description = {},
+        shortDescription = {},
+    )
+}
+
+private fun normalizeModelKey(text: String): String {
+    return text
+        .trim()
+        .lowercase()
+        .replace(Regex("[^a-z0-9]+"), "")
+}

--- a/app/src/main/java/me/rerere/rikkahub/data/model/RikkaRouter.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/model/RikkaRouter.kt
@@ -1,0 +1,26 @@
+package me.rerere.rikkahub.data.model
+
+import kotlinx.serialization.Serializable
+import kotlin.uuid.Uuid
+
+@Serializable
+data class RikkaRouterConfig(
+    val enabled: Boolean = true,
+    val groups: List<RikkaRouterGroup> = emptyList(),
+)
+
+@Serializable
+data class RikkaRouterGroup(
+    val id: Uuid = Uuid.random(),
+    val name: String = "",
+    val enabled: Boolean = true,
+    val primaryModelId: Uuid? = null,
+    val members: List<RikkaRouterMember> = emptyList(),
+)
+
+@Serializable
+data class RikkaRouterMember(
+    val modelId: Uuid,
+    val enabled: Boolean = true,
+    val order: Int = 0,
+)

--- a/app/src/main/java/me/rerere/rikkahub/di/AppModule.kt
+++ b/app/src/main/java/me/rerere/rikkahub/di/AppModule.kt
@@ -8,6 +8,7 @@ import kotlinx.serialization.json.Json
 import me.rerere.highlight.Highlighter
 import me.rerere.rikkahub.AppScope
 import me.rerere.rikkahub.data.ai.AILoggingManager
+import me.rerere.rikkahub.data.ai.ConversationProviderKeyStore
 import me.rerere.rikkahub.data.ai.tools.LocalTools
 import me.rerere.rikkahub.service.ChatService
 import me.rerere.rikkahub.utils.EmojiData
@@ -62,6 +63,10 @@ val appModule = module {
     }
 
     single {
+        ConversationProviderKeyStore(get())
+    }
+
+    single {
         ChatService(
             context = get(),
             appScope = get(),
@@ -71,6 +76,7 @@ val appModule = module {
             generationHandler = get(),
             templateTransformer = get(),
             providerManager = get(),
+            conversationProviderKeyStore = get(),
             localTools = get(),
             mcpManager = get(),
             filesManager = get()

--- a/app/src/main/java/me/rerere/rikkahub/service/ChatService.kt
+++ b/app/src/main/java/me/rerere/rikkahub/service/ChatService.kt
@@ -28,14 +28,15 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.onCompletion
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.serialization.json.jsonObject
 import me.rerere.ai.core.MessageRole
 import me.rerere.ai.core.Tool
+import me.rerere.ai.provider.Model
 import me.rerere.ai.provider.ModelAbility
 import me.rerere.ai.provider.ProviderManager
+import me.rerere.ai.provider.ProviderSetting
 import me.rerere.ai.provider.TextGenerationParams
 import me.rerere.ai.ui.ToolApprovalState
 import me.rerere.ai.ui.UIMessage
@@ -49,6 +50,7 @@ import me.rerere.rikkahub.CHAT_COMPLETED_NOTIFICATION_CHANNEL_ID
 import me.rerere.rikkahub.CHAT_LIVE_UPDATE_NOTIFICATION_CHANNEL_ID
 import me.rerere.rikkahub.R
 import me.rerere.rikkahub.RouteActivity
+import me.rerere.rikkahub.data.ai.ConversationProviderKeyStore
 import me.rerere.rikkahub.data.ai.GenerationChunk
 import me.rerere.rikkahub.data.ai.GenerationHandler
 import me.rerere.rikkahub.data.ai.mcp.McpManager
@@ -67,6 +69,7 @@ import me.rerere.rikkahub.data.datastore.findModelById
 import me.rerere.rikkahub.data.datastore.findProvider
 import me.rerere.rikkahub.data.datastore.getCurrentAssistant
 import me.rerere.rikkahub.data.datastore.getCurrentChatModel
+import me.rerere.rikkahub.data.datastore.resolveRikkaRouterCandidatesByModelId
 import me.rerere.rikkahub.data.files.FilesManager
 import me.rerere.rikkahub.data.model.Conversation
 import me.rerere.rikkahub.data.model.AssistantAffectScope
@@ -85,6 +88,8 @@ import java.util.concurrent.ConcurrentHashMap
 import kotlin.uuid.Uuid
 
 private const val TAG = "ChatService"
+private const val MAX_SAME_PROVIDER_KEY_RETRY = 3
+private val KEY_SPLIT_REGEX = Regex("[\\s,]+")
 
 data class ChatError(
     val id: Uuid = Uuid.random(),
@@ -119,6 +124,7 @@ class ChatService(
     private val generationHandler: GenerationHandler,
     private val templateTransformer: TemplateTransformer,
     private val providerManager: ProviderManager,
+    private val conversationProviderKeyStore: ConversationProviderKeyStore,
     private val localTools: LocalTools,
     val mcpManager: McpManager,
     private val filesManager: FilesManager,
@@ -427,16 +433,13 @@ class ChatService(
         messageRange: ClosedRange<Int>? = null
     ) {
         val settings = settingsStore.settingsFlow.first()
-        val model = settings.getCurrentChatModel() ?: return
+        val selectedModel = settings.getCurrentChatModel() ?: return
 
-        runCatching {
-            val conversation = getConversationFlow(conversationId).value
+        try {
+            val currentConversation = getConversationFlow(conversationId).value
+            updateConversation(conversationId, currentConversation.copy(chatSuggestions = emptyList()))
 
-            // reset suggestions
-            updateConversation(conversationId, conversation.copy(chatSuggestions = emptyList()))
-
-            // memory tool
-            if (!model.abilities.contains(ModelAbility.TOOL)) {
+            if (!selectedModel.abilities.contains(ModelAbility.TOOL)) {
                 if (settings.enableWebSearch || mcpManager.getAllAvailableTools().isNotEmpty()) {
                     addError(
                         IllegalStateException(context.getString(R.string.tools_warning)),
@@ -445,105 +448,283 @@ class ChatService(
                 }
             }
 
-            // check invalid messages
             checkInvalidMessages(conversationId)
+            val baseConversation = getConversationFlow(conversationId).value
+            val scopedMessages = baseConversation.currentMessages.let {
+                if (messageRange != null) {
+                    it.subList(messageRange.start, messageRange.endInclusive + 1)
+                } else {
+                    it
+                }
+            }
+            val assistant = settings.getCurrentAssistant()
+            val memories = if (assistant.useGlobalMemory) {
+                memoryRepository.getGlobalMemories()
+            } else {
+                memoryRepository.getMemoriesOfAssistant(settings.assistantId.toString())
+            }
+            val availableMcpTools = mcpManager.getAllAvailableTools()
+            val mcpWrappedTools = availableMcpTools.map { tool ->
+                Tool(
+                    name = "mcp__" + tool.name,
+                    description = tool.description ?: "",
+                    parameters = { tool.inputSchema },
+                    needsApproval = tool.needsApproval,
+                    execute = {
+                        listOf(
+                            UIMessagePart.Text(
+                                mcpManager.callTool(tool.name, it.jsonObject).toString()
+                            )
+                        )
+                    },
+                )
+            }
+            val tools = buildList {
+                if (settings.enableWebSearch) {
+                    addAll(createSearchTools(context, settings))
+                }
+                addAll(
+                    localTools.getTools(
+                        options = settings.getCurrentAssistant().localTools,
+                        sandboxId = conversationId,
+                        workflowStateProvider = {
+                            getConversationFlow(conversationId).value.workflowState
+                        },
+                        onWorkflowStateUpdate = { newWorkflowState ->
+                            val conversation = getConversationFlow(conversationId).value
+                            updateConversation(
+                                conversationId,
+                                conversation.copy(workflowState = newWorkflowState)
+                            )
+                        },
+                        todoStateProvider = {
+                            val conversation = getConversationFlow(conversationId).value
+                            conversation.todoState ?: if (
+                                settings.getCurrentAssistant().localTools.contains(
+                                    me.rerere.rikkahub.data.ai.tools.LocalToolOption.WorkflowTodo
+                                )
+                            ) {
+                                val newTodoState = me.rerere.rikkahub.data.model.TodoState(isEnabled = true)
+                                updateConversation(
+                                    conversationId,
+                                    conversation.copy(todoState = newTodoState)
+                                )
+                                newTodoState
+                            } else {
+                                null
+                            }
+                        },
+                        onTodoStateUpdate = { newTodoState ->
+                            val conversation = getConversationFlow(conversationId).value
+                            updateConversation(
+                                conversationId,
+                                conversation.copy(todoState = newTodoState)
+                            )
+                        },
+                        subAgents = me.rerere.rikkahub.data.model.SubAgentTemplates.All,
+                        settings = settings,
+                        parentModel = selectedModel,
+                        parentWorkflowPhase = baseConversation.workflowState?.phase,
+                        mcpTools = mcpWrappedTools,
+                    )
+                )
+                addAll(mcpWrappedTools)
+            }
 
-            // start generating
+            val targets = resolveGenerationTargets(settings, selectedModel)
+            var finalError: Throwable? = null
+            var completed = false
+
+            for ((targetIndex, target) in targets.withIndex()) {
+                val rawKeys = getProviderRawKeys(target.provider)
+                val keyCount = splitApiKeys(rawKeys).size
+                val maxAttempts = if (keyCount > 1) MAX_SAME_PROVIDER_KEY_RETRY else 1
+
+                for (attempt in 0 until maxAttempts) {
+                    val pinnedKey = when {
+                        keyCount <= 1 -> null
+                        attempt == 0 -> conversationProviderKeyStore.resolvePinnedKey(
+                            conversationId = conversationId,
+                            providerId = target.provider.id,
+                            rawKeys = rawKeys
+                        )
+                        else -> conversationProviderKeyStore.advancePinnedKey(
+                            conversationId = conversationId,
+                            providerId = target.provider.id,
+                            rawKeys = rawKeys
+                        )
+                    }
+                    val providerOverride = pinnedKey?.let { key ->
+                        withProviderApiKey(target.provider, key)
+                    } ?: target.provider
+
+                    updateConversation(conversationId, baseConversation)
+                    val result = runCatching {
+                        runGenerationAttempt(
+                            settings = settings,
+                            conversationId = conversationId,
+                            model = target.model,
+                            providerOverride = providerOverride,
+                            messages = scopedMessages,
+                            assistant = assistant,
+                            memories = memories,
+                            tools = tools,
+                            truncateIndex = baseConversation.truncateIndex,
+                        )
+                    }
+                    if (result.isSuccess) {
+                        completed = true
+                        break
+                    } else {
+                        finalError = result.exceptionOrNull()
+                    }
+                }
+
+                if (completed) break
+                if (targetIndex < targets.lastIndex) {
+                    val currentProvider = target.provider.name.ifBlank { target.provider.id.toString() }
+                    val nextProvider = targets[targetIndex + 1].provider.name.ifBlank {
+                        targets[targetIndex + 1].provider.id.toString()
+                    }
+                    addError(
+                        IllegalStateException("$currentProvider 失败，切换到 $nextProvider"),
+                        conversationId
+                    )
+                }
+            }
+
+            if (!completed) {
+                throw (finalError ?: IllegalStateException("所有候选供应商均失败"))
+            }
+
+            val finalConversation = getConversationFlow(conversationId).value
+            saveConversation(conversationId, finalConversation)
+            appScope.launch { generateTitle(conversationId, finalConversation) }
+            appScope.launch { generateSuggestion(conversationId, finalConversation) }
+        } catch (error: Throwable) {
+            cancelLiveUpdateNotification(conversationId)
+            error.printStackTrace()
+            addError(error, conversationId)
+            Logging.log(TAG, "handleMessageComplete: $error")
+            Logging.log(TAG, error.stackTraceToString())
+        }
+    }
+
+    private data class GenerationTarget(
+        val provider: ProviderSetting,
+        val model: Model,
+    )
+
+    private fun resolveGenerationTargets(
+        settings: me.rerere.rikkahub.data.datastore.Settings,
+        selectedModel: Model
+    ): List<GenerationTarget> {
+        val isRikkaRouterModel = settings.rikkaRouter.groups.any { it.id == selectedModel.id }
+        if (isRikkaRouterModel) {
+            val candidates = settings.resolveRikkaRouterCandidatesByModelId(selectedModel.id)
+            if (candidates.isEmpty()) {
+                error("rikkarouter 未配置可用模型")
+            }
+            return candidates.map { candidate ->
+                GenerationTarget(
+                    provider = candidate.provider,
+                    model = candidate.model
+                )
+            }
+        }
+
+        val provider = selectedModel.findProvider(settings.providers)
+            ?: error("Provider not found")
+        return listOf(
+            GenerationTarget(
+                provider = provider,
+                model = selectedModel
+            )
+        )
+    }
+
+    private fun getProviderRawKeys(provider: ProviderSetting): String {
+        return when (provider) {
+            is ProviderSetting.OpenAI -> provider.apiKey
+            is ProviderSetting.Claude -> provider.apiKey
+            is ProviderSetting.Google -> if (provider.vertexAI) "" else provider.apiKey
+        }
+    }
+
+    private fun splitApiKeys(rawKeys: String): List<String> {
+        return rawKeys
+            .split(KEY_SPLIT_REGEX)
+            .map { it.trim() }
+            .filter { it.isNotBlank() }
+            .distinct()
+    }
+
+    private fun withProviderApiKey(provider: ProviderSetting, apiKey: String): ProviderSetting {
+        return when (provider) {
+            is ProviderSetting.OpenAI -> provider.copy(apiKey = apiKey)
+            is ProviderSetting.Claude -> provider.copy(apiKey = apiKey)
+            is ProviderSetting.Google -> if (provider.vertexAI) provider else provider.copy(apiKey = apiKey)
+        }
+    }
+
+    private suspend fun runGenerationAttempt(
+        settings: me.rerere.rikkahub.data.datastore.Settings,
+        conversationId: Uuid,
+        model: Model,
+        providerOverride: ProviderSetting,
+        messages: List<UIMessage>,
+        assistant: me.rerere.rikkahub.data.model.Assistant,
+        memories: List<me.rerere.rikkahub.data.model.AssistantMemory>,
+        tools: List<Tool>,
+        truncateIndex: Int,
+    ) {
+        try {
             generationHandler.generateText(
                 settings = settings,
                 model = model,
-                messages = conversation.currentMessages.let {
-                    if (messageRange != null) {
-                        it.subList(messageRange.start, messageRange.endInclusive + 1)
-                    } else {
-                        it
-                    }
-                },
-                assistant = settings.getCurrentAssistant(),
-                memories = if (settings.getCurrentAssistant().useGlobalMemory) {
-                    memoryRepository.getGlobalMemories()
-                } else {
-                    memoryRepository.getMemoriesOfAssistant(settings.assistantId.toString())
-                },
+                providerOverride = providerOverride,
+                messages = messages,
+                assistant = assistant,
+                memories = memories,
                 inputTransformers = buildList {
                     addAll(inputTransformers)
                     add(templateTransformer)
                 },
                 outputTransformers = outputTransformers,
-                tools = buildList {
-                    if (settings.enableWebSearch) {
-                        addAll(createSearchTools(settings))
-                    }
-                    addAll(localTools.getTools(settings.getCurrentAssistant().localTools))
-                    mcpManager.getAllAvailableTools().forEach { tool ->
-                        add(
-                            Tool(
-                                name = "mcp__" + tool.name,
-                                description = tool.description ?: "",
-                                parameters = { tool.inputSchema },
-                                needsApproval = tool.needsApproval,
-                                execute = {
-                                    listOf(
-                                        UIMessagePart.Text(
-                                            mcpManager.callTool(tool.name, it.jsonObject).toString()
-                                        )
-                                    )
-                                },
-                            )
-                        )
-                    }
-                },
-                truncateIndex = conversation.truncateIndex,
-            ).onCompletion {
-                // 取消 Live Update 通知
-                cancelLiveUpdateNotification(conversationId)
-
-                // 可能被取消了，或者意外结束，兜底更新
-                val updatedConversation = getConversationFlow(conversationId).value.copy(
-                    messageNodes = getConversationFlow(conversationId).value.messageNodes.map { node ->
-                        node.copy(messages = node.messages.map { it.finishReasoning() })
-                    },
-                    updateAt = Instant.now()
-                )
-                updateConversation(conversationId, updatedConversation)
-
-                // Show notification if app is not in foreground
-                if (!isForeground.value && settings.displaySetting.enableNotificationOnMessageGeneration) {
-                    sendGenerationDoneNotification(conversationId)
-                }
-            }.collect { chunk ->
+                tools = tools,
+                truncateIndex = truncateIndex,
+            ).collect { chunk ->
                 when (chunk) {
                     is GenerationChunk.Messages -> {
                         val updatedConversation = getConversationFlow(conversationId).value
                             .updateCurrentMessages(chunk.messages)
                         updateConversation(conversationId, updatedConversation)
 
-                        // 如果应用不在前台，发送 Live Update 通知
-                        if (!isForeground.value && settings.displaySetting.enableNotificationOnMessageGeneration && settings.displaySetting.enableLiveUpdateNotification) {
+                        if (!isForeground.value &&
+                            settings.displaySetting.enableNotificationOnMessageGeneration &&
+                            settings.displaySetting.enableLiveUpdateNotification
+                        ) {
                             sendLiveUpdateNotification(conversationId, chunk.messages)
                         }
                     }
                 }
             }
-        }.onFailure {
-            // 取消 Live Update 通知
+        } finally {
             cancelLiveUpdateNotification(conversationId)
+        }
 
-            it.printStackTrace()
-            addError(it, conversationId)
-            Logging.log(TAG, "handleMessageComplete: $it")
-            Logging.log(TAG, it.stackTraceToString())
-        }.onSuccess {
-            val finalConversation = getConversationFlow(conversationId).value
-            saveConversation(conversationId, finalConversation)
+        val updatedConversation = getConversationFlow(conversationId).value.copy(
+            messageNodes = getConversationFlow(conversationId).value.messageNodes.map { node ->
+                node.copy(messages = node.messages.map { it.finishReasoning() })
+            },
+            updateAt = Instant.now()
+        )
+        updateConversation(conversationId, updatedConversation)
 
-            appScope.launch { generateTitle(conversationId, finalConversation) }
-            appScope.launch { generateSuggestion(conversationId, finalConversation) }
+        if (!isForeground.value && settings.displaySetting.enableNotificationOnMessageGeneration) {
+            sendGenerationDoneNotification(conversationId)
         }
     }
-
-    // ---- 检查无效消息 ----
-
     private fun checkInvalidMessages(conversationId: Uuid) {
         val conversation = getConversationFlow(conversationId).value
         var messagesNodes = conversation.messageNodes

--- a/app/src/main/java/me/rerere/rikkahub/ui/components/ai/ChatInput.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/ai/ChatInput.kt
@@ -246,6 +246,7 @@ fun ChatInput(
                     ModelSelector(
                         modelId = assistant.chatModelId ?: settings.chatModelId,
                         providers = settings.providers,
+                        includeRikkaRouter = true,
                         onSelect = {
                             onUpdateChatModel(it)
                             dismissExpand()

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/assistant/detail/AssistantBasicPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/assistant/detail/AssistantBasicPage.kt
@@ -204,6 +204,7 @@ internal fun AssistantBasicContent(
                         modelId = assistant.chatModelId,
                         providers = providers,
                         type = ModelType.CHAT,
+                        includeRikkaRouter = true,
                         onSelect = {
                             onUpdate(
                                 assistant.copy(

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingModelPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingModelPage.kt
@@ -415,6 +415,7 @@ private fun DefaultChatModelSetting(
                 ModelSelector(
                     modelId = settings.chatModelId,
                     type = ModelType.CHAT,
+                    includeRikkaRouter = true,
                     onSelect = {
                         vm.updateSettings(
                             settings.copy(

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingRikkaRouterPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingRikkaRouterPage.kt
@@ -1,0 +1,375 @@
+package me.rerere.rikkahub.ui.pages.setting
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.composables.icons.lucide.Boxes
+import com.composables.icons.lucide.ChevronDown
+import com.composables.icons.lucide.ChevronUp
+import com.composables.icons.lucide.Lucide
+import com.composables.icons.lucide.Plus
+import com.composables.icons.lucide.Star
+import com.composables.icons.lucide.Trash2
+import com.composables.icons.lucide.X
+import me.rerere.ai.provider.Model
+import me.rerere.ai.provider.ProviderSetting
+import me.rerere.rikkahub.data.datastore.findRikkaRouterMatches
+import me.rerere.rikkahub.data.model.RikkaRouterGroup
+import me.rerere.rikkahub.data.model.RikkaRouterMember
+import me.rerere.rikkahub.ui.components.nav.BackButton
+import me.rerere.rikkahub.ui.components.ui.AutoAIIcon
+import org.koin.androidx.compose.koinViewModel
+import kotlin.uuid.Uuid
+
+@Composable
+fun SettingRikkaRouterPage(vm: SettingVM = koinViewModel()) {
+    val settings by vm.settings.collectAsStateWithLifecycle()
+    val router = settings.rikkaRouter
+
+    var showAddDialog by remember { mutableStateOf(false) }
+    var newGroupName by remember { mutableStateOf("") }
+
+    fun updateGroup(group: RikkaRouterGroup) {
+        vm.updateSettings(
+            settings.copy(
+                rikkaRouter = router.copy(
+                    groups = router.groups.map {
+                        if (it.id == group.id) group else it
+                    }
+                )
+            )
+        )
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("rikkarouter") },
+                navigationIcon = { BackButton() },
+                actions = {
+                    IconButton(
+                        onClick = { showAddDialog = true }
+                    ) {
+                        Icon(Lucide.Plus, contentDescription = "Add")
+                    }
+                }
+            )
+        }
+    ) { innerPadding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding),
+            verticalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            Card(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp)
+            ) {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp, vertical = 12.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Text(
+                        text = "启用 rikkarouter",
+                        style = MaterialTheme.typography.titleMedium
+                    )
+                    Spacer(Modifier.weight(1f))
+                    Switch(
+                        checked = router.enabled,
+                        onCheckedChange = {
+                            vm.updateSettings(
+                                settings.copy(
+                                    rikkaRouter = router.copy(enabled = it)
+                                )
+                            )
+                        }
+                    )
+                }
+            }
+
+            if (router.groups.isEmpty()) {
+                Box(
+                    modifier = Modifier.fillMaxSize(),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Column(
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                        verticalArrangement = Arrangement.spacedBy(8.dp)
+                    ) {
+                        Text("暂无模型")
+                        Button(onClick = { showAddDialog = true }) {
+                            Text("添加模型")
+                        }
+                    }
+                }
+            } else {
+                LazyColumn(
+                    modifier = Modifier.fillMaxSize(),
+                    contentPadding = PaddingValues(16.dp),
+                    verticalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    items(router.groups, key = { it.id }) { group ->
+                        RikkaRouterGroupCard(
+                            group = group,
+                            matches = settings.findRikkaRouterMatches(group.name),
+                            onToggleEnabled = { enabled ->
+                                updateGroup(group.copy(enabled = enabled))
+                            },
+                            onDeleteGroup = {
+                                vm.updateSettings(
+                                    settings.copy(
+                                        rikkaRouter = router.copy(
+                                            groups = router.groups.filterNot { it.id == group.id }
+                                        )
+                                    )
+                                )
+                            },
+                            onToggleMember = { provider, model ->
+                                val existed = group.members.any { it.modelId == model.id }
+                                val newMembers = if (existed) {
+                                    group.members.filterNot { it.modelId == model.id }
+                                } else {
+                                    val nextOrder = (group.members.maxOfOrNull { it.order } ?: -1) + 1
+                                    group.members + RikkaRouterMember(
+                                        modelId = model.id,
+                                        enabled = true,
+                                        order = nextOrder
+                                    )
+                                }
+                                val primary = if (group.primaryModelId == model.id && existed) {
+                                    null
+                                } else {
+                                    group.primaryModelId
+                                }
+                                updateGroup(group.copy(members = newMembers, primaryModelId = primary))
+                            },
+                            onSetPrimary = { modelId ->
+                                updateGroup(group.copy(primaryModelId = modelId))
+                            }
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    if (showAddDialog) {
+        AlertDialog(
+            onDismissRequest = { showAddDialog = false },
+            title = { Text("添加常用模型") },
+            text = {
+                OutlinedTextField(
+                    value = newGroupName,
+                    onValueChange = { newGroupName = it },
+                    label = { Text("模型显示名称") },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth()
+                )
+            },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        val name = newGroupName.trim()
+                        if (name.isBlank()) return@TextButton
+                        vm.updateSettings(
+                            settings.copy(
+                                rikkaRouter = router.copy(
+                                    groups = listOf(
+                                        RikkaRouterGroup(
+                                            id = Uuid.random(),
+                                            name = name,
+                                        )
+                                    ) + router.groups
+                                )
+                            )
+                        )
+                        newGroupName = ""
+                        showAddDialog = false
+                    }
+                ) {
+                    Text("添加")
+                }
+            },
+            dismissButton = {
+                TextButton(
+                    onClick = {
+                        showAddDialog = false
+                        newGroupName = ""
+                    }
+                ) {
+                    Text("取消")
+                }
+            }
+        )
+    }
+}
+
+@Composable
+private fun RikkaRouterGroupCard(
+    group: RikkaRouterGroup,
+    matches: List<Pair<ProviderSetting, Model>>,
+    onToggleEnabled: (Boolean) -> Unit,
+    onDeleteGroup: () -> Unit,
+    onToggleMember: (ProviderSetting, Model) -> Unit,
+    onSetPrimary: (Uuid) -> Unit,
+) {
+    var expanded by rememberSaveable(group.id) { mutableStateOf(false) }
+    val selected = group.members.associateBy { it.modelId }
+
+    Card(
+        modifier = Modifier.fillMaxWidth()
+    ) {
+        Column(
+            modifier = Modifier.padding(12.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                Icon(Lucide.Boxes, contentDescription = null, modifier = Modifier.size(20.dp))
+                Text(
+                    text = group.name,
+                    style = MaterialTheme.typography.titleMedium,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.weight(1f)
+                )
+                Switch(
+                    checked = group.enabled,
+                    onCheckedChange = onToggleEnabled
+                )
+            }
+
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                Text(
+                    text = "已挂载 ${group.members.size} 个模型",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.weight(1f)
+                )
+                IconButton(
+                    onClick = { expanded = !expanded }
+                ) {
+                    Icon(if (expanded) Lucide.ChevronUp else Lucide.ChevronDown, contentDescription = null)
+                }
+                IconButton(
+                    onClick = onDeleteGroup
+                ) {
+                    Icon(Lucide.Trash2, contentDescription = null)
+                }
+            }
+
+            if (expanded) {
+                if (matches.isEmpty()) {
+                    Text(
+                        text = "没有匹配到可挂载模型",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                } else {
+                    matches.forEach { (provider, model) ->
+                        val selectedMember = selected[model.id]
+                        val isSelected = selectedMember != null
+                        val isPrimary = group.primaryModelId == model.id
+
+                        Card(
+                            modifier = Modifier.fillMaxWidth()
+                        ) {
+                            Column(
+                                modifier = Modifier.padding(10.dp),
+                                verticalArrangement = Arrangement.spacedBy(6.dp)
+                            ) {
+                                Row(
+                                    verticalAlignment = Alignment.CenterVertically,
+                                    horizontalArrangement = Arrangement.spacedBy(8.dp)
+                                ) {
+                                    AutoAIIcon(
+                                        name = model.modelId,
+                                        modifier = Modifier.size(24.dp)
+                                    )
+                                    Column(modifier = Modifier.weight(1f)) {
+                                        Text(
+                                            text = model.displayName.ifBlank { model.modelId },
+                                            style = MaterialTheme.typography.bodyMedium,
+                                            maxLines = 1,
+                                            overflow = TextOverflow.Ellipsis,
+                                        )
+                                        Text(
+                                            text = provider.name,
+                                            style = MaterialTheme.typography.labelSmall,
+                                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                                        )
+                                    }
+                                    IconButton(
+                                        onClick = { onToggleMember(provider, model) }
+                                    ) {
+                                        Icon(
+                                            if (isSelected) Lucide.X else Lucide.Plus,
+                                            contentDescription = null
+                                        )
+                                    }
+                                }
+
+                                if (isSelected) {
+                                    TextButton(
+                                        onClick = { onSetPrimary(model.id) }
+                                    ) {
+                                        Icon(
+                                            Lucide.Star,
+                                            contentDescription = null,
+                                            modifier = Modifier.size(14.dp)
+                                        )
+                                        Text(
+                                            text = if (isPrimary) "当前主力" else "设为主力",
+                                            modifier = Modifier.padding(start = 4.dp)
+                                        )
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
﻿这个 PR 不期待合并，直接关掉就行，主要是提功能请求的描述。我主要是想把这个需求描述清楚放这里，顺带附上一个跑得起来的原型供参考。如果 re 叔叔有兴趣的话，做一个优雅实现作为 2.0 的一部分会很令人兴奋。

为什么想做这个
目前供应商多了之后会遇到一个很割裂的体验：例如十几家供应商里有七八家都提供 deepseek-v3.2，平时用着还好，选中的某家中转突然失败了，就得在很长列表里手动找“下一家同款”，找到后还得重新选模型，会话就会被打断。
多 key 的情况也类似，原版没有轮询，想用多个 key 只能重复添加同一家供应商再手动标 (1)(2)(3) 区分。配置页会堆着一排重复供应商卡片，看起来很乱，管理和使用都不方便。

想做轮询时还有另一个顾虑：如果每条消息都换 key，供应商侧的上下文缓存基本会失效，上下文越长越贵，轮询收益可能还没缓存损失大。所以这个原型的策略是：同一会话尽量绑定稳住，失败了再切，新会话才自然推进到下一把 key，希望在轮询和缓存成本之间找平衡。

另外这件事放在客户端做还有一个聚合服务做不到的点：用本地或 VPS 搭聚合层时，拿不到客户端会话上下文 id，切换时机没法和会话状态协同，效果有上限（除非聚合层里全是按次数计费的提供商）。客户端可以直接感知这些状态，策略能做得更细。

原型做了什么
新增了一个叫 rikkarouter 的特殊入口，不是普通供应商配置页，专门用来把同一模型在不同供应商下的实例聚合管理：
- 可以给每个模型组设主力优先级，其余按顺序兜底。
- 同一供应商内 key 连续失败超过 3 次才切到下一家，不会频繁乱跳。
- 普通供应商的多 key 也复用了“会话绑定 + 失败才推进”逻辑，不用再靠重复添加供应商解决。

实现上尽量复用了现有结构，没引新依赖，也没有增加包体负担。

实验范围
这是第一版实验原型，只接进了聊天主生成链路；标题生成、建议、翻译等暂时没接。失败分类、重试策略可配置、失败轨迹可视化这些都还没做，细节还比较粗糙。

涉及的文件
app/src/main/java/me/rerere/rikkahub/data/model/RikkaRouter.kt
app/src/main/java/me/rerere/rikkahub/data/datastore/RikkaRouterResolver.kt
app/src/main/java/me/rerere/rikkahub/data/datastore/PreferencesStore.kt
app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingRikkaRouterPage.kt
app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingProviderPage.kt
app/src/main/java/me/rerere/rikkahub/RouteActivity.kt
app/src/main/java/me/rerere/rikkahub/ui/components/ai/ModelList.kt
app/src/main/java/me/rerere/rikkahub/ui/components/ai/ChatInput.kt
app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingModelPage.kt
app/src/main/java/me/rerere/rikkahub/ui/pages/assistant/detail/AssistantBasicPage.kt
app/src/main/java/me/rerere/rikkahub/data/ai/ConversationProviderKeyStore.kt
app/src/main/java/me/rerere/rikkahub/di/AppModule.kt
app/src/main/java/me/rerere/rikkahub/data/ai/GenerationHandler.kt
app/src/main/java/me/rerere/rikkahub/service/ChatService.kt

