### PR TITLE
feat：为助手记忆删除添加确认步骤

### DIFF
--- a/app/src/main/java/me/rerere/rikkahub/ui/components/message/ChatMessageActions.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/message/ChatMessageActions.kt
@@ -13,7 +13,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Icon
@@ -22,7 +21,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.ProvideTextStyle
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -61,6 +59,7 @@ import me.rerere.rikkahub.R
 import me.rerere.rikkahub.data.model.MessageNode
 import me.rerere.rikkahub.ui.context.LocalSettings
 import me.rerere.rikkahub.ui.context.LocalTTSState
+import me.rerere.rikkahub.ui.components.ui.RikkaConfirmDialog
 import me.rerere.rikkahub.utils.copyMessageToClipboard
 import me.rerere.rikkahub.utils.extractQuotedContentAsText
 import me.rerere.rikkahub.utils.toLocalString
@@ -207,28 +206,18 @@ fun ColumnScope.ChatMessageActionButtons(
     }
 
     // Regenerate confirmation dialog
-    if (showRegenerateConfirm) {
-        AlertDialog(
-            onDismissRequest = { showRegenerateConfirm = false },
-            title = { Text(stringResource(R.string.regenerate)) },
-            text = { Text(stringResource(R.string.regenerate_confirm_message)) },
-            confirmButton = {
-                TextButton(
-                    onClick = {
-                        showRegenerateConfirm = false
-                        onRegenerate()
-                    }
-                ) {
-                    Text(stringResource(R.string.confirm))
-                }
-            },
-            dismissButton = {
-                TextButton(onClick = { showRegenerateConfirm = false }) {
-                    Text(stringResource(R.string.cancel))
-                }
-            }
-        )
-    }
+    RikkaConfirmDialog(
+        show = showRegenerateConfirm,
+        title = stringResource(R.string.regenerate),
+        confirmText = stringResource(R.string.confirm),
+        dismissText = stringResource(R.string.cancel),
+        onConfirm = {
+            showRegenerateConfirm = false
+            onRegenerate()
+        },
+        onDismiss = { showRegenerateConfirm = false },
+        text = { Text(stringResource(R.string.regenerate_confirm_message)) }
+    )
 }
 
 @Composable

--- a/app/src/main/java/me/rerere/rikkahub/ui/components/ui/ConfirmDialog.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/ui/ConfirmDialog.kt
@@ -1,0 +1,37 @@
+package me.rerere.rikkahub.ui.components.ui
+
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+
+@Composable
+fun RikkaConfirmDialog(
+    show: Boolean,
+    title: String,
+    confirmText: String,
+    dismissText: String,
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit,
+    text: @Composable () -> Unit,
+) {
+    if (!show) {
+        return
+    }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(title) },
+        text = text,
+        confirmButton = {
+            TextButton(onClick = onConfirm) {
+                Text(confirmText)
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(dismissText)
+            }
+        }
+    )
+}

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/assistant/detail/AssistantMemoryPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/assistant/detail/AssistantMemoryPage.kt
@@ -25,6 +25,9 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -40,6 +43,7 @@ import me.rerere.rikkahub.R
 import me.rerere.rikkahub.data.model.Assistant
 import me.rerere.rikkahub.data.model.AssistantMemory
 import me.rerere.rikkahub.ui.components.nav.BackButton
+import me.rerere.rikkahub.ui.components.ui.RikkaConfirmDialog
 import me.rerere.rikkahub.ui.components.ui.FormItem
 import me.rerere.rikkahub.ui.hooks.EditStateContent
 import me.rerere.rikkahub.ui.hooks.useEditState
@@ -97,6 +101,7 @@ private fun AssistantMemoryContent(
             onUpdateMemory(it)
         }
     }
+    var pendingDeleteMemory by remember { mutableStateOf<AssistantMemory?>(null) }
 
     // 记忆对话框
     memoryDialogState.EditStateContent { memory, update ->
@@ -301,11 +306,32 @@ private fun AssistantMemoryContent(
                     onEditMemory = {
                         memoryDialogState.open(it)
                     },
-                    onDeleteMemory = onDeleteMemory
+                    onDeleteMemory = {
+                        pendingDeleteMemory = it
+                    }
                 )
             }
         }
     }
+
+    RikkaConfirmDialog(
+        show = pendingDeleteMemory != null,
+        title = stringResource(R.string.confirm_delete),
+        confirmText = stringResource(R.string.confirm),
+        dismissText = stringResource(R.string.cancel),
+        onConfirm = {
+            pendingDeleteMemory?.let(onDeleteMemory)
+            pendingDeleteMemory = null
+        },
+        onDismiss = { pendingDeleteMemory = null },
+        text = {
+            Text(
+                text = pendingDeleteMemory?.content.orEmpty(),
+                maxLines = 8,
+                overflow = TextOverflow.Ellipsis
+            )
+        }
+    )
 }
 
 @Composable


### PR DESCRIPTION
- 为「助手记忆」页面的删除操作增加二次确认弹窗
- 避免滑动/误触导致记忆被直接删除
- 抽取可复用的 `RikkaConfirmDialog`，并复用于“重新生成”确认弹窗

## 变更内容
- 更新 `AssistantMemoryPage`：删除改为先进入待删除状态，必须确认后才执行
- 新增通用组件 `RikkaConfirmDialog`（`ui/components/ui/ConfirmDialog.kt`）
- 将 `ChatMessageActions` 中“重新生成”确认弹窗切换为同一组件

## 测试
- [x] `./gradlew :app:compileDebugKotlin`
- [x] `./gradlew --no-daemon :app:assembleDebug`
- [ ] `./gradlew :app:testDebugUnitTest`  （`ShareSheetTest`、`PromptInjectionTransformerTest` 还是有问题啊）

Closes #787
