### PR TITLE
fix(ui): 修复 40 条之后的对话自动滚动失效问题

### DIFF
--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ConversationList.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ConversationList.kt
@@ -87,6 +87,7 @@ fun ColumnScope.ConversationList(
 
     LaunchedEffect(current.id, conversations.itemCount, hasScrolledToCurrent) {
         if (hasScrolledToCurrent) return@LaunchedEffect
+        if (conversations.itemCount == 0) return@LaunchedEffect
         val currentIndex = conversations.itemSnapshotList.items.indexOfFirst {
             (it as? ConversationListItem.Item)?.conversation?.id == current.id
         }
@@ -96,6 +97,8 @@ fun ColumnScope.ConversationList(
                 listState.scrollToItem(currentIndex)
             }
             hasScrolledToCurrent = true
+        } else {
+            conversations[conversations.itemCount - 1]
         }
     }
 


### PR DESCRIPTION
当目标不在已加载的数据中时，主动访问最后一个已加载项来触发 Paging 加载下一页。当新一页加载完成后 itemCount 变化，LaunchedEffect 重新运行，再次查找，直到找到为止。