### PR TITLE
修复侧边栏历史记录滚动位置在切换/返回对话后重置的问题

### DIFF
--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ChatDrawer.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ChatDrawer.kt
@@ -1,5 +1,6 @@
 package me.rerere.rikkahub.ui.pages.chat
 
+import android.content.Context
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -29,11 +30,13 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -41,8 +44,23 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.paging.PagingData
+import androidx.paging.cachedIn
+import androidx.paging.insertSeparators
+import androidx.paging.map
 import androidx.paging.compose.collectAsLazyPagingItems
+import java.time.LocalDate
+import java.time.ZoneId
+import kotlin.uuid.Uuid
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import me.rerere.hugeicons.HugeIcons
 import me.rerere.hugeicons.stroke.ChartColumn
@@ -74,9 +92,9 @@ import me.rerere.rikkahub.ui.hooks.rememberIsPlayStoreVersion
 import me.rerere.rikkahub.ui.hooks.useEditState
 import me.rerere.rikkahub.ui.modifier.onClick
 import me.rerere.rikkahub.utils.navigateToChatPage
+import me.rerere.rikkahub.utils.toLocalString
 import me.rerere.rikkahub.utils.toDp
 import org.koin.compose.koinInject
-import kotlin.uuid.Uuid
 
 @Composable
 fun ChatDrawerContent(
@@ -90,8 +108,25 @@ fun ChatDrawerContent(
     val isPlayStore = rememberIsPlayStoreVersion()
     val repo = koinInject<ConversationRepository>()
 
-    val conversations = vm.conversations.collectAsLazyPagingItems()
-    val conversationListState = rememberLazyListState()
+    val conversations = remember(settings.assistantId) {
+        ChatDrawerScrollState.getFlow(settings.assistantId, repo, context.applicationContext)
+    }.collectAsLazyPagingItems()
+
+    val pos = ChatDrawerScrollState.getScrollPosition()
+    val conversationListState = rememberLazyListState(
+        initialFirstVisibleItemIndex = pos.index,
+        initialFirstVisibleItemScrollOffset = pos.offset
+    )
+
+    LaunchedEffect(conversationListState) {
+        snapshotFlow {
+            conversationListState.firstVisibleItemIndex to conversationListState.firstVisibleItemScrollOffset
+        }
+            .distinctUntilChanged()
+            .collectLatest { (index, offset) ->
+                ChatDrawerScrollState.setScrollPosition(index, offset)
+            }
+    }
 
     val conversationJobs by vm.conversationJobs.collectAsStateWithLifecycle(
         initialValue = emptyMap(),
@@ -573,5 +608,102 @@ private fun AssistantItem(
                 }
             }
         }
+    }
+}
+
+private object ChatDrawerScrollState {
+    data class ScrollPosition(val index: Int = 0, val offset: Int = 0)
+
+    private var scrollPosition: ScrollPosition = ScrollPosition()
+
+    fun getScrollPosition(): ScrollPosition = scrollPosition
+
+    @Synchronized
+    fun setScrollPosition(index: Int, offset: Int) {
+        scrollPosition = ScrollPosition(index, offset)
+    }
+
+    private data class CachedState(
+        val assistantId: Uuid,
+        val flow: Flow<PagingData<ConversationListItem>>,
+        val scope: CoroutineScope,
+    )
+
+    private var cache: CachedState? = null
+
+    @Synchronized
+    fun getFlow(
+        assistantId: Uuid,
+        repo: ConversationRepository,
+        applicationContext: Context
+    ): Flow<PagingData<ConversationListItem>> {
+        val current = cache
+        if (current != null && current.assistantId == assistantId) {
+            return current.flow
+        }
+
+        current?.scope?.cancel()
+        val newScope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
+
+        val flow = repo.getConversationsOfAssistantPaging(assistantId)
+            .map { pagingData ->
+                pagingData
+                    .map { ConversationListItem.Item(it) }
+                    .insertSeparators { before: ConversationListItem.Item?, after: ConversationListItem.Item? ->
+                        insertSeparators(before, after, applicationContext)
+                    }
+            }
+            .cachedIn(newScope)
+
+        cache = CachedState(assistantId, flow, newScope)
+        return flow
+    }
+
+    private fun createDateHeader(item: ConversationListItem.Item, context: Context): ConversationListItem.DateHeader {
+        val date = item.conversation.updateAt.atZone(ZoneId.systemDefault()).toLocalDate()
+        return ConversationListItem.DateHeader(
+            date = date,
+            label = getDateLabel(date, context)
+        )
+    }
+
+    private fun getDateLabel(date: LocalDate, context: Context): String {
+        val today = LocalDate.now()
+        val yesterday = today.minusDays(1)
+        return when (date) {
+            today -> context.getString(R.string.chat_page_today)
+            yesterday -> context.getString(R.string.chat_page_yesterday)
+            else -> date.toLocalString(date.year != today.year)
+        }
+    }
+
+    private fun insertSeparators(
+        before: ConversationListItem.Item?,
+        after: ConversationListItem.Item?,
+        context: Context
+    ): ConversationListItem? {
+        if (after == null) return null
+
+        if (before == null) {
+            return if (after.conversation.isPinned) {
+                ConversationListItem.PinnedHeader
+            } else {
+                createDateHeader(after, context)
+            }
+        }
+
+        if (before.conversation.isPinned && !after.conversation.isPinned) {
+            return createDateHeader(after, context)
+        }
+
+        if (!before.conversation.isPinned && !after.conversation.isPinned) {
+            val beforeDate = before.conversation.updateAt.atZone(ZoneId.systemDefault()).toLocalDate()
+            val afterDate = after.conversation.updateAt.atZone(ZoneId.systemDefault()).toLocalDate()
+            if (beforeDate != afterDate) {
+                return createDateHeader(after, context)
+            }
+        }
+
+        return null
     }
 }


### PR DESCRIPTION
**关联反馈：**
https://discord.com/channels/1363906401902002656/1363906402560774149/1475348136871329940

**问题描述：**
在侧边栏历史记录中向下滚动大约几十个对话并点击进入某个对话后，返回或重新打开侧边栏时，列表滚动位置会重置到顶部，导致用户体验不连贯。

**修复方案：**
1. **状态持久化**：引入私有单例对象 `ChatDrawerState`，独立于 `ChatVM` 生命周期持有 `PagingData` 数据流和滚动位置（Index & Offset）。
2. **滚动恢复**：利用 `rememberLazyListState` 的初始参数恢复位置，并通过 `LaunchedEffect` + `snapshotFlow` 实时同步最新的滚动状态到单例中。
3. **内存安全**：在单例缓存数据流时强制使用 `applicationContext`，避免因捕获 Activity 上下文而导致的内存泄漏。
4. **数据一致性**：当切换助手（Assistant ID 变更）时，单例会自动重置缓存流和滚动位置，确保数据准确。