### PR TITLE
fix: 手机竖屏拍摄图片上传方向错误 (#863)

### DIFF
--- a/ai/src/test/java/me/rerere/ai/util/FileEncoderExifTransformTest.kt
+++ b/ai/src/test/java/me/rerere/ai/util/FileEncoderExifTransformTest.kt
@@ -1,0 +1,38 @@
+package me.rerere.ai.util
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class FileEncoderExifTransformTest {
+
+    @Test
+    fun `all supported exif orientations should map to expected transform`() {
+        assertEquals(ExifTransformType.NONE, mapExifOrientationToTransform(ORIENTATION_NORMAL))
+        assertEquals(ExifTransformType.FLIP_HORIZONTAL, mapExifOrientationToTransform(ORIENTATION_FLIP_HORIZONTAL))
+        assertEquals(ExifTransformType.ROTATE_180, mapExifOrientationToTransform(ORIENTATION_ROTATE_180))
+        assertEquals(ExifTransformType.FLIP_VERTICAL, mapExifOrientationToTransform(ORIENTATION_FLIP_VERTICAL))
+        assertEquals(ExifTransformType.TRANSPOSE, mapExifOrientationToTransform(ORIENTATION_TRANSPOSE))
+        assertEquals(ExifTransformType.ROTATE_90, mapExifOrientationToTransform(ORIENTATION_ROTATE_90))
+        assertEquals(ExifTransformType.TRANSVERSE, mapExifOrientationToTransform(ORIENTATION_TRANSVERSE))
+        assertEquals(ExifTransformType.ROTATE_270, mapExifOrientationToTransform(ORIENTATION_ROTATE_270))
+    }
+
+    @Test
+    fun `undefined or unknown orientation should map to none`() {
+        assertEquals(ExifTransformType.NONE, mapExifOrientationToTransform(ORIENTATION_UNDEFINED))
+        assertEquals(ExifTransformType.NONE, mapExifOrientationToTransform(999))
+        assertEquals(ExifTransformType.NONE, mapExifOrientationToTransform(-1))
+    }
+
+    companion object {
+        private const val ORIENTATION_UNDEFINED = 0
+        private const val ORIENTATION_NORMAL = 1
+        private const val ORIENTATION_FLIP_HORIZONTAL = 2
+        private const val ORIENTATION_ROTATE_180 = 3
+        private const val ORIENTATION_FLIP_VERTICAL = 4
+        private const val ORIENTATION_TRANSPOSE = 5
+        private const val ORIENTATION_ROTATE_90 = 6
+        private const val ORIENTATION_TRANSVERSE = 7
+        private const val ORIENTATION_ROTATE_270 = 8
+    }
+}


### PR DESCRIPTION
### 修复手机竖屏拍摄图片上传给模型时方向错误（EXIF orientation 未被处理）。

Closes #863

在图片编码出口统一处理 EXIF 方向（单点修复）：

- 文件：`ai/src/main/java/me/rerere/ai/util/FileEncoder.kt`
- 在 `compressAndEncode()` 中，`decodeFile` 后增加 `normalizeByExif(...)`
- 支持完整 EXIF 方向映射：
  - `NORMAL`
  - `ROTATE_90`
  - `ROTATE_180`
  - `ROTATE_270`
  - `FLIP_HORIZONTAL`
  - `FLIP_VERTICAL`
  - `TRANSPOSE`
  - `TRANSVERSE`
- EXIF 读取/变换失败时回退原 bitmap，避免上传链路失败

保持现有行为不变：

- GIF 仍走原样编码
- 非 GIF 仍统一压缩为 JPEG

新增最小单测：

- 文件：`ai/src/test/java/me/rerere/ai/util/FileEncoderExifTransformTest.kt`
- 覆盖“方向值 -> 变换类型”映射与未知值回退
  - https://github.com/jacob-sheng/rikkahub-dev/actions/runs/22350356924
  - https://github.com/jacob-sheng/rikkahub-dev/actions/runs/22350438795

- 对现有 provider 请求格式无影响（仍输出 JPEG）。
- 只在发送前编码出口修复，避免在多个上传入口重复处理。
- 可覆盖历史/不同来源的 `file://` 图片，保证模型收到的像素方向与用户预览一致。
