### PR TITLE
feat: 导入角色卡时同步导入世界书并自动绑定 (#800)

### DIFF
--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/assistant/AssistantPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/assistant/AssistantPage.kt
@@ -61,6 +61,7 @@ import me.rerere.rikkahub.data.datastore.DEFAULT_ASSISTANTS_IDS
 import me.rerere.rikkahub.data.datastore.Settings
 import me.rerere.rikkahub.data.model.Assistant
 import me.rerere.rikkahub.data.model.AssistantMemory
+import me.rerere.rikkahub.data.model.Lorebook
 import me.rerere.rikkahub.ui.components.nav.BackButton
 import me.rerere.rikkahub.ui.components.ui.FormItem
 import me.rerere.rikkahub.ui.components.ui.Tag
@@ -82,8 +83,11 @@ import androidx.compose.foundation.lazy.items as lazyItems
 @Composable
 fun AssistantPage(vm: AssistantVM = koinViewModel()) {
     val settings by vm.settings.collectAsStateWithLifecycle()
-    val createState = useEditState<Assistant> {
-        vm.addAssistant(it)
+    var pendingImportedLorebooks by remember { mutableStateOf(emptyList<Lorebook>()) }
+    val createState = useEditState<Assistant> { assistant ->
+        val lorebooks = pendingImportedLorebooks
+        pendingImportedLorebooks = emptyList()
+        vm.addAssistant(assistant, lorebooksToAdd = lorebooks)
     }
     val navController = LocalNavController.current
 
@@ -114,6 +118,7 @@ fun AssistantPage(vm: AssistantVM = koinViewModel()) {
             }, actions = {
                 IconButton(
                     onClick = {
+                        pendingImportedLorebooks = emptyList()
                         createState.open(Assistant())
                     }) {
                     Icon(Lucide.Plus, stringResource(R.string.assistant_page_add))
@@ -222,7 +227,11 @@ fun AssistantPage(vm: AssistantVM = koinViewModel()) {
         }
     }
 
-    AssistantCreationSheet(createState)
+    AssistantCreationSheet(
+        state = createState,
+        onUpdatePendingLorebooks = { pendingImportedLorebooks = it },
+        onClearPendingLorebooks = { pendingImportedLorebooks = emptyList() },
+    )
 
     // 操作菜单 Bottom Sheet
     actionSheetAssistant?.let { assistant ->
@@ -307,10 +316,13 @@ private fun AssistantTagsFilterRow(
 @Composable
 private fun AssistantCreationSheet(
     state: EditState<Assistant>,
+    onUpdatePendingLorebooks: (List<Lorebook>) -> Unit,
+    onClearPendingLorebooks: () -> Unit,
 ) {
     state.EditStateContent { assistant, update ->
         ModalBottomSheet(
             onDismissRequest = {
+                onClearPendingLorebooks()
                 state.dismiss()
             },
             sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
@@ -345,8 +357,9 @@ private fun AssistantCreationSheet(
                     }
 
                     AssistantImporter(
-                        onUpdate = {
-                            update(it)
+                        onUpdate = { importedAssistant, importedLorebooks ->
+                            onUpdatePendingLorebooks(importedLorebooks)
+                            update(importedAssistant)
                             state.confirm()
                         },
                         modifier = Modifier.fillMaxWidth(),
@@ -358,6 +371,7 @@ private fun AssistantCreationSheet(
                 ) {
                     TextButton(
                         onClick = {
+                            onClearPendingLorebooks()
                             state.dismiss()
                         }) {
                         Text(stringResource(R.string.assistant_page_cancel))

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/assistant/AssistantPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/assistant/AssistantPage.kt
@@ -83,6 +83,7 @@ import androidx.compose.foundation.lazy.items as lazyItems
 @Composable
 fun AssistantPage(vm: AssistantVM = koinViewModel()) {
     val settings by vm.settings.collectAsStateWithLifecycle()
+    // 角色卡导入可能带世界书，先暂存，确认保存时一起写入设置
     var pendingImportedLorebooks by remember { mutableStateOf(emptyList<Lorebook>()) }
     val createState = useEditState<Assistant> { assistant ->
         val lorebooks = pendingImportedLorebooks
@@ -118,6 +119,7 @@ fun AssistantPage(vm: AssistantVM = koinViewModel()) {
             }, actions = {
                 IconButton(
                     onClick = {
+                        // 避免上一次导入的世界书残留到新建流程
                         pendingImportedLorebooks = emptyList()
                         createState.open(Assistant())
                     }) {
@@ -322,6 +324,7 @@ private fun AssistantCreationSheet(
     state.EditStateContent { assistant, update ->
         ModalBottomSheet(
             onDismissRequest = {
+                // 关闭创建弹窗时清空暂存，避免下次误绑定
                 onClearPendingLorebooks()
                 state.dismiss()
             },

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/assistant/AssistantVM.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/assistant/AssistantVM.kt
@@ -34,7 +34,9 @@ class AssistantVM(
     fun addAssistant(assistant: Assistant, lorebooksToAdd: List<Lorebook> = emptyList()) {
         viewModelScope.launch {
             settingsStore.update { settings ->
+                // 同一次更新写入 assistant 和 lorebooks，保证导入绑定不丢
                 val lorebookIds = lorebooksToAdd.map { it.id }.toSet()
+                // 补齐 lorebookIds，并避免重复追加
                 val assistantWithLorebooks = if (lorebookIds.isNotEmpty() && !assistant.lorebookIds.containsAll(lorebookIds)) {
                     assistant.copy(lorebookIds = assistant.lorebookIds + lorebookIds)
                 } else {

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/assistant/AssistantVM.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/assistant/AssistantVM.kt
@@ -12,6 +12,7 @@ import me.rerere.rikkahub.data.datastore.SettingsStore
 import me.rerere.rikkahub.data.files.FilesManager
 import me.rerere.rikkahub.data.model.Assistant
 import me.rerere.rikkahub.data.model.Avatar
+import me.rerere.rikkahub.data.model.Lorebook
 import me.rerere.rikkahub.data.repository.ConversationRepository
 import me.rerere.rikkahub.data.repository.MemoryRepository
 
@@ -30,14 +31,21 @@ class AssistantVM(
         }
     }
 
-    fun addAssistant(assistant: Assistant) {
+    fun addAssistant(assistant: Assistant, lorebooksToAdd: List<Lorebook> = emptyList()) {
         viewModelScope.launch {
-            val settings = settings.value
-            settingsStore.update(
+            settingsStore.update { settings ->
+                val lorebookIds = lorebooksToAdd.map { it.id }.toSet()
+                val assistantWithLorebooks = if (lorebookIds.isNotEmpty() && !assistant.lorebookIds.containsAll(lorebookIds)) {
+                    assistant.copy(lorebookIds = assistant.lorebookIds + lorebookIds)
+                } else {
+                    assistant
+                }
+
                 settings.copy(
-                    assistants = settings.assistants.plus(assistant)
+                    assistants = settings.assistants.plus(assistantWithLorebooks),
+                    lorebooks = settings.lorebooks.plus(lorebooksToAdd)
                 )
-            )
+            }
         }
     }
 

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/assistant/detail/AssistantImporter.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/assistant/detail/AssistantImporter.kt
@@ -31,12 +31,19 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.booleanOrNull
 import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.intOrNull
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import me.rerere.ai.ui.UIMessage
 import me.rerere.rikkahub.data.model.Assistant
+import me.rerere.rikkahub.data.model.InjectionPosition
+import me.rerere.rikkahub.data.model.Lorebook
+import me.rerere.rikkahub.data.model.PromptInjection
 import me.rerere.rikkahub.data.files.FilesManager
 import me.rerere.rikkahub.ui.components.ui.AutoAIIcon
 import me.rerere.rikkahub.ui.context.LocalToaster
@@ -44,11 +51,12 @@ import me.rerere.rikkahub.utils.ImageUtils
 import me.rerere.rikkahub.utils.jsonPrimitiveOrNull
 import me.rerere.rikkahub.R
 import org.koin.compose.koinInject
+import kotlin.uuid.Uuid
 
 @Composable
 fun AssistantImporter(
     modifier: Modifier = Modifier,
-    onUpdate: (Assistant) -> Unit,
+    onUpdate: (Assistant, List<Lorebook>) -> Unit,
 ) {
     Row(
         verticalAlignment = Alignment.CenterVertically,
@@ -61,7 +69,7 @@ fun AssistantImporter(
 
 @Composable
 private fun SillyTavernImporter(
-    onImport: (Assistant) -> Unit
+    onImport: (Assistant, List<Lorebook>) -> Unit
 ) {
     val context = LocalContext.current
     val filesManager: FilesManager = koinInject()
@@ -246,12 +254,179 @@ private fun parseAssistantFromJson(
     return parser.parse(context = context, json = json, background = background)
 }
 
+internal fun parseLorebooksFromTavernCard(
+    json: JsonObject,
+    assistantName: String,
+): List<Lorebook> {
+    return runCatching {
+        val data = json["data"]?.jsonObject ?: return emptyList()
+        val candidates = buildLorebookCandidates(data)
+        val firstValidLorebook = candidates.firstNotNullOfOrNull { candidate ->
+            parseLorebookFromBookElement(candidate, assistantName)
+        }
+        firstValidLorebook?.let { listOf(it) } ?: emptyList()
+    }.getOrDefault(emptyList())
+}
+
+private fun buildLorebookCandidates(data: JsonObject): List<kotlinx.serialization.json.JsonElement> {
+    val keys = listOf("character_book", "characterBook", "worldbook", "lorebook")
+    val candidates = buildList {
+        keys.forEach { key ->
+            data[key]?.let { add(it) }
+        }
+
+        val extensions = data["extensions"]?.jsonObject
+        if (extensions != null) {
+            keys.forEach { key ->
+                extensions.values.forEach { ext ->
+                    val obj = ext as? JsonObject ?: return@forEach
+                    obj[key]?.let { add(it) }
+                }
+            }
+        }
+    }
+    return candidates
+}
+
+private fun parseLorebookFromBookElement(
+    bookElement: kotlinx.serialization.json.JsonElement,
+    assistantName: String,
+): Lorebook? {
+    val bookObj = bookElement as? JsonObject ?: return null
+    val entriesElement = bookObj["entries"] ?: return null
+    val entries = parseLorebookEntries(entriesElement)
+    if (entries.isEmpty()) return null
+
+    val name = bookObj["name"]?.jsonPrimitiveOrNull?.contentOrNull
+        ?.takeIf { it.isNotBlank() }
+        ?: "$assistantName Lorebook"
+
+    return Lorebook(
+        id = Uuid.random(),
+        name = name,
+        description = "",
+        enabled = true,
+        entries = entries,
+    )
+}
+
+private fun parseLorebookEntries(entriesElement: kotlinx.serialization.json.JsonElement): List<PromptInjection.RegexInjection> {
+    val entryObjects = when (entriesElement) {
+        is JsonObject -> entriesElement.values.mapNotNull { it as? JsonObject }
+        is JsonArray -> entriesElement.mapNotNull { it as? JsonObject }
+        else -> emptyList()
+    }
+
+    return entryObjects.mapNotNull { entry ->
+        runCatching { parseLorebookEntry(entry) }.getOrNull()
+    }
+}
+
+private fun parseLorebookEntry(entry: JsonObject): PromptInjection.RegexInjection {
+    val keywords = parseLorebookEntryKeywords(entry)
+    val extensions = entry["extensions"] as? JsonObject
+
+    val comment = entry["comment"]?.jsonPrimitiveOrNull?.contentOrNull.orEmpty()
+    val name = comment.ifEmpty { keywords.firstOrNull().orEmpty() }
+
+    val disabledByDisable = entry["disable"]?.jsonPrimitiveOrNull?.booleanOrNull == true
+    val enabledField = entry["enabled"]?.jsonPrimitiveOrNull?.booleanOrNull
+    val enabled = when {
+        disabledByDisable -> false
+        enabledField == false -> false
+        else -> true
+    }
+
+    val priority = entry["order"]?.jsonPrimitiveOrNull?.intOrNull
+        ?: entry["priority"]?.jsonPrimitiveOrNull?.intOrNull
+        ?: entry["insertion_order"]?.jsonPrimitiveOrNull?.intOrNull
+        ?: entry["insertion_order"]?.jsonPrimitiveOrNull?.contentOrNull?.toIntOrNull()
+        ?: 100
+
+    val positionInt = entry["position"]?.jsonPrimitiveOrNull?.intOrNull
+        ?: extensions?.get("position")?.jsonPrimitiveOrNull?.intOrNull
+        ?: entry["position"]?.jsonPrimitiveOrNull?.contentOrNull?.toIntOrNull()
+    val positionStr = entry["position"]?.jsonPrimitiveOrNull?.contentOrNull
+    val position = when {
+        positionInt != null -> mapSillyTavernPosition(positionInt)
+        !positionStr.isNullOrBlank() -> mapSillyTavernPositionString(positionStr) ?: InjectionPosition.AFTER_SYSTEM_PROMPT
+        else -> InjectionPosition.AFTER_SYSTEM_PROMPT
+    }
+
+    val injectDepth = entry["depth"]?.jsonPrimitiveOrNull?.intOrNull
+        ?: extensions?.get("depth")?.jsonPrimitiveOrNull?.intOrNull
+        ?: entry["depth"]?.jsonPrimitiveOrNull?.contentOrNull?.toIntOrNull()
+        ?: 4
+
+    val scanDepth = entry["scanDepth"]?.jsonPrimitiveOrNull?.intOrNull
+        ?: entry["scan_depth"]?.jsonPrimitiveOrNull?.intOrNull
+        ?: extensions?.get("scan_depth")?.jsonPrimitiveOrNull?.intOrNull
+        ?: 4
+
+    val caseSensitive = entry["caseSensitive"]?.jsonPrimitiveOrNull?.booleanOrNull
+        ?: entry["case_sensitive"]?.jsonPrimitiveOrNull?.booleanOrNull
+        ?: extensions?.get("case_sensitive")?.jsonPrimitiveOrNull?.booleanOrNull
+        ?: false
+
+    val constantActive = entry["constant"]?.jsonPrimitiveOrNull?.booleanOrNull ?: false
+
+    val content = entry["content"]?.jsonPrimitiveOrNull?.contentOrNull.orEmpty()
+
+    return PromptInjection.RegexInjection(
+        id = Uuid.random(),
+        name = name,
+        enabled = enabled,
+        priority = priority,
+        position = position,
+        injectDepth = injectDepth,
+        content = content,
+        keywords = keywords,
+        useRegex = false,
+        caseSensitive = caseSensitive,
+        scanDepth = scanDepth,
+        constantActive = constantActive,
+    )
+}
+
+private fun parseLorebookEntryKeywords(entry: JsonObject): List<String> {
+    val element = entry["key"] ?: entry["keys"] ?: return emptyList()
+    return when (element) {
+        is JsonArray -> element.mapNotNull { it.jsonPrimitiveOrNull?.contentOrNull?.takeIf(String::isNotBlank) }
+        is JsonPrimitive -> element.contentOrNull?.takeIf(String::isNotBlank)?.let { listOf(it) } ?: emptyList()
+        else -> emptyList()
+    }
+}
+
+private fun mapSillyTavernPosition(position: Int): InjectionPosition {
+    return when (position) {
+        0 -> InjectionPosition.BEFORE_SYSTEM_PROMPT
+        1 -> InjectionPosition.AFTER_SYSTEM_PROMPT
+        2 -> InjectionPosition.TOP_OF_CHAT
+        3 -> InjectionPosition.TOP_OF_CHAT // After Examples -> 聊天历史开头
+        4 -> InjectionPosition.AT_DEPTH    // @Depth 模式
+        else -> InjectionPosition.AFTER_SYSTEM_PROMPT
+    }
+}
+
+private fun mapSillyTavernPositionString(position: String): InjectionPosition? {
+    return when (position.trim().lowercase()) {
+        "before_char" -> InjectionPosition.BEFORE_SYSTEM_PROMPT
+        "after_char" -> InjectionPosition.AFTER_SYSTEM_PROMPT
+        "before_system_prompt" -> InjectionPosition.BEFORE_SYSTEM_PROMPT
+        "after_system_prompt" -> InjectionPosition.AFTER_SYSTEM_PROMPT
+        "top_of_chat" -> InjectionPosition.TOP_OF_CHAT
+        "bottom_of_chat" -> InjectionPosition.BOTTOM_OF_CHAT
+        "at_depth" -> InjectionPosition.AT_DEPTH
+        else -> null
+    }
+}
+
 // endregion
 
 private suspend fun importAssistantFromUri(
     context: Context,
     uri: Uri,
-    onImport: (Assistant) -> Unit,
+    onImport: (Assistant, List<Lorebook>) -> Unit,
     toaster: ToasterState,
     filesManager: FilesManager,
 ) {
@@ -280,7 +455,13 @@ private suspend fun importAssistantFromUri(
         }
         val json = Json.parseToJsonElement(jsonString).jsonObject
         val assistant = parseAssistantFromJson(context = context, json = json, background = backgroundStr)
-        onImport(assistant)
+        val importedLorebooks = parseLorebooksFromTavernCard(json = json, assistantName = assistant.name)
+        val updatedAssistant = if (importedLorebooks.isNotEmpty()) {
+            assistant.copy(lorebookIds = assistant.lorebookIds + importedLorebooks.map { it.id })
+        } else {
+            assistant
+        }
+        onImport(updatedAssistant, importedLorebooks)
     } catch (exception: Exception) {
         exception.printStackTrace()
         toaster.show(

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/assistant/detail/AssistantImporter.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/assistant/detail/AssistantImporter.kt
@@ -258,6 +258,7 @@ internal fun parseLorebooksFromTavernCard(
     json: JsonObject,
     assistantName: String,
 ): List<Lorebook> {
+    // 尝试从酒馆角色卡解析世界书，解析失败直接忽略
     return runCatching {
         val data = json["data"]?.jsonObject ?: return emptyList()
         val candidates = buildLorebookCandidates(data)
@@ -269,6 +270,7 @@ internal fun parseLorebooksFromTavernCard(
 }
 
 private fun buildLorebookCandidates(data: JsonObject): List<kotlinx.serialization.json.JsonElement> {
+    // 兼容不同字段名，也兼容 extensions 里的嵌套结构
     val keys = listOf("character_book", "characterBook", "worldbook", "lorebook")
     val candidates = buildList {
         keys.forEach { key ->
@@ -311,6 +313,7 @@ private fun parseLorebookFromBookElement(
 }
 
 private fun parseLorebookEntries(entriesElement: kotlinx.serialization.json.JsonElement): List<PromptInjection.RegexInjection> {
+    // entries 可能是对象映射，也可能是数组
     val entryObjects = when (entriesElement) {
         is JsonObject -> entriesElement.values.mapNotNull { it as? JsonObject }
         is JsonArray -> entriesElement.mapNotNull { it as? JsonObject }
@@ -398,6 +401,7 @@ private fun parseLorebookEntryKeywords(entry: JsonObject): List<String> {
 }
 
 private fun mapSillyTavernPosition(position: Int): InjectionPosition {
+    // 酒馆 position 映射为注入位置
     return when (position) {
         0 -> InjectionPosition.BEFORE_SYSTEM_PROMPT
         1 -> InjectionPosition.AFTER_SYSTEM_PROMPT
@@ -456,6 +460,7 @@ private suspend fun importAssistantFromUri(
         val json = Json.parseToJsonElement(jsonString).jsonObject
         val assistant = parseAssistantFromJson(context = context, json = json, background = backgroundStr)
         val importedLorebooks = parseLorebooksFromTavernCard(json = json, assistantName = assistant.name)
+        // 如果解析到世界书，同时把 id 绑定到 assistant 并回传给上层写入
         val updatedAssistant = if (importedLorebooks.isNotEmpty()) {
             assistant.copy(lorebookIds = assistant.lorebookIds + importedLorebooks.map { it.id })
         } else {

--- a/app/src/test/java/me/rerere/rikkahub/ui/pages/assistant/detail/TavernLorebookParseTest.kt
+++ b/app/src/test/java/me/rerere/rikkahub/ui/pages/assistant/detail/TavernLorebookParseTest.kt
@@ -8,6 +8,7 @@ import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
+// 覆盖酒馆世界书的常见格式与兼容字段解析
 class TavernLorebookParseTest {
 
     private fun parseLorebooks(jsonString: String, assistantName: String = "Test"): List<me.rerere.rikkahub.data.model.Lorebook> {

--- a/app/src/test/java/me/rerere/rikkahub/ui/pages/assistant/detail/TavernLorebookParseTest.kt
+++ b/app/src/test/java/me/rerere/rikkahub/ui/pages/assistant/detail/TavernLorebookParseTest.kt
@@ -1,0 +1,227 @@
+package me.rerere.rikkahub.ui.pages.assistant.detail
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+import me.rerere.rikkahub.data.model.InjectionPosition
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class TavernLorebookParseTest {
+
+    private fun parseLorebooks(jsonString: String, assistantName: String = "Test"): List<me.rerere.rikkahub.data.model.Lorebook> {
+        val json = Json.parseToJsonElement(jsonString).jsonObject
+        return parseLorebooksFromTavernCard(json = json, assistantName = assistantName)
+    }
+
+    @Test
+    fun `character_book entries as object map should be imported`() {
+        val lorebooks = parseLorebooks(
+            jsonString = """
+            {
+              "data": {
+                "character_book": {
+                  "name": "Alice WB",
+                  "entries": {
+                    "1": {
+                      "key": ["foo", "bar"],
+                      "content": "hello",
+                      "comment": "c1",
+                      "constant": true,
+                      "position": 1,
+                      "order": 42,
+                      "disable": false,
+                      "depth": 2,
+                      "scanDepth": 3,
+                      "caseSensitive": true
+                    }
+                  }
+                }
+              }
+            }
+            """.trimIndent(),
+            assistantName = "Alice"
+        )
+
+        assertEquals(1, lorebooks.size)
+        val book = lorebooks[0]
+        assertEquals("Alice WB", book.name)
+        assertEquals(1, book.entries.size)
+
+        val entry = book.entries[0]
+        assertEquals("c1", entry.name)
+        assertEquals(listOf("foo", "bar"), entry.keywords)
+        assertEquals("hello", entry.content)
+        assertTrue(entry.enabled)
+        assertTrue(entry.constantActive)
+        assertEquals(42, entry.priority)
+        assertEquals(InjectionPosition.AFTER_SYSTEM_PROMPT, entry.position)
+        assertEquals(2, entry.injectDepth)
+        assertEquals(3, entry.scanDepth)
+        assertTrue(entry.caseSensitive)
+        assertFalse(entry.useRegex)
+    }
+
+    @Test
+    fun `character_book entries as array should be imported`() {
+        val lorebooks = parseLorebooks(
+            jsonString = """
+            {
+              "data": {
+                "character_book": {
+                  "entries": [
+                    {
+                      "keys": "trigger",
+                      "content": "x",
+                      "position": 0,
+                      "order": 1
+                    }
+                  ]
+                }
+              }
+            }
+            """.trimIndent(),
+            assistantName = "Alice"
+        )
+
+        assertEquals(1, lorebooks.size)
+        val book = lorebooks[0]
+        assertEquals("Alice Lorebook", book.name)
+        assertEquals(1, book.entries.size)
+
+        val entry = book.entries[0]
+        assertEquals("trigger", entry.name)
+        assertEquals(listOf("trigger"), entry.keywords)
+        assertEquals("x", entry.content)
+        assertEquals(InjectionPosition.BEFORE_SYSTEM_PROMPT, entry.position)
+        assertEquals(1, entry.priority)
+    }
+
+    @Test
+    fun `compat fields should be accepted`() {
+        val lorebooks = parseLorebooks(
+            jsonString = """
+            {
+              "data": {
+                "character_book": {
+                  "entries": [
+                    {
+                      "key": "abc",
+                      "scan_depth": 5,
+                      "case_sensitive": true,
+                      "enabled": false
+                    }
+                  ]
+                }
+              }
+            }
+            """.trimIndent()
+        )
+
+        assertEquals(1, lorebooks.size)
+        val entry = lorebooks[0].entries.single()
+        assertEquals(listOf("abc"), entry.keywords)
+        assertEquals(5, entry.scanDepth)
+        assertTrue(entry.caseSensitive)
+        assertFalse(entry.enabled)
+    }
+
+    @Test
+    fun `missing worldbook config should return empty list`() {
+        val lorebooks = parseLorebooks(
+            jsonString = """
+            {
+              "data": {
+                "name": "Alice"
+              }
+            }
+            """.trimIndent()
+        )
+
+        assertTrue(lorebooks.isEmpty())
+    }
+
+    @Test
+    fun `disable should take precedence over enabled`() {
+        val lorebooks = parseLorebooks(
+            jsonString = """
+            {
+              "data": {
+                "character_book": {
+                  "entries": [
+                    {
+                      "key": "a",
+                      "disable": true,
+                      "enabled": true
+                    }
+                  ]
+                }
+              }
+            }
+            """.trimIndent()
+        )
+
+        assertEquals(1, lorebooks.size)
+        val entry = lorebooks[0].entries.single()
+        assertFalse(entry.enabled)
+    }
+
+    @Test
+    fun `insertion_order should be used as priority fallback`() {
+        val lorebooks = parseLorebooks(
+            jsonString = """
+            {
+              "data": {
+                "character_book": {
+                  "entries": [
+                    {
+                      "keys": ["k"],
+                      "content": "x",
+                      "insertion_order": 777
+                    }
+                  ]
+                }
+              }
+            }
+            """.trimIndent()
+        )
+
+        assertEquals(1, lorebooks.size)
+        val entry = lorebooks[0].entries.single()
+        assertEquals(777, entry.priority)
+    }
+
+    @Test
+    fun `extensions fields should be used as fallback`() {
+        val lorebooks = parseLorebooks(
+            jsonString = """
+            {
+              "data": {
+                "character_book": {
+                  "entries": [
+                    {
+                      "keys": ["k"],
+                      "content": "x",
+                      "position": "before_char",
+                      "extensions": {
+                        "depth": 2,
+                        "scan_depth": 9,
+                        "case_sensitive": true
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+            """.trimIndent()
+        )
+
+        assertEquals(1, lorebooks.size)
+        val entry = lorebooks[0].entries.single()
+        assertEquals(InjectionPosition.BEFORE_SYSTEM_PROMPT, entry.position)
+        assertEquals(2, entry.injectDepth)
+        assertEquals(9, entry.scanDepth)
+        assertTrue(entry.caseSensitive)
+    }
+}


### PR DESCRIPTION
Fixes #800

### 说明
导入 SillyTavern/Tavern 角色卡（PNG/JSON）创建 Assistant 时，如果角色卡 `chara` JSON 中包含世界书（Lorebook/Worldbook）配置，则自动导入并一键绑定到该 Assistant。
- 导入时解析角色卡中的世界书配置（优先 `data.character_book`，并兼容 `characterBook/worldbook/lorebook` 以及 `data.extensions.*`）
- 自动创建 `Lorebook` 并追加写入 `Settings.lorebooks`
- 新导入的 Assistant 自动绑定：`assistant.lorebookIds += lorebook.id`
- `Assistant + Lorebook` 通过一次 `SettingsStore.update { ... }` 原子写入，避免并发覆盖导致的覆盖/丢失

### 兼容
- `entries` 支持 map/object 与 array/list
- entry 字段兼容：`key/keys`、`order/priority/insertion_order`、`scanDepth/scan_depth`、`caseSensitive/case_sensitive`、`disable/enabled`
- `position` 支持 int 与字符串（`before_char`/`after_char`/`top_of_chat`/`bottom_of_chat`/`at_depth`），并兼容 `extensions.position`

### 测试
- 单元测试：`TavernLorebookParseTest`
- Workflow
  https://github.com/jacob-sheng/rikkahub-dev/actions/runs/22438103117
  Artifact：`issue-800-screenshots`（两张截图分别覆盖
设置 → Prompt Injection → Lorebook
Assistant → Prompt Injections → Lorebooks）


