### PR TITLE
fix(mcp): 修改 SseClientTransport 清理流程避免出现死锁导致资源释放异常

### DIFF
--- a/app/src/main/java/me/rerere/rikkahub/data/ai/mcp/transport/SseClientTransport.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/ai/mcp/transport/SseClientTransport.kt
@@ -187,7 +187,7 @@ class SseClientTransport(
     private suspend fun closeResources() {
         if (!initialized.compareAndSet(expectedValue = true, newValue = false)) return
 
-        job?.cancelAndJoin()
+        job?.cancel()
         try {
             if (::session.isInitialized) session.cancel()
             if (::scope.isInitialized) scope.cancel()


### PR DESCRIPTION
### 问题

`SseClientTransport` 在资源释放过程中存在死锁问题，导致后续 `send` 调用异常（`client.transport` 不为 `null`，`initialized` 为 `false` 但资源未被正确清理）。

复现与原因分析：

1. 在 `start()` 中启动协程，并将引用赋值给 `job`：
   ```kotlin
   job = scope.launch { collectMessages() }
   ```

2. 在 `collectMessages()` 内部，通过 `try...finally` 在消息收集结束或发生异常时执行资源清理：

   ```kotlin
   finally { closeResources() }
   ```

3. 在 `closeResources()` 中调用了 `job?.cancelAndJoin()`。由于该方法可能在 `job` 自身的协程上下文中执行，导致协程等待自身结束，从而发生挂起，形成死锁，后续清理流程无法继续执行：

   ```kotlin
   private suspend fun closeResources() {
       if (!initialized.compareAndSet(expectedValue = true, newValue = false)) return

       job?.cancelAndJoin()
       try {
           if (::session.isInitialized) session.cancel()
           if (::scope.isInitialized) scope.cancel()
           endpoint.cancel()
       } catch (e: Throwable) {
           _onError(e)
       }

       _onClose()
   }
   ```

### 解决方案

将 `job?.cancelAndJoin()` 修改为 `job?.cancel()`，避免协程自我等待导致的死锁问题。

重复释放问题由 `initialized.compareAndSet(true, false)` 保证不会发生。

### 测试

* 编译环境：github actions，基于 master 分支`ebb05f3096ce0f14a50ce39572c8977340573647`改动
* 设备：vivo X300 Pro (V2509A), Android 16
* 方法：调用 MCP 服务过程中反复断开网络连接
* 结果：网络恢复后均可正常重新访问 MCP 服务，无异常或卡死现象

close #730

