### PR TITLE
feat(mcp): 支持从 JSON 导入 MCP Server 配置

### DIFF
--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -888,5 +888,10 @@ mDNSアドレス: .localホスト名を使用し、IPを知らなくても同じ
   <string name="error_title_compress_conversation">会話の圧縮に失敗しました</string>
   <string name="error_title_operation">操作に失敗しました</string>
   <string name="setting_provider_page_claude_prompt_caching">プロンプトキャッシュ（cache_control）</string>
+  <string name="setting_mcp_page_import_title">MCPサーバーをインポート</string>
+  <string name="setting_mcp_page_import_desc">MCPサーバーJSON設定を貼り付けます。標準のmcpServers形式に対応</string>
+  <string name="setting_mcp_page_import_no_valid_config">有効なMCPサーバー設定が見つかりません</string>
+  <string name="setting_mcp_page_import_parse_error">JSON解析に失敗しました: %1$s</string>
+  <string name="setting_mcp_page_import_confirm">インポート</string>
 </resources>
 

--- a/app/src/main/res/values-ko-rKR/strings.xml
+++ b/app/src/main/res/values-ko-rKR/strings.xml
@@ -888,5 +888,10 @@ mDNS 주소: .local 호스트네임을 사용하며, IP를 몰라도 같은 네�
   <string name="error_title_compress_conversation">대화 압축 실패</string>
   <string name="error_title_operation">작업 실패</string>
   <string name="setting_provider_page_claude_prompt_caching">프롬프트 캐싱 (cache_control)</string>
+  <string name="setting_mcp_page_import_title">MCP 서버 가져오기</string>
+  <string name="setting_mcp_page_import_desc">MCP 서버 JSON 구성을 붙여넣으세요. 표준 mcpServers 형식을 지원합니다</string>
+  <string name="setting_mcp_page_import_no_valid_config">유효한 MCP 서버 구성을 찾을 수 없습니다</string>
+  <string name="setting_mcp_page_import_parse_error">JSON 파싱 실패: %1$s</string>
+  <string name="setting_mcp_page_import_confirm">가져오기</string>
 </resources>
 

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -881,5 +881,10 @@
   <string name="error_title_compress_conversation">Сжатие переписки не удалось</string>
   <string name="error_title_operation">Операция не выполнена</string>
   <string name="setting_provider_page_claude_prompt_caching">Кэширование промптов (cache_control)</string>
+  <string name="setting_mcp_page_import_title">Импортировать сервер MCP</string>
+  <string name="setting_mcp_page_import_desc">Вставьте JSON-конфигурацию MCP-сервера, поддерживается стандартный формат mcpServers</string>
+  <string name="setting_mcp_page_import_no_valid_config">Не найдена допустимая конфигурация сервера MCP</string>
+  <string name="setting_mcp_page_import_parse_error">Ошибка разбора JSON: %1$s</string>
+  <string name="setting_mcp_page_import_confirm">Импорт</string>
 </resources>
 

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -886,5 +886,10 @@
   <string name="error_title_compress_conversation">對話壓縮失敗</string>
   <string name="error_title_operation">操作失敗</string>
   <string name="setting_provider_page_claude_prompt_caching">提示快取 (cache_control)</string>
+  <string name="setting_mcp_page_import_title">匯入 MCP Server</string>
+  <string name="setting_mcp_page_import_desc">貼上 MCP Server JSON 設定，支援標準 mcpServers 格式</string>
+  <string name="setting_mcp_page_import_no_valid_config">未找到有效的 MCP Server 配置</string>
+  <string name="setting_mcp_page_import_parse_error">JSON 解析失敗：%1$s</string>
+  <string name="setting_mcp_page_import_confirm">匯入</string>
 </resources>
 

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -888,5 +888,10 @@ mDNS 地址：使用 .local 主机名，同一网络中的其他设备可通过�
   <string name="error_title_compress_conversation">对话压缩失败</string>
   <string name="error_title_operation">操作失败</string>
   <string name="setting_provider_page_claude_prompt_caching">提示缓存 (cache_control)</string>
+  <string name="setting_mcp_page_import_title">导入MCP服务器</string>
+  <string name="setting_mcp_page_import_desc">粘贴 MCP 服务器 JSON 配置，支持标准 mcpServers 格式</string>
+  <string name="setting_mcp_page_import_no_valid_config">未找到有效的 MCP Server 配置</string>
+  <string name="setting_mcp_page_import_parse_error">JSON 解析失败：%1$s</string>
+  <string name="setting_mcp_page_import_confirm">导入</string>
 </resources>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -886,5 +886,10 @@
   <string name="error_title_translate_message">Message translation failed</string>
   <string name="error_title_compress_conversation">Conversation compression failed</string>
   <string name="error_title_operation">Operation failed</string>
+  <string name="setting_mcp_page_import_title">Import MCP Server</string>
+  <string name="setting_mcp_page_import_desc">Paste MCP Server JSON config, supports standard mcpServers format</string>
+  <string name="setting_mcp_page_import_no_valid_config">No valid MCP Server configuration found</string>
+  <string name="setting_mcp_page_import_parse_error">JSON parse failed: %1$s</string>
+  <string name="setting_mcp_page_import_confirm">Import</string>
 </resources>
 


### PR DESCRIPTION
## Summary

- 在 MCP 设置页 TopAppBar 添加导入按钮（Import 图标）
- 点击后弹出底部弹窗，用户可粘贴标准 `mcpServers` JSON 配置
- 解析逻辑支持 `streamable_http` 和 `sse` 两种传输类型，自动提取 `url`、`headers`
- 按 name 去重，已存在同名 Server 不会被重复导入
- 解析失败时展示错误提示信息
- 多语言本地化（简中/繁中/日语/韩语/俄语）

## Test plan

- [ ] 粘贴合法 JSON（含 streamable_http 类型）验证导入成功
- [ ] 粘贴含 sse 类型的 JSON 验证类型正确
- [ ] 粘贴含 headers 的 JSON 验证请求头正确导入
- [ ] 粘贴非法 JSON 验证错误提示显示
- [ ] 重复导入同名 Server 验证去重逻辑
- [ ] 切换语言验证多语言显示正常

Closes #874