### PR TITLE
fix: 修复谷歌模型内置搜索和 URL 获取

### DIFF
--- a/ai/src/main/java/me/rerere/ai/provider/providers/GoogleProvider.kt
+++ b/ai/src/main/java/me/rerere/ai/provider/providers/GoogleProvider.kt
@@ -442,13 +442,13 @@ class GoogleProvider(private val client: OkHttpClient) : Provider<ProviderSettin
                     when (builtInTool) {
                         BuiltInTools.Search -> {
                             add(buildJsonObject {
-                                put("google_search", buildJsonObject {})
+                                put("googleSearch", buildJsonObject {})
                             })
                         }
 
                         BuiltInTools.UrlContext -> {
                             add(buildJsonObject {
-                                put("url_context", buildJsonObject {})
+                                put("urlContext", buildJsonObject {})
                             })
                         }
                     }


### PR DESCRIPTION
根据 [Google 文档](https://ai.google.dev/api/caching#Tool)，google search 工具 key 名为 `googleSearch` ， url context 工具 key 名为 `urlContext` 。

[Google 自己的样例文档](https://ai.google.dev/gemini-api/docs/google-search#rest)中所演示的 `google_search` 疑似拼写错误。

修改后， gemini 模型可以正确启用模型内置搜索。