### PR TITLE
fix(web): 上传前规范化文本文件 MIME 类型

### DIFF
--- a/web-ui/app/components/input/chat-input.tsx
+++ b/web-ui/app/components/input/chat-input.tsx
@@ -60,12 +60,63 @@ export interface ChatInputProps {
 
 const IMAGE_UPLOAD_ACCEPT = "image/*";
 
-async function isAllowedUploadFile(file: globalThis.File): Promise<boolean> {
+type UploadFileInspection = {
+  allowed: boolean;
+  normalizedMime: string | null;
+};
+
+function isLikelyTextContent(sample: Uint8Array): boolean {
+  if (sample.length === 0) return false;
+  let printable = 0;
+
+  for (const value of sample) {
+    if (
+      value === 0x09 ||
+      value === 0x0a ||
+      value === 0x0d ||
+      (value >= 0x20 && value <= 0x7e)
+    ) {
+      printable += 1;
+    }
+  }
+
+  return printable / sample.length >= 0.8;
+}
+
+function normalizeUploadFileType(
+  file: globalThis.File,
+  mime: string | null,
+): globalThis.File {
+  if (!mime || file.type === mime) {
+    return file;
+  }
+
+  return new globalThis.File([file], file.name, {
+    type: mime,
+    lastModified: file.lastModified,
+  });
+}
+
+async function inspectUploadFile(
+  file: globalThis.File,
+): Promise<UploadFileInspection> {
   const buffer = await file.slice(0, 4100).arrayBuffer();
   const detected = await fileTypeFromBuffer(buffer);
 
   // 无法识别 magic bytes → 文本文件 → 允许
-  if (!detected) return true;
+  if (!detected) {
+    if (isLikelyTextContent(new Uint8Array(buffer))) {
+      return {
+        allowed: true,
+        normalizedMime: "text/plain",
+      };
+    }
+
+    return {
+      allowed: true,
+      normalizedMime: file.type || null,
+    };
+  }
 
   // 识别为图片 / 视频 / 音频 → 允许
   if (
@@ -73,11 +124,17 @@ async function isAllowedUploadFile(file: globalThis.File): Promise<boolean> {
     detected.mime.startsWith("video/") ||
     detected.mime.startsWith("audio/")
   ) {
-    return true;
+    return {
+      allowed: true,
+      normalizedMime: detected.mime,
+    };
   }
 
   // 其他可识别的二进制格式（exe、zip 等）→ 拒绝
-  return false;
+  return {
+    allowed: false,
+    normalizedMime: null,
+  };
 }
 
 function toMessagePart(
@@ -248,9 +305,14 @@ function ChatInputInner({
 
       const allFiles = Array.from(fileList);
       const results = await Promise.all(
-        allFiles.map(async (f) => ({ file: f, allowed: await isAllowedUploadFile(f) })),
+        allFiles.map(async (f) => ({
+          file: f,
+          ...(await inspectUploadFile(f)),
+        })),
       );
-      const uploadableFiles = results.filter((r) => r.allowed).map((r) => r.file);
+      const uploadableFiles = results
+        .filter((r) => r.allowed)
+        .map((r) => normalizeUploadFileType(r.file, r.normalizedMime));
       const skippedFiles = results.filter((r) => !r.allowed).map((r) => r.file);
 
       if (skippedFiles.length > 0) {
@@ -409,11 +471,14 @@ function ChatInputInner({
             .filter((item) => item.kind === "file")
             .map((item) => item.getAsFile())
             .filter((file): file is globalThis.File => file !== null)
-            .map(async (file) => ({ file, allowed: await isAllowedUploadFile(file) })),
+            .map(async (file) => ({
+              file,
+              ...(await inspectUploadFile(file)),
+            })),
         )
       )
         .filter((r) => r.allowed)
-        .map((r) => r.file);
+        .map((r) => normalizeUploadFileType(r.file, r.normalizedMime));
 
       if (uploadableFiles.length === 0) {
         return;


### PR DESCRIPTION
## 摘要

- 在构建 `FormData` 之前规范化类似文本文件的上传 MIME 类型
- 保留通过 `file-type` 检测得到的图片/视频/音频的二进制媒体 MIME 类型
- 保留现有的上传允许/拒绝行为，同时避免浏览器 `.ts` 文件的 MIME 类型歧义（`video/vnd.dlna.mpeg-tts`）

## 原因

某些浏览器在 multipart 上传中可能会将 TypeScript 源文件（`.ts`）报告为 MPEG-TS 视频 MIME 类型，这会导致 Web UI 将服务器响应的 MIME 类型视为视频。

此更改在前端应用基于内容的文本启发式检测，并在上传前将类似文本文件的 MIME 类型重写为 `text/plain`。

<img width="1821" height="1088" alt="image" src="https://github.com/user-attachments/assets/96ae0237-cd42-46c1-baa3-463f36470220" />

## 验证
- 上传 `routes.ts`（TypeScript 源文件）：识别为文档
- 上传真实的 MPEG-TS 文件（`tmp-video.ts`）：识别为视频
Closes #933