### PR TITLE
fix(ai): 修复 Claude 流式 MCP 工具参数 JSON 拼接错误

### DIFF
--- a/ai/src/main/java/me/rerere/ai/provider/providers/ClaudeProvider.kt
+++ b/ai/src/main/java/me/rerere/ai/provider/providers/ClaudeProvider.kt
@@ -147,6 +147,8 @@ class ClaudeProvider(private val client: OkHttpClient) : Provider<ProviderSettin
         messages: List<UIMessage>,
         params: TextGenerationParams
     ): Flow<MessageChunk> = callbackFlow {
+        // 按 content block 记住当前流式上下文
+        val streamAccumulator = ClaudeStreamEventAccumulator()
         val requestBody = buildMessageRequest(providerSetting, messages, params, stream = true)
         val request = Request.Builder()
             .url("${providerSetting.baseUrl}/messages")
@@ -177,16 +179,10 @@ class ClaudeProvider(private val client: OkHttpClient) : Provider<ProviderSettin
                 }
 
                 val dataJson = json.parseToJsonElement(data).jsonObject
-                val deltaMessage = parseMessage(buildJsonArray {
-                    val contentBlockObj = dataJson["content_block"]?.jsonObject
-                    val deltaObj = dataJson["delta"]?.jsonObject
-                    if (contentBlockObj != null) {
-                        add(contentBlockObj)
-                    }
-                    if (deltaObj != null) {
-                        add(deltaObj)
-                    }
-                })
+                val deltaMessage = streamAccumulator.parseEvent(
+                    eventType = type ?: dataJson["type"]?.jsonPrimitive?.contentOrNull,
+                    dataJson = dataJson
+                )
                 val tokenUsage = parseTokenUsage(dataJson)
                 val messageChunk = MessageChunk(
                     id = id ?: "",
@@ -480,74 +476,9 @@ class ClaudeProvider(private val client: OkHttpClient) : Provider<ProviderSettin
     }
 
     private fun parseMessage(content: JsonArray): UIMessage {
-        val parts = mutableListOf<UIMessagePart>()
-
-        content.forEach { contentBlock ->
-            val block = contentBlock.jsonObject
-            val type = block["type"]?.jsonPrimitive?.contentOrNull
-
-            when (type) {
-                "text", "text_delta" -> {
-                    val text = block["text"]?.jsonPrimitive?.contentOrNull ?: ""
-                    if (text.isNotEmpty()) {
-                        parts.add(UIMessagePart.Text(text))
-                    }
-                }
-
-                "thinking", "thinking_delta", "signature_delta" -> {
-                    val thinking = block["thinking"]?.jsonPrimitive?.contentOrNull ?: ""
-                    val signature = block["signature"]?.jsonPrimitive?.contentOrNull
-                    if (thinking.isNotEmpty() || signature != null) {
-                        val reasoning = UIMessagePart.Reasoning(
-                            reasoning = thinking,
-                            createdAt = Clock.System.now(),
-                            finishedAt = null
-                        )
-                        if (signature != null) {
-                            reasoning.metadata = buildJsonObject {
-                                put("signature", signature)
-                            }
-                        }
-                        parts.add(reasoning)
-                    }
-                }
-
-                "redacted_thinking" -> {
-                    val data = block["data"]?.jsonPrimitiveOrNull?.contentOrNull
-                    println(data)
-                }
-
-                "tool_use" -> {
-                    val id = block["id"]?.jsonPrimitive?.contentOrNull ?: ""
-                    val name = block["name"]?.jsonPrimitive?.contentOrNull ?: ""
-                    val input = block["input"]?.jsonObject ?: JsonObject(emptyMap())
-                    parts.add(
-                        UIMessagePart.Tool(
-                            toolCallId = id,
-                            toolName = name,
-                            input = if (input.isEmpty()) "" else json.encodeToString(input),
-                            output = emptyList()
-                        )
-                    )
-                }
-
-                "input_json_delta" -> {
-                    val input = block["partial_json"]?.jsonPrimitive?.contentOrNull
-                    parts.add(
-                        UIMessagePart.Tool(
-                            toolCallId = "",
-                            toolName = "",
-                            input = input ?: "",
-                            output = emptyList()
-                        )
-                    )
-                }
-            }
-        }
-
         return UIMessage(
             role = MessageRole.ASSISTANT,
-            parts = parts
+            parts = content.mapNotNull { parseClaudeContentBlock(it.jsonObject) }
         )
     }
 
@@ -569,5 +500,137 @@ class ClaudeProvider(private val client: OkHttpClient) : Provider<ProviderSettin
             totalTokens = promptTokens + completionTokens,
             cachedTokens = cachedInputTokens,
         )
+    }
+}
+
+internal data class ClaudeStreamToolContext(
+    val toolCallId: String,
+    val toolName: String,
+)
+
+internal data class ClaudeStreamContentBlockContext(
+    val type: String,
+    val toolContext: ClaudeStreamToolContext? = null,
+)
+
+internal class ClaudeStreamEventAccumulator {
+    private val contentBlockContexts = mutableMapOf<Int, ClaudeStreamContentBlockContext>()
+
+    fun parseEvent(eventType: String?, dataJson: JsonObject): UIMessage {
+        val parts = when (eventType) {
+            "content_block_start" -> {
+                val contentBlock = dataJson["content_block"]?.jsonObject
+                if (contentBlock != null) {
+                    // 用 index 绑定后续 delta 到同一个 block
+                    dataJson["index"]?.jsonPrimitive?.intOrNull?.let { index ->
+                        contentBlockContexts[index] = contentBlock.toContentBlockContext()
+                    }
+                    listOfNotNull(parseClaudeContentBlock(contentBlock))
+                } else {
+                    emptyList()
+                }
+            }
+
+            "content_block_delta" -> {
+                val delta = dataJson["delta"]?.jsonObject
+                val context = dataJson["index"]?.jsonPrimitive?.intOrNull?.let(contentBlockContexts::get)
+                if (delta != null) {
+                    listOfNotNull(parseClaudeContentBlock(delta, context?.toolContext))
+                } else {
+                    emptyList()
+                }
+            }
+
+            "content_block_stop" -> {
+                // block 结束后立刻清理上下文
+                dataJson["index"]?.jsonPrimitive?.intOrNull?.let(contentBlockContexts::remove)
+                emptyList()
+            }
+
+            else -> emptyList()
+        }
+        return UIMessage(role = MessageRole.ASSISTANT, parts = parts)
+    }
+
+    private fun JsonObject.toContentBlockContext(): ClaudeStreamContentBlockContext {
+        val type = this["type"]?.jsonPrimitive?.contentOrNull.orEmpty()
+        val toolContext = if (type == "tool_use") {
+            ClaudeStreamToolContext(
+                toolCallId = this["id"]?.jsonPrimitive?.contentOrNull.orEmpty(),
+                toolName = this["name"]?.jsonPrimitive?.contentOrNull.orEmpty(),
+            )
+        } else {
+            null
+        }
+        return ClaudeStreamContentBlockContext(type = type, toolContext = toolContext)
+    }
+}
+
+private fun parseClaudeContentBlock(
+    block: JsonObject,
+    toolContext: ClaudeStreamToolContext? = null
+): UIMessagePart? {
+    val type = block["type"]?.jsonPrimitive?.contentOrNull
+
+    return when (type) {
+        "text", "text_delta" -> {
+            val text = block["text"]?.jsonPrimitive?.contentOrNull ?: ""
+            if (text.isNotEmpty()) {
+                UIMessagePart.Text(text)
+            } else {
+                null
+            }
+        }
+
+        "thinking", "thinking_delta", "signature_delta" -> {
+            val thinking = block["thinking"]?.jsonPrimitive?.contentOrNull ?: ""
+            val signature = block["signature"]?.jsonPrimitive?.contentOrNull
+            if (thinking.isNotEmpty() || signature != null) {
+                val reasoning = UIMessagePart.Reasoning(
+                    reasoning = thinking,
+                    createdAt = Clock.System.now(),
+                    finishedAt = null
+                )
+                if (signature != null) {
+                    reasoning.metadata = buildJsonObject {
+                        put("signature", signature)
+                    }
+                }
+                reasoning
+            } else {
+                null
+            }
+        }
+
+        "redacted_thinking" -> {
+            val data = block["data"]?.jsonPrimitiveOrNull?.contentOrNull
+            println(data)
+            null
+        }
+
+        "tool_use" -> {
+            val id = block["id"]?.jsonPrimitive?.contentOrNull ?: ""
+            val name = block["name"]?.jsonPrimitive?.contentOrNull ?: ""
+            val input = block["input"]?.jsonObject ?: JsonObject(emptyMap())
+            UIMessagePart.Tool(
+                toolCallId = id,
+                toolName = name,
+                input = if (input.isEmpty()) "" else json.encodeToString(input),
+                output = emptyList()
+            )
+        }
+
+        "input_json_delta" -> {
+            val input = block["partial_json"]?.jsonPrimitive?.contentOrNull ?: return null
+            UIMessagePart.Tool(
+                // 这里只继续追加参数片段 名字保留给 start 事件
+                toolCallId = toolContext?.toolCallId.orEmpty(),
+                toolName = "",
+                input = input,
+                output = emptyList()
+            )
+        }
+
+        else -> null
     }
 }

--- a/ai/src/main/java/me/rerere/ai/ui/Message.kt
+++ b/ai/src/main/java/me/rerere/ai/ui/Message.kt
@@ -93,8 +93,10 @@ data class UIMessage(
 
                     is UIMessagePart.Tool -> {
                         if (deltaPart.toolCallId.isBlank()) {
-                            // No ID yet - append to the last Tool if it also has no ID
-                            val lastTool = acc.lastOrNull { it is UIMessagePart.Tool } as? UIMessagePart.Tool
+                            // 空 id 只允许并到还没执行的匿名 tool
+                            val lastTool = acc.lastOrNull {
+                                it is UIMessagePart.Tool && !it.isExecuted && it.toolCallId.isBlank()
+                            } as? UIMessagePart.Tool
                             if (lastTool != null) {
                                 acc.map { part ->
                                     if (part === lastTool) part.merge(deltaPart) else part
@@ -103,7 +105,7 @@ data class UIMessage(
                                 acc + deltaPart.copy()
                             }
                         } else {
-                            // Has ID - find and update by ID, or insert new
+                            // 有 id 时始终按 id 归并
                             val existsPart = acc.find {
                                 it is UIMessagePart.Tool && it.toolCallId == deltaPart.toolCallId
                             } as? UIMessagePart.Tool

--- a/ai/src/test/java/me/rerere/ai/provider/providers/ClaudeProviderMessageTest.kt
+++ b/ai/src/test/java/me/rerere/ai/provider/providers/ClaudeProviderMessageTest.kt
@@ -36,10 +36,11 @@ class ClaudeProviderMessageTest {
     private fun invokeBuildMessages(messages: List<UIMessage>): JsonArray {
         val method = ClaudeProvider::class.java.getDeclaredMethod(
             "buildMessages",
-            List::class.java
+            List::class.java,
+            Boolean::class.javaPrimitiveType!!
         )
         method.isAccessible = true
-        return method.invoke(provider, messages) as JsonArray
+        return method.invoke(provider, messages, false) as JsonArray
     }
 
     @Test

--- a/ai/src/test/java/me/rerere/ai/provider/providers/ClaudeProviderStreamAccumulatorTest.kt
+++ b/ai/src/test/java/me/rerere/ai/provider/providers/ClaudeProviderStreamAccumulatorTest.kt
@@ -1,0 +1,211 @@
+package me.rerere.ai.provider.providers
+
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+import me.rerere.ai.core.MessageRole
+import me.rerere.ai.ui.MessageChunk
+import me.rerere.ai.ui.UIMessage
+import me.rerere.ai.ui.UIMessageChoice
+import me.rerere.ai.ui.UIMessagePart
+import me.rerere.ai.ui.handleMessageChunk
+import me.rerere.ai.util.json
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ClaudeProviderStreamAccumulatorTest {
+
+    @Test
+    fun `input json delta should preserve escaped chars and unicode`() {
+        val fullInput = """{"path":"EN × LUNÉLYS.md","content":"\n\n---\n\n**2026-03-07 新加入的：*測試* \"Quote\""}"""
+        val quoteIndex = fullInput.indexOf("\"\\n\\n---")
+        val partials = listOf(
+            fullInput.substring(0, quoteIndex),
+            fullInput.substring(quoteIndex, quoteIndex + 5),
+            fullInput.substring(quoteIndex + 5)
+        )
+
+        val messages = processEvents(
+            initialMessages = listOf(UIMessage.user("Write the note")),
+            events = listOf(
+                "content_block_start" to contentBlockStart(
+                    index = 0,
+                    contentBlock = toolUseBlock(id = "call_1", name = "write-note")
+                ),
+                "content_block_delta" to contentBlockDelta(0, inputJsonDelta(partials[0])),
+                "content_block_delta" to contentBlockDelta(0, inputJsonDelta(partials[1])),
+                "content_block_delta" to contentBlockDelta(0, inputJsonDelta(partials[2])),
+                "content_block_stop" to contentBlockStop(0),
+            )
+        )
+
+        val tool = messages.last().getTools().single()
+        assertEquals("call_1", tool.toolCallId)
+        assertEquals("write-note", tool.toolName)
+        assertEquals(fullInput, tool.input)
+
+        val arguments = json.parseToJsonElement(tool.input).jsonObject
+        assertEquals("EN × LUNÉLYS.md", arguments["path"]?.jsonPrimitive?.content)
+        assertEquals("\n\n---\n\n**2026-03-07 新加入的：*測試* \"Quote\"", arguments["content"]?.jsonPrimitive?.content)
+    }
+
+    @Test
+    fun `new tool call should stay isolated from previously executed tool in same assistant message`() {
+        val previousTool = UIMessagePart.Tool(
+            toolCallId = "call_prev",
+            toolName = "append-to-section",
+            input = """{"path":"old.md","content":"old"}""",
+            output = listOf(UIMessagePart.Text("done"))
+        )
+        val newInput = """{"path":"fresh.md","content":"new"}"""
+        val messages = processEvents(
+            initialMessages = listOf(
+                UIMessage.user("Continue editing"),
+                UIMessage(
+                    role = MessageRole.ASSISTANT,
+                    parts = listOf(
+                        UIMessagePart.Text("Previous step"),
+                        previousTool
+                    )
+                )
+            ),
+            events = listOf(
+                "content_block_start" to contentBlockStart(
+                    index = 0,
+                    contentBlock = toolUseBlock(id = "call_new", name = "replace-section")
+                ),
+                "content_block_delta" to contentBlockDelta(0, inputJsonDelta(newInput.substring(0, 18))),
+                "content_block_delta" to contentBlockDelta(0, inputJsonDelta(newInput.substring(18))),
+                "content_block_stop" to contentBlockStop(0),
+            )
+        )
+
+        val tools = messages.last().getTools()
+        assertEquals(2, tools.size)
+        assertEquals("""{"path":"old.md","content":"old"}""", tools[0].input)
+        assertTrue(tools[0].isExecuted)
+        assertEquals("call_new", tools[1].toolCallId)
+        assertEquals(newInput, tools[1].input)
+    }
+
+    @Test
+    fun `mixed content blocks should preserve order and bind tool args by index`() {
+        val toolInput = """{"path":"notes.md","content":"hello"}"""
+        val messages = processEvents(
+            initialMessages = listOf(UIMessage.user("Plan and write")),
+            events = listOf(
+                "content_block_start" to contentBlockStart(
+                    index = 0,
+                    contentBlock = textBlock("")
+                ),
+                "content_block_delta" to contentBlockDelta(0, textDelta("Plan: ")),
+                "content_block_stop" to contentBlockStop(0),
+                "content_block_start" to contentBlockStart(
+                    index = 1,
+                    contentBlock = thinkingBlock("")
+                ),
+                "content_block_delta" to contentBlockDelta(1, thinkingDelta("需要先写入文件")),
+                "content_block_delta" to contentBlockDelta(1, signatureDelta("sig_1")),
+                "content_block_stop" to contentBlockStop(1),
+                "content_block_start" to contentBlockStart(
+                    index = 2,
+                    contentBlock = toolUseBlock(id = "call_mix", name = "write-note")
+                ),
+                "content_block_delta" to contentBlockDelta(2, inputJsonDelta(toolInput.substring(0, 20))),
+                "content_block_delta" to contentBlockDelta(2, inputJsonDelta(toolInput.substring(20))),
+                "content_block_stop" to contentBlockStop(2),
+            )
+        )
+
+        val parts = messages.last().parts
+        assertEquals(3, parts.size)
+        assertTrue(parts[0] is UIMessagePart.Text)
+        assertTrue(parts[1] is UIMessagePart.Reasoning)
+        assertTrue(parts[2] is UIMessagePart.Tool)
+        assertEquals("Plan: ", (parts[0] as UIMessagePart.Text).text)
+        assertEquals("需要先写入文件", (parts[1] as UIMessagePart.Reasoning).reasoning)
+        assertEquals("sig_1", (parts[1] as UIMessagePart.Reasoning).metadata?.get("signature")?.jsonPrimitive?.content)
+        assertEquals("call_mix", (parts[2] as UIMessagePart.Tool).toolCallId)
+        assertEquals(toolInput, (parts[2] as UIMessagePart.Tool).input)
+    }
+
+    private fun processEvents(
+        initialMessages: List<UIMessage>,
+        events: List<Pair<String, JsonObject>>
+    ): List<UIMessage> {
+        val accumulator = ClaudeStreamEventAccumulator()
+        var messages = initialMessages
+
+        events.forEach { (eventType, data) ->
+            val chunk = MessageChunk(
+                id = "msg_1",
+                model = "claude-test",
+                choices = listOf(
+                    UIMessageChoice(
+                        index = 0,
+                        delta = accumulator.parseEvent(eventType, data),
+                        message = null,
+                        finishReason = null
+                    )
+                )
+            )
+            messages = messages.handleMessageChunk(chunk)
+        }
+
+        return messages
+    }
+
+    private fun contentBlockStart(index: Int, contentBlock: JsonObject) = buildJsonObject {
+        put("index", index)
+        put("content_block", contentBlock)
+    }
+
+    private fun contentBlockDelta(index: Int, delta: JsonObject) = buildJsonObject {
+        put("index", index)
+        put("delta", delta)
+    }
+
+    private fun contentBlockStop(index: Int) = buildJsonObject {
+        put("index", index)
+    }
+
+    private fun toolUseBlock(id: String, name: String) = buildJsonObject {
+        put("type", "tool_use")
+        put("id", id)
+        put("name", name)
+        put("input", buildJsonObject {})
+    }
+
+    private fun textBlock(text: String) = buildJsonObject {
+        put("type", "text")
+        put("text", text)
+    }
+
+    private fun thinkingBlock(thinking: String) = buildJsonObject {
+        put("type", "thinking")
+        put("thinking", thinking)
+    }
+
+    private fun textDelta(text: String) = buildJsonObject {
+        put("type", "text_delta")
+        put("text", text)
+    }
+
+    private fun thinkingDelta(thinking: String) = buildJsonObject {
+        put("type", "thinking_delta")
+        put("thinking", thinking)
+    }
+
+    private fun signatureDelta(signature: String) = buildJsonObject {
+        put("type", "signature_delta")
+        put("signature", signature)
+    }
+
+    private fun inputJsonDelta(partialJson: String) = buildJsonObject {
+        put("type", "input_json_delta")
+        put("partial_json", partialJson)
+    }
+}

--- a/ai/src/test/java/me/rerere/ai/ui/MessageTest.kt
+++ b/ai/src/test/java/me/rerere/ai/ui/MessageTest.kt
@@ -175,6 +175,56 @@ class MessageTest {
         assertTrue(message.isValidToUpload())
     }
 
+    @Test
+    fun `blank tool delta should not merge into executed tool`() {
+        val initialMessages = listOf(
+            UIMessage.user("resume"),
+            UIMessage(
+                role = MessageRole.ASSISTANT,
+                parts = listOf(
+                    UIMessagePart.Tool(
+                        toolCallId = "call-1",
+                        toolName = "write-note",
+                        input = """{"path":"old.md","content":"done"}""",
+                        output = listOf(UIMessagePart.Text("ok"))
+                    )
+                )
+            )
+        )
+        val blankToolDelta = UIMessage(
+            role = MessageRole.ASSISTANT,
+            parts = listOf(
+                UIMessagePart.Tool(
+                    toolCallId = "",
+                    toolName = "",
+                    input = "{\"path\":\"new.md\"",
+                )
+            )
+        )
+
+        val chunk = MessageChunk(
+            id = "msg-1",
+            model = "claude-test",
+            choices = listOf(
+                UIMessageChoice(
+                    index = 0,
+                    delta = blankToolDelta,
+                    message = null,
+                    finishReason = null
+                )
+            )
+        )
+
+        val result = initialMessages.handleMessageChunk(chunk)
+        val tools = result.last().getTools()
+
+        assertEquals(2, tools.size)
+        assertEquals("""{"path":"old.md","content":"done"}""", tools[0].input)
+        assertTrue(tools[0].isExecuted)
+        assertEquals("{\"path\":\"new.md\"", tools[1].input)
+        assertFalse(tools[1].isExecuted)
+    }
+
     // ==================== migrateToolMessages Tests ====================
 
     @Test


### PR DESCRIPTION
closes #925

针对 Claude 流式输出中的 MCP 工具调用参数，改为按 Anthropic 的 content block 上下文归并 `input_json_delta`，避免长对话场景下工具参数被错误拼接，最终触发 JSON 解析失败

## 变更内容

- 为 Claude 流式事件增加按 `content_block_start` / `content_block_delta` / `content_block_stop` 和 `index` 维护的累加器
- 将 `input_json_delta` 片段绑定到对应 `tool_use` 的 `toolCallId`
- 在 `content_block_stop` 时清理 block 上下文，避免跨 block 污染
- 加强通用消息合并逻辑
  空 id 的 tool delta 只允许并到未执行的匿名 tool，不再误拼到历史已执行 tool
- 修复现有 Claude message test 中失效的反射签名
- 新增流式回归测试，覆盖转义字符、Unicode、多种 content block 混排，以及空 id fallback 的场景

## 问题原因

之前 Claude 的流式 `input_json_delta` 会以不带稳定 tool id 的增量进入通用合并逻辑

在长对话或多轮 assistant/tool 混排场景下，这些参数片段有机会被拼到错误的 tool 上，导致最终 `tool.input` 不是合法 JSON，进而在 MCP 工具执行前触发 `kotlinx.serialization` 的 JSON 解析异常

