### PR TITLE
fix(openai): codex response api guidance and xhigh reasoning

### DIFF
--- a/ai/src/main/java/me/rerere/ai/core/Reasoning.kt
+++ b/ai/src/main/java/me/rerere/ai/core/Reasoning.kt
@@ -8,10 +8,20 @@ enum class ReasoningLevel(
     AUTO(-1, "auto"),
     LOW(1024, "low"),
     MEDIUM(16_000, "medium"),
-    HIGH(32_000, "high");
+    HIGH(32_000, "high"),
+    XHIGH(64_000, "xhigh");
 
     val isEnabled: Boolean
         get() = this != OFF
+
+    fun toOpenAIChatCompletionsEffort(): String {
+        // Chat Completions 最高只到 high 所以 xhigh 降级为 high
+        return when (this) {
+            OFF, AUTO, LOW -> "low"
+            MEDIUM -> "medium"
+            HIGH, XHIGH -> "high"
+        }
+    }
 
     companion object {
         fun fromBudgetTokens(budgetTokens: Int?): ReasoningLevel {

--- a/ai/src/main/java/me/rerere/ai/provider/providers/GoogleProvider.kt
+++ b/ai/src/main/java/me/rerere/ai/provider/providers/GoogleProvider.kt
@@ -385,9 +385,11 @@ class GoogleProvider(private val client: OkHttpClient) : Provider<ProviderSettin
                         else -> {
                             if (ModelRegistry.GEMINI_3_SERIES.match(modelId = params.model.modelId)) {
                                 when (val level = ReasoningLevel.fromBudgetTokens(params.thinkingBudget)) {
-                                    ReasoningLevel.HIGH -> put("thinkingLevel", "high")
-                                    ReasoningLevel.MEDIUM -> put("thinkingLevel", "high")
                                     ReasoningLevel.LOW -> put("thinkingLevel", "low")
+                                    ReasoningLevel.MEDIUM, ReasoningLevel.HIGH, ReasoningLevel.XHIGH -> put(
+                                        "thinkingLevel",
+                                        "high"
+                                    )
                                     else -> error("Unknown reasoning level: $level")
                                 }
                             } else {

--- a/ai/src/main/java/me/rerere/ai/provider/providers/OpenAIProvider.kt
+++ b/ai/src/main/java/me/rerere/ai/provider/providers/OpenAIProvider.kt
@@ -44,6 +44,12 @@ class OpenAIProvider(
     private val chatCompletionsAPI = ChatCompletionsAPI(client = client, keyRoulette = keyRoulette)
     private val responseAPI = ResponseAPI(client = client)
 
+    private fun requireCodexUsesResponseApi(providerSetting: ProviderSetting.OpenAI, modelId: String) {
+        if (!providerSetting.useResponseApi && modelId.contains("codex", ignoreCase = true)) {
+            // Codex 模型必须开启 Response API
+            error("Codex 模型需要开启 Response API 请在 OpenAI 提供商设置中勾选 Response API")
+        }
+    }
 
     override suspend fun listModels(providerSetting: ProviderSetting.OpenAI): List<Model> =
         withContext(Dispatchers.IO) {
@@ -106,36 +112,44 @@ class OpenAIProvider(
         providerSetting: ProviderSetting.OpenAI,
         messages: List<UIMessage>,
         params: TextGenerationParams
-    ): Flow<MessageChunk> = if (providerSetting.useResponseApi) {
-        responseAPI.streamText(
-            providerSetting = providerSetting,
-            messages = messages,
-            params = params
-        )
-    } else {
-        chatCompletionsAPI.streamText(
-            providerSetting = providerSetting,
-            messages = messages,
-            params = params
-        )
+    ): Flow<MessageChunk> {
+        requireCodexUsesResponseApi(providerSetting, params.model.modelId)
+
+        return if (providerSetting.useResponseApi) {
+            responseAPI.streamText(
+                providerSetting = providerSetting,
+                messages = messages,
+                params = params
+            )
+        } else {
+            chatCompletionsAPI.streamText(
+                providerSetting = providerSetting,
+                messages = messages,
+                params = params
+            )
+        }
     }
 
     override suspend fun generateText(
         providerSetting: ProviderSetting.OpenAI,
         messages: List<UIMessage>,
         params: TextGenerationParams
-    ): MessageChunk = if (providerSetting.useResponseApi) {
-        responseAPI.generateText(
-            providerSetting = providerSetting,
-            messages = messages,
-            params = params
-        )
-    } else {
-        chatCompletionsAPI.generateText(
-            providerSetting = providerSetting,
-            messages = messages,
-            params = params
-        )
+    ): MessageChunk {
+        requireCodexUsesResponseApi(providerSetting, params.model.modelId)
+
+        return if (providerSetting.useResponseApi) {
+            responseAPI.generateText(
+                providerSetting = providerSetting,
+                messages = messages,
+                params = params
+            )
+        } else {
+            chatCompletionsAPI.generateText(
+                providerSetting = providerSetting,
+                messages = messages,
+                params = params
+            )
+        }
     }
 
     override suspend fun generateEmbedding(

--- a/ai/src/main/java/me/rerere/ai/provider/providers/openai/ChatCompletionsAPI.kt
+++ b/ai/src/main/java/me/rerere/ai/provider/providers/openai/ChatCompletionsAPI.kt
@@ -364,7 +364,7 @@ class ChatCompletionsAPI(
                         // OpenAI 官方
                         // 文档中，completions API 只支持 "low", "medium", "high"
                         if (level != ReasoningLevel.AUTO) {
-                            put("reasoning_effort", if (level.effort == "none") "low" else level.effort)
+                            put("reasoning_effort", level.toOpenAIChatCompletionsEffort())
                         }
                     }
                 }

--- a/ai/src/main/java/me/rerere/ai/registry/ModelRegistry.kt
+++ b/ai/src/main/java/me/rerere/ai/registry/ModelRegistry.kt
@@ -63,6 +63,17 @@ object ModelRegistry {
         toolReasoningAbility()
     }
 
+    private val GPT_5_CODEX = defineModel {
+        tokens("gpt", "5", "codex")
+        visionInput()
+        toolReasoningAbility()
+    }
+
+    private val CODEX_MINI_LATEST = defineModel {
+        exact("codex-mini-latest")
+        toolReasoningAbility()
+    }
+
     private val GEMINI_20_FLASH = defineModel {
         tokens("gemini", "2", "0", "flash")
         visionInput()
@@ -328,6 +339,8 @@ object ModelRegistry {
         GPT_5_2,
         GPT_5_3,
         GPT_5_4,
+        GPT_5_CODEX,
+        CODEX_MINI_LATEST,
         GEMINI_20_FLASH,
         GEMINI_2_5_FLASH,
         GEMINI_2_5_PRO,

--- a/ai/src/test/java/me/rerere/ai/ModelRegistryTest.kt
+++ b/ai/src/test/java/me/rerere/ai/ModelRegistryTest.kt
@@ -90,4 +90,36 @@ class ModelRegistryTest {
             ModelRegistry.MODEL_ABILITIES.getData("minimax-m2.5")
         )
     }
+
+    @Test
+    fun testCodexModels() {
+        listOf(
+            "gpt-5-codex",
+            "gpt-5.2-codex",
+            "gpt-5.1-codex-max"
+        ).forEach { modelId ->
+            assertEquals(
+                listOf(Modality.TEXT, Modality.IMAGE),
+                ModelRegistry.MODEL_INPUT_MODALITIES.getData(modelId)
+            )
+            assertEquals(
+                listOf(ModelAbility.TOOL, ModelAbility.REASONING),
+                ModelRegistry.MODEL_ABILITIES.getData(modelId)
+            )
+        }
+
+        assertEquals(
+            listOf(Modality.TEXT),
+            ModelRegistry.MODEL_INPUT_MODALITIES.getData("codex-mini-latest")
+        )
+        assertEquals(
+            listOf(ModelAbility.TOOL, ModelAbility.REASONING),
+            ModelRegistry.MODEL_ABILITIES.getData("codex-mini-latest")
+        )
+
+        assertEquals(
+            listOf(Modality.TEXT),
+            ModelRegistry.MODEL_INPUT_MODALITIES.getData("gpt-5-chat")
+        )
+    }
 }

--- a/ai/src/test/java/me/rerere/ai/core/ReasoningLevelTest.kt
+++ b/ai/src/test/java/me/rerere/ai/core/ReasoningLevelTest.kt
@@ -1,0 +1,11 @@
+package me.rerere.ai.core
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ReasoningLevelTest {
+    @Test
+    fun `xhigh should clamp to high for openai chat completions`() {
+        assertEquals("high", ReasoningLevel.XHIGH.toOpenAIChatCompletionsEffort())
+    }
+}

--- a/ai/src/test/java/me/rerere/ai/provider/providers/openai/ResponseAPIMessageTest.kt
+++ b/ai/src/test/java/me/rerere/ai/provider/providers/openai/ResponseAPIMessageTest.kt
@@ -353,6 +353,21 @@ class ResponseAPIMessageTest {
         assertEquals("low", reasoning!!["effort"]?.jsonPrimitive?.content)
     }
 
+    @Test
+    fun `openai response api should use xhigh effort when thinkingBudget is 64000`() {
+        val providerSetting = ProviderSetting.OpenAI(
+            baseUrl = "https://api.openai.com/v1"
+        )
+        val requestBody = invokeBuildRequestBody(
+            providerSetting = providerSetting,
+            params = createReasoningParams(thinkingBudget = 64_000)
+        )
+
+        val reasoning = requestBody["reasoning"]?.jsonObject
+        assertTrue("reasoning should exist", reasoning != null)
+        assertEquals("xhigh", reasoning!!["effort"]?.jsonPrimitive?.content)
+    }
+
     // ==================== Helper Functions ====================
 
     private fun createExecutedTool(

--- a/app/src/main/java/me/rerere/rikkahub/ui/components/ai/ReasoningPicker.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/ai/ReasoningPicker.kt
@@ -82,6 +82,7 @@ fun ReasoningButton(
                     ReasoningLevel.LOW -> Icon(ReasoningLow, null)
                     ReasoningLevel.MEDIUM -> Icon(ReasoningMedium, null)
                     ReasoningLevel.HIGH -> Icon(ReasoningHigh, null)
+                    ReasoningLevel.XHIGH -> Icon(ReasoningHigh, null)
                 }
             }
             if (!onlyIcon) Text(stringResource(R.string.setting_provider_page_reasoning))
@@ -182,6 +183,21 @@ fun ReasoningPicker(
                 },
                 onClick = {
                     onUpdateReasoningTokens(32_000)
+                }
+            )
+            ReasoningLevelCard(
+                selected = currentLevel == ReasoningLevel.XHIGH,
+                icon = {
+                    Icon(ReasoningHigh, null)
+                },
+                title = {
+                    Text(stringResource(id = R.string.reasoning_xhigh))
+                },
+                description = {
+                    Text(stringResource(id = R.string.reasoning_xhigh_desc))
+                },
+                onClick = {
+                    onUpdateReasoningTokens(64_000)
                 }
             )
 

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/components/ProviderConfigure.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/components/ProviderConfigure.kt
@@ -231,6 +231,9 @@ private val OFFICIAL_PROVIDER_HOSTS = setOf(
     CLAUDE_OFFICIAL_HOST
 )
 
+private fun ProviderSetting.OpenAI.hasCodexModel(): Boolean =
+    models.any { it.modelId.contains("codex", ignoreCase = true) }
+
 @Composable
 private fun ColumnScope.ProviderConfigureOpenAI(
     provider: ProviderSetting.OpenAI,
@@ -317,6 +320,14 @@ private fun ColumnScope.ProviderConfigureOpenAI(
                     )
                 }
             }
+        )
+    }
+
+    if (!provider.useResponseApi && provider.hasCodexModel()) {
+        Text(
+            text = stringResource(R.string.setting_provider_page_response_api_codex_warning),
+            color = MaterialTheme.colorScheme.error,
+            style = MaterialTheme.typography.bodySmall,
         )
     }
 }

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -347,6 +347,8 @@
   <string name="reasoning_custom">自定義推理預算</string>
   <string name="reasoning_heavy">重度推理</string>
   <string name="reasoning_heavy_desc">模型將使用大量推理來回答問題。</string>
+  <string name="reasoning_xhigh">超重度推理</string>
+  <string name="reasoning_xhigh_desc">模型將使用超大量推理來回答問題。</string>
   <string name="reasoning_light">輕度推理</string>
   <string name="reasoning_light_desc">模型將使用少量推理來回答問題。</string>
   <string name="reasoning_medium">中度推理</string>
@@ -549,6 +551,7 @@
   <string name="setting_provider_page_reasoning">推理</string>
   <string name="setting_provider_page_response_api">Response API</string>
   <string name="setting_provider_page_response_api_warning">Response API是OpenAI新一代API，大部分提供商並不支持，如果你不知道這是什麼，不要開啟</string>
+  <string name="setting_provider_page_response_api_codex_warning">Codex 模型需要開啟 Response API</string>
   <string name="setting_provider_page_save">保存</string>
   <string name="setting_provider_page_save_success">保存成功</string>
   <string name="setting_provider_page_scan_error">錯誤: %s</string>
@@ -912,4 +915,3 @@
   <string name="setting_display_page_use_app_icon_style_loading_indicator_title">使用 APP 圖示風格的載入指示器</string>
   <string name="setting_display_page_use_app_icon_style_loading_indicator_desc">使用應用程式圖示動畫取代預設的圓形載入指示器</string>
 </resources>
-

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -347,6 +347,8 @@
   <string name="reasoning_custom">自定义推理预算</string>
   <string name="reasoning_heavy">重度推理</string>
   <string name="reasoning_heavy_desc">模型将使用大量推理来回答问题。</string>
+  <string name="reasoning_xhigh">超重度推理</string>
+  <string name="reasoning_xhigh_desc">模型将使用超大量推理来回答问题。</string>
   <string name="reasoning_light">轻度推理</string>
   <string name="reasoning_light_desc">模型将使用少量推理来回答问题。</string>
   <string name="reasoning_medium">中度推理</string>
@@ -551,6 +553,7 @@
   <string name="setting_provider_page_reasoning">推理</string>
   <string name="setting_provider_page_response_api">Response API</string>
   <string name="setting_provider_page_response_api_warning">Response API是OpenAI新一代API，大部分提供商并不支持，如果你不知道这是什么，不要开启</string>
+  <string name="setting_provider_page_response_api_codex_warning">Codex 模型需要开启 Response API</string>
   <string name="setting_provider_page_save">保存</string>
   <string name="setting_provider_page_save_success">保存成功</string>
   <string name="setting_provider_page_scan_error">错误: %s</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -359,6 +359,8 @@
   <string name="reasoning_custom">Custom reasoning budget</string>
   <string name="reasoning_heavy">Heavy reasoning</string>
   <string name="reasoning_heavy_desc">The model will use a large amount of reasoning to answer questions.</string>
+  <string name="reasoning_xhigh">XHigh reasoning</string>
+  <string name="reasoning_xhigh_desc">The model will use an extra-large amount of reasoning to answer questions.</string>
   <string name="reasoning_light">Light reasoning</string>
   <string name="reasoning_light_desc">The model will use a small amount of reasoning to answer questions.</string>
   <string name="reasoning_medium">Medium reasoning</string>
@@ -564,6 +566,7 @@
   <string name="setting_provider_page_reasoning">Reasoning</string>
   <string name="setting_provider_page_response_api">Response API</string>
   <string name="setting_provider_page_response_api_warning">Response API is OpenAI\'s next-generation API. Most providers do not support it. If you don\'t know what this is, don\'t enable it.</string>
+  <string name="setting_provider_page_response_api_codex_warning">Codex models require Response API</string>
   <string name="setting_provider_page_save">Save</string>
   <string name="setting_provider_page_save_success">Save successful</string>
   <string name="setting_provider_page_scan_error">Error: %s</string>


### PR DESCRIPTION
Closes #952

## 变更
- OpenAI 在选择 Codex 模型且未启用 Response API 时直接给出清晰错误提示 避免只看到原始 4xx
- 设置页 OpenAI Provider 在存在 Codex 模型且 Response API 关闭时显示红色提示
- 推理新增 XHIGH(64_000) Responses API 发送 reasoning.effort=xhigh Chat Completions 自动降级为 high
- ModelRegistry 识别 gpt-5-*-codex 与 codex-mini-latest 并补齐模态与能力
