### PR TITLE
修复：自定义 Content-Type 被自动追加 charset 导致协议头不一致

### DIFF
--- a/ai/src/main/java/me/rerere/ai/provider/providers/openai/ChatCompletionsAPI.kt
+++ b/ai/src/main/java/me/rerere/ai/provider/providers/openai/ChatCompletionsAPI.kt
@@ -46,6 +46,7 @@ import me.rerere.ai.util.mergeCustomBody
 import me.rerere.ai.util.parseErrorDetail
 import me.rerere.ai.util.stringSafe
 import me.rerere.ai.util.toHeaders
+import me.rerere.ai.util.toJsonRequestBodyWithCustomContentType
 import me.rerere.common.http.await
 import me.rerere.common.http.jsonArrayOrNull
 import me.rerere.common.http.jsonObjectOrNull
@@ -82,7 +83,7 @@ class ChatCompletionsAPI(
         val request = Request.Builder()
             .url("${providerSetting.baseUrl}${providerSetting.chatCompletionsPath}")
             .headers(params.customHeaders.toHeaders())
-            .post(json.encodeToString(requestBody).toRequestBody("application/json".toMediaType()))
+            .post(json.encodeToString(requestBody).toJsonRequestBodyWithCustomContentType(params.customHeaders))
             .addHeader("Authorization", "Bearer ${keyRoulette.next(providerSetting.apiKey)}")
             .configureReferHeaders(providerSetting.baseUrl)
             .build()
@@ -139,9 +140,8 @@ class ChatCompletionsAPI(
         val request = Request.Builder()
             .url("${providerSetting.baseUrl}${providerSetting.chatCompletionsPath}")
             .headers(params.customHeaders.toHeaders())
-            .post(json.encodeToString(requestBody).toRequestBody("application/json".toMediaType()))
+            .post(json.encodeToString(requestBody).toJsonRequestBodyWithCustomContentType(params.customHeaders))
             .addHeader("Authorization", "Bearer ${keyRoulette.next(providerSetting.apiKey)}")
-            .addHeader("Content-Type", "application/json")
             .configureReferHeaders(providerSetting.baseUrl)
             .build()
 

--- a/ai/src/main/java/me/rerere/ai/provider/providers/openai/ResponseAPI.kt
+++ b/ai/src/main/java/me/rerere/ai/provider/providers/openai/ResponseAPI.kt
@@ -40,6 +40,7 @@ import me.rerere.ai.util.mergeCustomBody
 import me.rerere.ai.util.parseErrorDetail
 import me.rerere.ai.util.stringSafe
 import me.rerere.ai.util.toHeaders
+import me.rerere.ai.util.toJsonRequestBodyWithCustomContentType
 import me.rerere.common.http.await
 import me.rerere.common.http.jsonObjectOrNull
 import me.rerere.common.http.jsonPrimitiveOrNull
@@ -71,9 +72,8 @@ class ResponseAPI(private val client: OkHttpClient) : OpenAIImpl {
         val request = Request.Builder()
             .url("${providerSetting.baseUrl}/responses")
             .headers(params.customHeaders.toHeaders())
-            .post(json.encodeToString(requestBody).toRequestBody("application/json".toMediaType()))
+            .post(json.encodeToString(requestBody).toJsonRequestBodyWithCustomContentType(params.customHeaders))
             .addHeader("Authorization", "Bearer ${providerSetting.apiKey}")
-            .addHeader("Content-Type", "application/json")
             .configureReferHeaders(providerSetting.baseUrl)
             .build()
 
@@ -106,9 +106,8 @@ class ResponseAPI(private val client: OkHttpClient) : OpenAIImpl {
         val request = Request.Builder()
             .url("${providerSetting.baseUrl}/responses")
             .headers(params.customHeaders.toHeaders())
-            .post(json.encodeToString(requestBody).toRequestBody("application/json".toMediaType()))
+            .post(json.encodeToString(requestBody).toJsonRequestBodyWithCustomContentType(params.customHeaders))
             .addHeader("Authorization", "Bearer ${providerSetting.apiKey}")
-            .addHeader("Content-Type", "application/json")
             .configureReferHeaders(providerSetting.baseUrl)
             .build()
 

--- a/ai/src/main/java/me/rerere/ai/util/Request.kt
+++ b/ai/src/main/java/me/rerere/ai/util/Request.kt
@@ -8,7 +8,11 @@ import me.rerere.ai.provider.CustomHeader
 import okhttp3.Headers
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Request
+import okhttp3.MediaType
+import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.ResponseBody
+import okhttp3.RequestBody
+import okio.BufferedSink
 import okhttp3.internal.http.RealResponseBody
 
 fun List<CustomHeader>.toHeaders(): Headers {
@@ -19,6 +23,30 @@ fun List<CustomHeader>.toHeaders(): Headers {
                 add(it.name, it.value)
             }
     }.build()
+}
+
+fun List<CustomHeader>.contentTypeValueOrNull(): String? {
+    return firstOrNull { it.name.equals("Content-Type", ignoreCase = true) && it.value.isNotBlank() }
+        ?.value
+        ?.trim()
+}
+
+/**
+ * Build a JSON request body but force its Content-Type to exactly match the user-provided header
+ * when present (e.g. "application/json" without charset).
+ */
+fun String.toJsonRequestBodyWithCustomContentType(customHeaders: List<CustomHeader>): RequestBody {
+    val explicit = customHeaders.contentTypeValueOrNull()
+    val mediaType: MediaType = (explicit ?: "application/json").toMediaType()
+    val bytes = toByteArray(Charsets.UTF_8)
+
+    return object : RequestBody() {
+        override fun contentType(): MediaType = mediaType
+        override fun contentLength(): Long = bytes.size.toLong()
+        override fun writeTo(sink: BufferedSink) {
+            sink.write(bytes)
+        }
+    }
 }
 
 fun Request.Builder.configureReferHeaders(url: String): Request.Builder {


### PR DESCRIPTION
### 背景

目前在部分请求链路中，body 的 RequestBody 构造会导致 Content-Type 被隐式处理/追加 ; charset=utf-8，从而覆盖或改变用户在自定义 header 中显式配置的 Content-Type，与“严格按用户配置发送”不一致，导致部分AI平台返回400。

### 改动内容

新增统一的 JSON RequestBody 构造方式：当自定义 header 中存在 Content-Type 时，严格使用该值作为请求体的 contentType()（不再追加 charset）。
OpenAI 相关接口调用统一改为使用该构造方式，避免再硬编码 application/json 或触发自动 charset 追加。


### 影响范围

仅调整网络请求体 Content-Type 的生成逻辑；不影响请求 payload 内容。
主要覆盖 OpenAI ChatCompletions / Responses 相关链路。


### 涉及文件

```
ai/src/main/java/me/rerere/ai/util/Request.kt
ai/src/main/java/me/rerere/ai/provider/providers/openai/ChatCompletionsAPI.kt
ai/src/main/java/me/rerere/ai/provider/providers/openai/ResponseAPI.kt
```

### 测试说明

CI 编译通过（基于当前分支构建）。
可通过抓包验证：当自定义header 配置 Content-Type: application/json（或其他值）时，请求体 Content-Type 不再出现  ; charset=utf-8追加。

**以下代码以及description均由AI生成并校验可编译**