### PR TITLE
feat: 新增 Vercel AI Gateway 默认提供商

### DIFF
--- a/app/src/main/java/me/rerere/rikkahub/data/datastore/DefaultProviders.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/datastore/DefaultProviders.kt
@@ -186,6 +186,19 @@ val DEFAULT_PROVIDERS = listOf(
         )
     ),
     ProviderSetting.OpenAI(
+        id = Uuid.parse("386e0f29-8228-4512-affe-8fd8add82d88"),
+        name = "Vercel AI Gateway",
+        baseUrl = "https://ai-gateway.vercel.sh/v1",
+        apiKey = "",
+        enabled = false,
+        builtIn = true,
+        balanceOption = BalanceOption(
+            enabled = true,
+            apiPath = "/credits",
+            resultPath = "balance",
+        )
+    ),
+    ProviderSetting.OpenAI(
         id = Uuid.parse("da020a90-f7b3-4c29-b90e-c511a0630630"),
         name = "小马算力",
         baseUrl = "https://api.tokenpony.cn/v1",

--- a/app/src/test/java/me/rerere/rikkahub/data/datastore/DefaultProvidersTest.kt
+++ b/app/src/test/java/me/rerere/rikkahub/data/datastore/DefaultProvidersTest.kt
@@ -1,0 +1,26 @@
+package me.rerere.rikkahub.data.datastore
+
+import me.rerere.ai.provider.ProviderSetting
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class DefaultProvidersTest {
+    @Test
+    fun `default providers should include vercel ai gateway with expected balance config`() {
+        val vercelProviders = DEFAULT_PROVIDERS
+            .filterIsInstance<ProviderSetting.OpenAI>()
+            .filter { it.name == "Vercel AI Gateway" }
+
+        assertEquals(1, vercelProviders.size)
+
+        val provider = vercelProviders.single()
+        assertEquals("https://ai-gateway.vercel.sh/v1", provider.baseUrl)
+        assertFalse(provider.enabled)
+        assertTrue(provider.builtIn)
+        assertTrue(provider.balanceOption.enabled)
+        assertEquals("/credits", provider.balanceOption.apiPath)
+        assertEquals("balance", provider.balanceOption.resultPath)
+    }
+}


### PR DESCRIPTION
## 添加
- 新增内置 `Vercel AI Gateway` Provider（OpenAI 兼容）。
- 默认关闭，Base URL：`https://ai-gateway.vercel.sh/v1`。
- 新增余额配置：`/credits`，结果字段 `balance`。
- 新增 `DefaultProvidersTest` 覆盖默认配置校验。


Closes #979
