### PR TITLE
fix: 翻译默认关闭思考能力（#976）

### DIFF
--- a/app/src/main/java/me/rerere/rikkahub/data/ai/GenerationHandler.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/ai/GenerationHandler.kt
@@ -18,6 +18,7 @@ import me.rerere.ai.core.Tool
 import me.rerere.ai.core.merge
 import me.rerere.ai.provider.CustomBody
 import me.rerere.ai.provider.Model
+import me.rerere.ai.provider.ModelAbility
 import me.rerere.ai.provider.Provider
 import me.rerere.ai.provider.ProviderManager
 import me.rerere.ai.provider.ProviderSetting
@@ -47,6 +48,13 @@ import java.util.Locale
 import kotlin.time.Clock
 
 private const val TAG = "GenerationHandler"
+
+internal fun Model.disableReasoningForTranslation(): Model {
+    if (abilities.none { it == ModelAbility.REASONING }) return this
+    return copy(
+        abilities = abilities.filterNot { it == ModelAbility.REASONING }
+    )
+}
 
 @Serializable
 sealed interface GenerationChunk {
@@ -447,7 +455,8 @@ class GenerationHandler(
     ): Flow<String> = flow {
         val model = settings.providers.findModelById(settings.translateModeId)
             ?: error("Translation model not found")
-        val provider = model.findProvider(settings.providers)
+        val translationModel = model.disableReasoningForTranslation()
+        val provider = translationModel.findProvider(settings.providers)
             ?: error("Translation provider not found")
 
         val providerHandler = providerManager.getProviderByType(provider)
@@ -466,7 +475,7 @@ class GenerationHandler(
                 providerSetting = provider,
                 messages = messages,
                 params = TextGenerationParams(
-                    model = model,
+                    model = translationModel,
                     temperature = 0.3f,
                 ),
             ).collect { chunk ->
@@ -485,7 +494,7 @@ class GenerationHandler(
                 providerSetting = provider,
                 messages = messages,
                 params = TextGenerationParams(
-                    model = model,
+                    model = translationModel,
                     temperature = 0.3f,
                     topP = 0.95f,
                     customBody = listOf(

--- a/app/src/test/java/me/rerere/rikkahub/data/ai/GenerationHandlerTranslationModelTest.kt
+++ b/app/src/test/java/me/rerere/rikkahub/data/ai/GenerationHandlerTranslationModelTest.kt
@@ -1,0 +1,40 @@
+package me.rerere.rikkahub.data.ai
+
+import me.rerere.ai.provider.Model
+import me.rerere.ai.provider.ModelAbility
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class GenerationHandlerTranslationModelTest {
+    @Test
+    fun disableReasoningForTranslation_removesReasoningAbility() {
+        val model = Model(
+            modelId = "test-model",
+            displayName = "Test Model",
+            abilities = listOf(ModelAbility.TOOL, ModelAbility.REASONING)
+        )
+
+        val translationModel = model.disableReasoningForTranslation()
+
+        assertFalse(translationModel.abilities.contains(ModelAbility.REASONING))
+        assertTrue(translationModel.abilities.contains(ModelAbility.TOOL))
+        assertEquals(model.modelId, translationModel.modelId)
+        assertEquals(model.displayName, translationModel.displayName)
+        assertEquals(model.id, translationModel.id)
+    }
+
+    @Test
+    fun disableReasoningForTranslation_keepsModelWithoutReasoningUnchanged() {
+        val model = Model(
+            modelId = "test-model",
+            displayName = "Test Model",
+            abilities = listOf(ModelAbility.TOOL)
+        )
+
+        val translationModel = model.disableReasoningForTranslation()
+
+        assertEquals(model, translationModel)
+    }
+}


### PR DESCRIPTION
## 关闭翻译的思考能力
- 翻译链路统一使用去除 `REASONING` 能力的模型副本


Closes #976
