### PR TITLE
feat: 新增 MiMo TTS（流式 pcm16 拼接）

### DIFF
--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingTTSPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingTTSPage.kt
@@ -372,6 +372,7 @@ private fun TTSProviderItem(
                             is TTSProviderSetting.Qwen -> "Qwen"
                             is TTSProviderSetting.Groq -> "Groq"
                             is TTSProviderSetting.XAI -> "xAI"
+                            is TTSProviderSetting.MiMo -> "MiMo"
                         },
                         style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colorScheme.onSurfaceVariant

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/components/TTSProviderConfigure.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/components/TTSProviderConfigure.kt
@@ -55,6 +55,7 @@ fun TTSProviderConfigure(
                         is TTSProviderSetting.Qwen -> "Qwen"
                         is TTSProviderSetting.Groq -> "Groq"
                         is TTSProviderSetting.XAI -> "xAI"
+                        is TTSProviderSetting.MiMo -> "MiMo"
                     },
                     onValueChange = {},
                     readOnly = true,
@@ -81,6 +82,7 @@ fun TTSProviderConfigure(
                                         TTSProviderSetting.Qwen::class -> "Qwen"
                                         TTSProviderSetting.Groq::class -> "Groq"
                                         TTSProviderSetting.XAI::class -> "xAI"
+                                        TTSProviderSetting.MiMo::class -> "MiMo"
                                         else -> providerClass.simpleName ?: "Unknown"
                                     }
                                 )
@@ -123,6 +125,11 @@ fun TTSProviderConfigure(
                                         name = "xAI TTS"
                                     )
 
+                                    TTSProviderSetting.MiMo::class -> TTSProviderSetting.MiMo(
+                                        id = setting.id,
+                                        name = "MiMo TTS"
+                                    )
+
                                     else -> setting
                                 }
                                 onValueChange(newSetting)
@@ -157,6 +164,7 @@ fun TTSProviderConfigure(
             is TTSProviderSetting.Qwen -> QwenTTSConfiguration(setting, onValueChange)
             is TTSProviderSetting.Groq -> GroqTTSConfiguration(setting, onValueChange)
             is TTSProviderSetting.XAI -> XAITTSConfiguration(setting, onValueChange)
+            is TTSProviderSetting.MiMo -> MiMoTTSConfiguration(setting, onValueChange)
         }
     }
 }
@@ -250,6 +258,73 @@ private fun OpenAITTSConfiguration(
                 }
             }
         }
+    }
+}
+
+@Composable
+private fun MiMoTTSConfiguration(
+    setting: TTSProviderSetting.MiMo,
+    onValueChange: (TTSProviderSetting) -> Unit
+) {
+    // MiMo 配置均为自由输入 默认值只是占位
+    // API Key
+    FormItem(
+        label = { Text(stringResource(R.string.setting_tts_page_api_key)) },
+        description = { Text(stringResource(R.string.setting_tts_page_api_key_description)) }
+    ) {
+        OutlinedTextField(
+            value = setting.apiKey,
+            onValueChange = { newApiKey ->
+                onValueChange(setting.copy(apiKey = newApiKey))
+            },
+            modifier = Modifier.fillMaxWidth(),
+            placeholder = { Text("mimo-xxx") },
+        )
+    }
+
+    // Base URL
+    FormItem(
+        label = { Text(stringResource(R.string.setting_tts_page_base_url)) },
+        description = { Text(stringResource(R.string.setting_tts_page_base_url_description)) }
+    ) {
+        OutlinedTextField(
+            value = setting.baseUrl,
+            onValueChange = { newBaseUrl ->
+                onValueChange(setting.copy(baseUrl = newBaseUrl))
+            },
+            modifier = Modifier.fillMaxWidth(),
+            placeholder = { Text("https://api.xiaomimimo.com/v1") }
+        )
+    }
+
+    // Model
+    FormItem(
+        label = { Text(stringResource(R.string.setting_tts_page_model)) },
+        description = { Text(stringResource(R.string.setting_tts_page_model_description)) }
+    ) {
+        OutlinedTextField(
+            value = setting.model,
+            onValueChange = { newModel ->
+                onValueChange(setting.copy(model = newModel))
+            },
+            modifier = Modifier.fillMaxWidth(),
+            placeholder = { Text("mimo-v2-tts") }
+        )
+    }
+
+    // Voice
+    FormItem(
+        label = { Text(stringResource(R.string.setting_tts_page_voice)) },
+        description = { Text(stringResource(R.string.setting_tts_page_voice_description)) }
+    ) {
+        OutlinedTextField(
+            value = setting.voice,
+            onValueChange = { newVoice ->
+                onValueChange(setting.copy(voice = newVoice))
+            },
+            modifier = Modifier.fillMaxWidth(),
+            placeholder = { Text("mimo_default") }
+        )
     }
 }
 

--- a/tts/src/main/java/me/rerere/tts/provider/TTSManager.kt
+++ b/tts/src/main/java/me/rerere/tts/provider/TTSManager.kt
@@ -6,6 +6,7 @@ import me.rerere.tts.model.AudioChunk
 import me.rerere.tts.model.TTSRequest
 import me.rerere.tts.provider.providers.GeminiTTSProvider
 import me.rerere.tts.provider.providers.GroqTTSProvider
+import me.rerere.tts.provider.providers.MiMoTTSProvider
 import me.rerere.tts.provider.providers.MiniMaxTTSProvider
 import me.rerere.tts.provider.providers.OpenAITTSProvider
 import me.rerere.tts.provider.providers.QwenTTSProvider
@@ -20,6 +21,7 @@ class TTSManager(private val context: Context) {
     private val qwenProvider = QwenTTSProvider()
     private val groqProvider = GroqTTSProvider()
     private val xaiProvider = XAITTSProvider()
+    private val miMoProvider = MiMoTTSProvider()
 
     fun generateSpeech(
         providerSetting: TTSProviderSetting,
@@ -33,6 +35,7 @@ class TTSManager(private val context: Context) {
             is TTSProviderSetting.Qwen -> qwenProvider.generateSpeech(context, providerSetting, request)
             is TTSProviderSetting.Groq -> groqProvider.generateSpeech(context, providerSetting, request)
             is TTSProviderSetting.XAI -> xaiProvider.generateSpeech(context, providerSetting, request)
+            is TTSProviderSetting.MiMo -> miMoProvider.generateSpeech(context, providerSetting, request)
         }
     }
 }

--- a/tts/src/main/java/me/rerere/tts/provider/TTSProviderSetting.kt
+++ b/tts/src/main/java/me/rerere/tts/provider/TTSProviderSetting.kt
@@ -162,6 +162,28 @@ sealed class TTSProviderSetting {
         }
     }
 
+    @Serializable
+    @SerialName("mimo")
+    // 默认值仅用于快捷起步 可在设置页任意修改
+    data class MiMo(
+        override var id: Uuid = Uuid.random(),
+        override var name: String = "MiMo TTS",
+        val apiKey: String = "",
+        val baseUrl: String = "https://api.xiaomimimo.com/v1",
+        val model: String = "mimo-v2-tts",
+        val voice: String = "mimo_default"
+    ) : TTSProviderSetting() {
+        override fun copyProvider(
+            id: Uuid,
+            name: String,
+        ): TTSProviderSetting {
+            return this.copy(
+                id = id,
+                name = name,
+            )
+        }
+    }
+
     companion object {
         val Types by lazy {
             listOf(
@@ -172,6 +194,7 @@ sealed class TTSProviderSetting {
                 Qwen::class,
                 Groq::class,
                 XAI::class,
+                MiMo::class,
             )
         }
     }

--- a/tts/src/main/java/me/rerere/tts/provider/providers/MiMoTTSProvider.kt
+++ b/tts/src/main/java/me/rerere/tts/provider/providers/MiMoTTSProvider.kt
@@ -1,0 +1,155 @@
+package me.rerere.tts.provider.providers
+
+import android.content.Context
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import me.rerere.common.http.SseEvent
+import me.rerere.common.http.sseFlow
+import me.rerere.tts.model.AudioChunk
+import me.rerere.tts.model.AudioFormat
+import me.rerere.tts.model.TTSRequest
+import me.rerere.tts.provider.TTSProvider
+import me.rerere.tts.provider.TTSProviderSetting
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import java.util.Base64
+import java.util.concurrent.TimeUnit
+
+// MiMo 流式音频按文档示例使用 24kHz PCM16LE
+private const val MIMO_SAMPLE_RATE = 24000
+private val JSON_MEDIA_TYPE = "application/json".toMediaType()
+// 只关心 delta.audio.data 其余字段忽略
+private val mimoJson = Json { ignoreUnknownKeys = true }
+
+@Serializable
+private data class MiMoChunk(
+    val choices: List<MiMoChoice> = emptyList()
+)
+
+@Serializable
+private data class MiMoChoice(
+    val delta: MiMoDelta? = null
+)
+
+@Serializable
+private data class MiMoDelta(
+    val audio: MiMoAudio? = null
+)
+
+@Serializable
+private data class MiMoAudio(
+    val data: String? = null
+)
+
+internal fun decodeMiMoAudioData(data: String): ByteArray? {
+    val payload = data.trim()
+    // [DONE] 表示流结束 不输出音频
+    if (payload == "[DONE]") return null
+    // 非 [DONE] 的 data 视为 JSON 片段 解析失败直接上抛
+    val chunk = mimoJson.decodeFromString<MiMoChunk>(payload)
+    val encoded = chunk.choices.firstOrNull()?.delta?.audio?.data ?: return null
+    // 空字符串视为无音频片段
+    if (encoded.isBlank()) return null
+    return Base64.getDecoder().decode(encoded)
+}
+
+internal class MiMoSseProcessor(
+    private val model: String,
+    private val voice: String
+) {
+    private var hasAudio = false
+    // metadata 只构造一次 贯穿整个流
+    private val metadata = mapOf(
+        "provider" to "mimo",
+        "model" to model,
+        "voice" to voice
+    )
+
+    fun process(event: SseEvent): AudioChunk? {
+        return when (event) {
+            is SseEvent.Open -> null
+            is SseEvent.Event -> {
+                // 只处理包含 audio.data 的增量事件 其他事件忽略
+                val pcmData = decodeMiMoAudioData(event.data) ?: return null
+                hasAudio = true
+                AudioChunk(
+                    data = pcmData,
+                    format = AudioFormat.PCM,
+                    sampleRate = MIMO_SAMPLE_RATE,
+                    metadata = metadata
+                )
+            }
+
+            is SseEvent.Closed -> {
+                // 如果整段流没有任何音频片段 直接报错
+                if (!hasAudio) {
+                    throw IllegalStateException("MiMo TTS returned no audio chunks")
+                }
+                // 流关闭时补一个终结 chunk 便于播放器收尾
+                AudioChunk(
+                    data = byteArrayOf(),
+                    format = AudioFormat.PCM,
+                    sampleRate = MIMO_SAMPLE_RATE,
+                    isLast = true,
+                    metadata = metadata
+                )
+            }
+
+            is SseEvent.Failure -> throw event.throwable ?: Exception("MiMo TTS streaming failed")
+        }
+    }
+}
+
+class MiMoTTSProvider : TTSProvider<TTSProviderSetting.MiMo> {
+    private val httpClient = OkHttpClient.Builder()
+        .readTimeout(120, TimeUnit.SECONDS)
+        .build()
+
+    override fun generateSpeech(
+        context: Context,
+        providerSetting: TTSProviderSetting.MiMo,
+        request: TTSRequest
+    ): Flow<AudioChunk> = flow {
+        // OpenAI 兼容的 chat/completions SSE 流式返回 音频增量在 delta.audio.data
+        val requestBody = buildJsonObject {
+            put("model", providerSetting.model)
+            put("messages", buildJsonArray {
+                add(buildJsonObject {
+                    put("role", "assistant")
+                    put("content", request.text)
+                })
+            })
+            put("audio", buildJsonObject {
+                put("format", "pcm16")
+                put("voice", providerSetting.voice)
+            })
+            put("stream", true)
+        }
+
+        // baseUrl 允许用户在设置页自定义 这里直接拼接路径
+        val httpRequest = Request.Builder()
+            .url("${providerSetting.baseUrl}/chat/completions")
+            // MiMo 使用 api-key 头传 token
+            .addHeader("api-key", providerSetting.apiKey)
+            .addHeader("Content-Type", "application/json")
+            // JsonObject 的 toString 会输出 JSON 字符串
+            .post(requestBody.toString().toRequestBody(JSON_MEDIA_TYPE))
+            .build()
+
+        val processor = MiMoSseProcessor(
+            model = providerSetting.model,
+            voice = providerSetting.voice
+        )
+
+        httpClient.sseFlow(httpRequest).collect { event ->
+            processor.process(event)?.let { emit(it) }
+        }
+    }
+}

--- a/tts/src/test/java/me/rerere/tts/provider/TTSProviderSettingMiMoTest.kt
+++ b/tts/src/test/java/me/rerere/tts/provider/TTSProviderSettingMiMoTest.kt
@@ -1,0 +1,23 @@
+package me.rerere.tts.provider
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class TTSProviderSettingMiMoTest {
+    @Test
+    fun mimo_defaults_are_expected() {
+        val setting = TTSProviderSetting.MiMo()
+
+        assertEquals("MiMo TTS", setting.name)
+        assertEquals("https://api.xiaomimimo.com/v1", setting.baseUrl)
+        assertEquals("mimo-v2-tts", setting.model)
+        assertEquals("mimo_default", setting.voice)
+        assertEquals("", setting.apiKey)
+    }
+
+    @Test
+    fun mimo_is_registered_in_provider_types() {
+        assertTrue(TTSProviderSetting.Types.contains(TTSProviderSetting.MiMo::class))
+    }
+}

--- a/tts/src/test/java/me/rerere/tts/provider/providers/MiMoTTSProviderTest.kt
+++ b/tts/src/test/java/me/rerere/tts/provider/providers/MiMoTTSProviderTest.kt
@@ -1,0 +1,66 @@
+package me.rerere.tts.provider.providers
+
+import me.rerere.common.http.SseEvent
+import me.rerere.tts.model.AudioFormat
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.util.Base64
+
+class MiMoTTSProviderTest {
+    @Test
+    fun decode_audio_data_from_sse_chunk() {
+        val expected = byteArrayOf(1, 2, 3, 4)
+        val encoded = Base64.getEncoder().encodeToString(expected)
+        val data = """{"choices":[{"delta":{"audio":{"data":"$encoded"}}}]}"""
+
+        val actual = decodeMiMoAudioData(data)
+
+        assertNotNull(actual)
+        assertArrayEquals(expected, actual)
+    }
+
+    @Test
+    fun ignore_sse_chunk_without_audio_data() {
+        val data = """{"choices":[{"delta":{"content":"hello"}}]}"""
+        assertNull(decodeMiMoAudioData(data))
+    }
+
+    @Test
+    fun emits_single_terminal_chunk_on_done_and_closed() {
+        val processor = MiMoSseProcessor(model = "mimo-v2-tts", voice = "mimo_default")
+        val encoded = Base64.getEncoder().encodeToString(byteArrayOf(9, 8, 7))
+        val audioData = """{"choices":[{"delta":{"audio":{"data":"$encoded"}}}]}"""
+
+        val first = processor.process(SseEvent.Event(id = null, type = null, data = audioData))
+        val done = processor.process(SseEvent.Event(id = null, type = null, data = "[DONE]"))
+        val terminal = processor.process(SseEvent.Closed)
+
+        assertNotNull(first)
+        assertEquals(AudioFormat.PCM, first?.format)
+        assertFalse(first?.isLast ?: true)
+        assertNull(done)
+        assertNotNull(terminal)
+        assertTrue(terminal?.isLast ?: false)
+    }
+
+    @Test
+    fun throws_when_stream_closed_without_audio() {
+        val processor = MiMoSseProcessor(model = "mimo-v2-tts", voice = "mimo_default")
+
+        var thrown: Throwable? = null
+        try {
+            processor.process(SseEvent.Event(id = null, type = null, data = "[DONE]"))
+            processor.process(SseEvent.Closed)
+        } catch (t: Throwable) {
+            thrown = t
+        }
+
+        assertNotNull(thrown)
+        assertTrue(thrown is IllegalStateException)
+    }
+}


### PR DESCRIPTION
新增 MiMo TTS Provider：SSE 流式返回 pcm16，客户端实时拼接播放
设置页支持自定义：API Key / Base URL / Model / Voice

### 修改内容
```
app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingTTSPage.kt
app/src/main/java/me/rerere/rikkahub/ui/pages/setting/components/TTSProviderConfigure.kt
tts/src/main/java/me/rerere/tts/provider/TTSProviderSetting.kt
tts/src/main/java/me/rerere/tts/provider/TTSManager.kt
tts/src/main/java/me/rerere/tts/provider/providers/MiMoTTSProvider.kt
  新增 MiMo 流式 TTS 实现：SSE 解析 `choices[0].delta.audio.data`(base64) -> PCM chunk（24kHz）
```

closes #980 
