### PR TITLE
fix: 调整显示设置中“文本长度阈值”位置，修复 #1025

### DIFF
--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingDisplayPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingDisplayPage.kt
@@ -581,6 +581,29 @@ fun SettingDisplayPage(vm: SettingVM = koinViewModel()) {
                                 )
                             },
                         )
+                        if (displaySetting.pasteLongTextAsFile) {
+                            item(
+                                headlineContent = { Text(stringResource(R.string.setting_display_page_paste_long_text_threshold_title)) },
+                                supportingContent = {
+                                    Row(
+                                        modifier = Modifier.fillMaxWidth(),
+                                        verticalAlignment = Alignment.CenterVertically,
+                                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                                    ) {
+                                        Slider(
+                                            value = displaySetting.pasteLongTextThreshold.toFloat(),
+                                            onValueChange = {
+                                                updateDisplaySetting(displaySetting.copy(pasteLongTextThreshold = it.toInt()))
+                                            },
+                                            valueRange = 100f..10000f,
+                                            steps = 98,
+                                            modifier = Modifier.weight(1f)
+                                        )
+                                        Text(text = "${displaySetting.pasteLongTextThreshold}")
+                                    }
+                                },
+                            )
+                        }
                         item(
                             headlineContent = { Text(stringResource(R.string.setting_display_page_volume_key_scroll_title)) },
                             supportingContent = { Text(stringResource(R.string.setting_display_page_volume_key_scroll_desc)) },
@@ -615,41 +638,6 @@ fun SettingDisplayPage(vm: SettingVM = koinViewModel()) {
                                     }
                                 }
                             )
-                        }
-                    }
-
-                    if (displaySetting.pasteLongTextAsFile) {
-                        Column(
-                            modifier = Modifier
-                                .padding(horizontal = 8.dp)
-                                .fillMaxWidth()
-                                .clip(RoundedCornerShape(20.dp))
-                                .background(MaterialTheme.colorScheme.surfaceBright)
-                        ) {
-                            ListItem(
-                                headlineContent = { Text(stringResource(R.string.setting_display_page_paste_long_text_threshold_title)) },
-                                colors = CustomColors.listItemColors,
-                            )
-                            Row(
-                                modifier = Modifier
-                                    .padding(horizontal = 16.dp)
-                                    .fillMaxWidth(),
-                                verticalAlignment = Alignment.CenterVertically,
-                                horizontalArrangement = Arrangement.spacedBy(8.dp),
-                            ) {
-                                Slider(
-                                    value = displaySetting.pasteLongTextThreshold.toFloat(),
-                                    onValueChange = {
-                                        updateDisplaySetting(displaySetting.copy(pasteLongTextThreshold = it.toInt()))
-                                    },
-                                    valueRange = 100f..10000f,
-                                    steps = 98,
-                                    modifier = Modifier.weight(1f)
-                                )
-                                Text(
-                                    text = "${displaySetting.pasteLongTextThreshold}",
-                                )
-                            }
                         }
                     }
                 }


### PR DESCRIPTION
## 问题
closes: #1025

在「设置 -> 显示设置」中，“文本长度阈值”应紧挨“粘贴长文本为文件”，
但实际被“音量键翻页”隔开，造成顺序不符合预期。

## 原因
“文本长度阈值”的条件渲染块位于交互设置 CardGroup 外部，
因此在列表中出现在“音量键翻页”相关项之后。

## 修复方案
将“文本长度阈值”条件条目移入同一 CardGroup，并紧跟在“粘贴长文本为文件”后方。
仅调整 UI 渲染顺序，不修改功能逻辑或配置结构。
