### PR TITLE
fix: 修复 Markdown details/summary 渲染问题

### DIFF
--- a/app/src/main/java/me/rerere/rikkahub/ui/components/richtext/Markdown.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/richtext/Markdown.kt
@@ -1,6 +1,7 @@
 package me.rerere.rikkahub.ui.components.richtext
 
 import android.content.Intent
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -22,6 +23,7 @@ import androidx.compose.foundation.text.appendInlineContent
 import androidx.compose.material3.ColorScheme
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
+import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ProvideTextStyle
@@ -32,6 +34,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.key
 import androidx.compose.runtime.referentialEqualityPolicy
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
@@ -219,13 +222,132 @@ fun MarkdownBlock(
         Column(
             modifier = modifier.padding(start = 4.dp)
         ) {
-            astTree.children.fastForEach { child ->
-                MarkdownNode(
-                    node = child, content = preprocessed, onClickCitation = onClickCitation
+            RenderMarkdownNodes(
+                nodes = astTree.children,
+                content = preprocessed,
+                onClickCitation = onClickCitation,
+            )
+        }
+    }
+}
+
+@Composable
+private fun RenderMarkdownNodes(
+    nodes: List<ASTNode>,
+    content: String,
+    modifier: Modifier = Modifier,
+    onClickCitation: (String) -> Unit = {},
+    listLevel: Int = 0,
+) {
+    var index = 0
+    while (index < nodes.size) {
+        val detailsBlock = collectMarkdownDetailsBlock(nodes, index, content)
+        if (detailsBlock != null) {
+            key(detailsBlock.stableKey) {
+                MarkdownDetailsNode(
+                    detailsBlock = detailsBlock,
+                    modifier = modifier,
+                    onClickCitation = onClickCitation,
+                    listLevel = listLevel,
+                )
+            }
+            if (detailsBlock.trailingMarkdown.isNotBlank()) {
+                RenderMarkdownFragment(
+                    content = detailsBlock.trailingMarkdown,
+                    modifier = modifier,
+                    onClickCitation = onClickCitation,
+                    listLevel = listLevel,
+                )
+            }
+            index += detailsBlock.consumedNodeCount
+            continue
+        }
+
+        MarkdownNode(
+            node = nodes[index],
+            content = content,
+            modifier = modifier,
+            onClickCitation = onClickCitation,
+            listLevel = listLevel,
+        )
+        index++
+    }
+}
+
+@Composable
+private fun MarkdownDetailsNode(
+    detailsBlock: MarkdownDetailsBlock,
+    modifier: Modifier = Modifier,
+    onClickCitation: (String) -> Unit = {},
+    listLevel: Int = 0,
+) {
+    val isExpandedState = remember(
+        detailsBlock.stableKey,
+        detailsBlock.isOpenByDefault,
+    ) {
+        mutableStateOf(detailsBlock.isOpenByDefault)
+    }
+    val isExpanded = isExpandedState.value
+    val summaryText = remember(detailsBlock.summaryHtml, detailsBlock.summaryText) {
+        detailsBlock.summaryHtml?.let(::buildAnnotatedStringFromHtmlFragment) ?: AnnotatedString(detailsBlock.summaryText)
+    }
+
+    Column(modifier = modifier.padding(vertical = 4.dp)) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .clickable { isExpandedState.value = !isExpandedState.value }
+                .padding(vertical = 8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                text = if (isExpanded) "▼ " else "▶ ",
+                style = LocalTextStyle.current.copy(color = LocalContentColor.current),
+            )
+            Text(
+                text = summaryText,
+                style = LocalTextStyle.current.copy(
+                    color = LocalContentColor.current,
+                    fontWeight = FontWeight.Medium,
+                ),
+            )
+        }
+
+        AnimatedVisibility(visible = isExpanded) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(start = 16.dp, top = 4.dp),
+            ) {
+                RenderMarkdownFragment(
+                    content = detailsBlock.contentMarkdown,
+                    onClickCitation = onClickCitation,
+                    listLevel = listLevel,
                 )
             }
         }
     }
+}
+
+@Composable
+private fun RenderMarkdownFragment(
+    content: String,
+    modifier: Modifier = Modifier,
+    onClickCitation: (String) -> Unit = {},
+    listLevel: Int = 0,
+) {
+    if (content.isBlank()) return
+
+    val astTree = remember(content) {
+        parser.buildMarkdownTreeFromString(content)
+    }
+    RenderMarkdownNodes(
+        nodes = astTree.children,
+        content = content,
+        modifier = modifier,
+        onClickCitation = onClickCitation,
+        listLevel = listLevel,
+    )
 }
 
 // for debug
@@ -273,11 +395,13 @@ private fun MarkdownNode(
     when (node.type) {
         // 文件根节点
         MarkdownElementTypes.MARKDOWN_FILE -> {
-            node.children.fastForEach { child ->
-                MarkdownNode(
-                    node = child, content = content, modifier = modifier, onClickCitation = onClickCitation
-                )
-            }
+            RenderMarkdownNodes(
+                nodes = node.children,
+                content = content,
+                modifier = modifier,
+                onClickCitation = onClickCitation,
+                listLevel = listLevel,
+            )
         }
 
         // 段落
@@ -387,11 +511,12 @@ private fun MarkdownNode(
                             )
                         }
                         .padding(8.dp)) {
-                    node.children.fastForEach { child ->
-                        MarkdownNode(
-                            node = child, content = content, onClickCitation = onClickCitation
-                        )
-                    }
+                    RenderMarkdownNodes(
+                        nodes = node.children,
+                        content = content,
+                        onClickCitation = onClickCitation,
+                        listLevel = listLevel,
+                    )
                 }
             }
         }
@@ -572,11 +697,13 @@ private fun MarkdownNode(
         // 其他类型的节点，递归处理子节点
         else -> {
             // 递归处理其他节点的子节点
-            node.children.fastForEach { child ->
-                MarkdownNode(
-                    node = child, content = content, modifier = modifier, onClickCitation = onClickCitation
-                )
-            }
+            RenderMarkdownNodes(
+                nodes = node.children,
+                content = content,
+                modifier = modifier,
+                onClickCitation = onClickCitation,
+                listLevel = listLevel,
+            )
         }
     }
 }
@@ -658,14 +785,12 @@ private fun ListItemNode(
                     horizontalArrangement = Arrangement.spacedBy(8.dp),
                     itemVerticalAlignment = Alignment.CenterVertically,
                 ) {
-                    directContent.fastForEach { contentChild ->
-                        MarkdownNode(
-                            node = contentChild,
-                            content = content,
-                            onClickCitation = onClickCitation,
-                            listLevel = level,
-                        )
-                    }
+                    RenderMarkdownNodes(
+                        nodes = directContent,
+                        content = content,
+                        onClickCitation = onClickCitation,
+                        listLevel = level,
+                    )
                 }
             }
         }

--- a/app/src/main/java/me/rerere/rikkahub/ui/components/richtext/MarkdownDetails.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/richtext/MarkdownDetails.kt
@@ -1,0 +1,177 @@
+package me.rerere.rikkahub.ui.components.richtext
+
+import org.intellij.markdown.MarkdownElementTypes
+import org.intellij.markdown.ast.ASTNode
+import org.jsoup.Jsoup
+
+private val DETAILS_OPEN_TAG_REGEX = Regex("<details(?:\\s[^>]*)?>", RegexOption.IGNORE_CASE)
+private val DETAILS_CLOSE_TAG_REGEX = Regex("</details>", RegexOption.IGNORE_CASE)
+private val DETAILS_TAG_REGEX = Regex(
+    "<details(?:\\s[^>]*)?>|</details>",
+    RegexOption.IGNORE_CASE,
+)
+private val DETAILS_SUMMARY_TAG_REGEX = Regex(
+    "^\\s*<summary(?:\\s[^>]*)?>([\\s\\S]*?)</summary>\\s*",
+    setOf(RegexOption.IGNORE_CASE, RegexOption.DOT_MATCHES_ALL),
+)
+
+private data class MarkdownDetailsMeta(
+    val summaryHtml: String?,
+    val summaryText: String,
+    val bodyMarkdown: String,
+    val isOpenByDefault: Boolean,
+)
+
+internal data class MarkdownDetailsBlock(
+    val summaryHtml: String?,
+    val summaryText: String,
+    val contentMarkdown: String,
+    val trailingMarkdown: String,
+    val consumedNodeCount: Int,
+    val isOpenByDefault: Boolean,
+    val stableKey: String,
+)
+
+internal fun collectMarkdownDetailsBlock(
+    nodes: List<ASTNode>,
+    startIndex: Int,
+    content: String,
+): MarkdownDetailsBlock? {
+    if (startIndex !in nodes.indices) return null
+
+    val startNode = nodes[startIndex]
+    if (startNode.type != MarkdownElementTypes.HTML_BLOCK) return null
+
+    val detailsSource = StringBuilder()
+    var depth = 0
+
+    for (index in startIndex until nodes.size) {
+        val child = nodes[index]
+        val childText = child.textIn(content)
+
+        if (child.type == MarkdownElementTypes.HTML_BLOCK) {
+            val scan = scanDetailsHtmlBlock(
+                html = childText,
+                initialDepth = depth,
+                requireOpeningTag = index == startIndex,
+            ) ?: return null
+
+            val consumedText = if (scan.closeEndIndex != null) {
+                childText.substring(0, scan.closeEndIndex)
+            } else {
+                childText
+            }
+            detailsSource.append(consumedText)
+            depth = scan.depthAfter
+
+            if (scan.closeEndIndex != null) {
+                val meta = detailsSource.toString().parseMarkdownDetailsMeta() ?: return null
+                return MarkdownDetailsBlock(
+                    summaryHtml = meta.summaryHtml,
+                    summaryText = meta.summaryText,
+                    contentMarkdown = meta.bodyMarkdown,
+                    trailingMarkdown = childText.substring(scan.closeEndIndex),
+                    consumedNodeCount = index - startIndex + 1,
+                    isOpenByDefault = meta.isOpenByDefault,
+                    stableKey = "${startNode.startOffset}:${child.startOffset + scan.closeEndIndex}",
+                )
+            }
+        } else {
+            detailsSource.append(childText)
+        }
+    }
+
+    return null
+}
+
+private fun String.parseMarkdownDetailsMeta(): MarkdownDetailsMeta? {
+    val openingTag = DETAILS_OPEN_TAG_REGEX.find(this) ?: return null
+    if (substring(0, openingTag.range.first).isNotBlank()) return null
+
+    val closingTagRange = findMatchingDetailsClosingTagRange(this) ?: return null
+    val innerContent = substring(openingTag.range.last + 1, closingTagRange.first)
+    val summaryMatch = DETAILS_SUMMARY_TAG_REGEX.find(innerContent)
+    val summaryHtml = summaryMatch?.groupValues?.getOrNull(1)?.takeIf { it.isNotBlank() }
+    val summaryText = summaryHtml?.parseSummaryText() ?: "Details"
+
+    return MarkdownDetailsMeta(
+        summaryHtml = summaryHtml,
+        summaryText = summaryText,
+        bodyMarkdown = if (summaryMatch != null) {
+            innerContent.substring(summaryMatch.range.last + 1)
+        } else {
+            innerContent
+        },
+        isOpenByDefault = runCatching {
+            Jsoup.parseBodyFragment(openingTag.value).selectFirst("details")?.hasAttr("open") == true
+        }.getOrDefault(false),
+    )
+}
+
+private fun String.parseSummaryText(): String {
+    return runCatching {
+        Jsoup.parseBodyFragment("<summary>$this</summary>").selectFirst("summary")?.text()
+    }.getOrNull()?.ifBlank { "Details" } ?: "Details"
+}
+
+private fun scanDetailsHtmlBlock(
+    html: String,
+    initialDepth: Int,
+    requireOpeningTag: Boolean,
+): DetailsHtmlBlockScan? {
+    var depth = initialDepth
+    var hasOpeningTag = initialDepth > 0
+
+    if (requireOpeningTag) {
+        val openingTag = DETAILS_OPEN_TAG_REGEX.find(html) ?: return null
+        if (html.substring(0, openingTag.range.first).isNotBlank()) return null
+    }
+
+    DETAILS_TAG_REGEX.findAll(html).forEach { match ->
+        if (match.value.startsWith("</", ignoreCase = true)) {
+            depth--
+            if (hasOpeningTag && depth == 0) {
+                return DetailsHtmlBlockScan(
+                    closeEndIndex = match.range.last + 1,
+                    depthAfter = 0,
+                )
+            }
+        } else {
+            hasOpeningTag = true
+            depth++
+        }
+    }
+
+    return if (hasOpeningTag) {
+        DetailsHtmlBlockScan(
+            closeEndIndex = null,
+            depthAfter = depth,
+        )
+    } else {
+        null
+    }
+}
+
+private fun findMatchingDetailsClosingTagRange(content: String): IntRange? {
+    var depth = 0
+
+    DETAILS_TAG_REGEX.findAll(content).forEach { match ->
+        if (match.value.startsWith("</", ignoreCase = true)) {
+            depth--
+            if (depth == 0) {
+                return match.range
+            }
+        } else {
+            depth++
+        }
+    }
+
+    return null
+}
+
+private data class DetailsHtmlBlockScan(
+    val closeEndIndex: Int?,
+    val depthAfter: Int,
+)
+
+private fun ASTNode.textIn(content: String): String = content.substring(startOffset, endOffset)

--- a/app/src/main/java/me/rerere/rikkahub/ui/components/richtext/SimpleHtmlBlock.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/richtext/SimpleHtmlBlock.kt
@@ -28,11 +28,13 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.LinkAnnotation
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.text.withLink
 import androidx.compose.ui.unit.dp
 import androidx.core.graphics.toColorInt
 import me.rerere.rikkahub.ui.components.table.DataTable
@@ -310,19 +312,36 @@ private fun RenderImage(
     }
 }
 
+internal fun buildAnnotatedStringFromHtmlFragment(html: String): AnnotatedString {
+    val element = runCatching {
+        Jsoup.parseBodyFragment("<span>$html</span>").body().children().singleOrNull()
+    }.getOrNull()
+
+    return if (element != null) {
+        buildAnnotatedStringFromElement(element)
+    } else {
+        AnnotatedString(html)
+    }
+}
+
 private fun buildAnnotatedStringFromElement(
     element: Element,
     onLinkClick: (String) -> Unit
 ): AnnotatedString {
+    return buildAnnotatedStringFromElement(element)
+}
+
+private fun buildAnnotatedStringFromElement(
+    element: Element,
+): AnnotatedString {
     return buildAnnotatedString {
-        processElementNodes(element, this, onLinkClick)
+        processElementNodes(element, this)
     }
 }
 
 private fun processElementNodes(
     element: Element,
     builder: AnnotatedString.Builder,
-    onLinkClick: (String) -> Unit
 ) {
     element.childNodes().forEach { node ->
         when (node) {
@@ -334,7 +353,7 @@ private fun processElementNodes(
                 when (node.tagName().lowercase()) {
                     "b", "strong" -> {
                         val start = builder.length
-                        processElementNodes(node, builder, onLinkClick)
+                        processElementNodes(node, builder)
                         builder.addStyle(
                             SpanStyle(fontWeight = FontWeight.Bold),
                             start,
@@ -344,7 +363,7 @@ private fun processElementNodes(
 
                     "i", "em" -> {
                         val start = builder.length
-                        processElementNodes(node, builder, onLinkClick)
+                        processElementNodes(node, builder)
                         builder.addStyle(
                             SpanStyle(fontStyle = FontStyle.Italic),
                             start,
@@ -354,7 +373,7 @@ private fun processElementNodes(
 
                     "u" -> {
                         val start = builder.length
-                        processElementNodes(node, builder, onLinkClick)
+                        processElementNodes(node, builder)
                         builder.addStyle(
                             SpanStyle(textDecoration = TextDecoration.Underline),
                             start,
@@ -364,29 +383,29 @@ private fun processElementNodes(
 
                     "a" -> {
                         val href = node.attr("href")
-                        val start = builder.length
-                        processElementNodes(node, builder, onLinkClick)
                         if (href.isNotEmpty()) {
-                            builder.addStyle(
-                                SpanStyle(
-                                    color = Color.Blue,
-                                    textDecoration = TextDecoration.Underline
-                                ),
-                                start,
-                                builder.length
-                            )
-                            builder.addStringAnnotation(
-                                tag = "URL",
-                                annotation = href,
-                                start = start,
-                                end = builder.length
-                            )
+                            with(builder) {
+                                withLink(LinkAnnotation.Url(href)) {
+                                    val start = length
+                                    processElementNodes(node, this)
+                                    addStyle(
+                                        SpanStyle(
+                                            color = Color.Blue,
+                                            textDecoration = TextDecoration.Underline
+                                        ),
+                                        start,
+                                        length
+                                    )
+                                }
+                            }
+                        } else {
+                            processElementNodes(node, builder)
                         }
                     }
 
                     "code" -> {
                         val start = builder.length
-                        processElementNodes(node, builder, onLinkClick)
+                        processElementNodes(node, builder)
                         builder.addStyle(
                             SpanStyle(
                                 fontFamily = androidx.compose.ui.text.font.FontFamily.Monospace,
@@ -403,7 +422,7 @@ private fun processElementNodes(
 
                     "span" -> {
                         val start = builder.length
-                        processElementNodes(node, builder, onLinkClick)
+                        processElementNodes(node, builder)
 
                         // Handle inline styles
                         val style = node.attr("style")
@@ -421,7 +440,7 @@ private fun processElementNodes(
 
                     "font" -> {
                         val start = builder.length
-                        processElementNodes(node, builder, onLinkClick)
+                        processElementNodes(node, builder)
 
                         // Handle font color attribute
                         val color = node.attr("color")
@@ -438,7 +457,7 @@ private fun processElementNodes(
                     }
 
                     else -> {
-                        processElementNodes(node, builder, onLinkClick)
+                        processElementNodes(node, builder)
                     }
                 }
             }

--- a/app/src/test/java/me/rerere/rikkahub/ui/components/richtext/MarkdownDetailsGroupingTest.kt
+++ b/app/src/test/java/me/rerere/rikkahub/ui/components/richtext/MarkdownDetailsGroupingTest.kt
@@ -1,0 +1,128 @@
+package me.rerere.rikkahub.ui.components.richtext
+
+import org.intellij.markdown.ast.ASTNode
+import org.intellij.markdown.flavours.gfm.GFMFlavourDescriptor
+import org.intellij.markdown.parser.MarkdownParser
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class MarkdownDetailsGroupingTest {
+    private val parser = MarkdownParser(
+        GFMFlavourDescriptor(
+            makeHttpsAutoLinks = true,
+            useSafeLinks = true,
+        )
+    )
+
+    @Test
+    fun `collectMarkdownDetailsBlock should group markdown body inside details`() {
+        val content = """
+            <details>
+            <summary>点我展开/收起</summary>
+
+            这里是被折叠的内容，
+            支持**加粗**、*斜体*、甚至 [链接](https://github.com)。
+
+            </details>
+        """.trimIndent()
+
+        val astTree = parser.buildMarkdownTreeFromString(content)
+        val detailsBlock = collectMarkdownDetailsBlock(astTree.children, 0, content)
+
+        assertNotNull(detailsBlock)
+        assertEquals("点我展开/收起", detailsBlock?.summaryText)
+        assertFalse(detailsBlock?.isOpenByDefault ?: true)
+        assertEquals("", detailsBlock?.trailingMarkdown)
+
+        val bodyText = detailsBlock?.contentMarkdown.orEmpty()
+        assertTrue(bodyText.contains("这里是被折叠的内容"))
+        assertTrue(bodyText.contains("**加粗**"))
+        assertFalse(bodyText.contains("</details>"))
+    }
+
+    @Test
+    fun `collectMarkdownDetailsBlock should preserve siblings around details`() {
+        val content = """
+            展开前的说明
+
+            <details>
+            <summary>More</summary>
+
+            hidden
+
+            </details>
+
+            展开后的说明
+        """.trimIndent()
+
+        val blocks = collectRenderedBlocks(content)
+        val siblingText = blocks
+            .filterIsInstance<ASTNode>()
+            .joinToString("\n") { content.substring(it.startOffset, it.endOffset) }
+
+        assertEquals(1, blocks.count { it is MarkdownDetailsBlock })
+        assertTrue(siblingText.contains("展开前的说明"))
+        assertTrue(siblingText.contains("展开后的说明"))
+    }
+
+    @Test
+    fun `collectMarkdownDetailsBlock should support compact single line details`() {
+        val content = "<details><summary>More</summary>hidden</details>"
+
+        val astTree = parser.buildMarkdownTreeFromString(content)
+        val detailsBlock = collectMarkdownDetailsBlock(astTree.children, 0, content)
+
+        assertNotNull(detailsBlock)
+        assertEquals("More", detailsBlock?.summaryText)
+        assertEquals("hidden", detailsBlock?.contentMarkdown)
+        assertEquals("", detailsBlock?.trailingMarkdown)
+    }
+
+    @Test
+    fun `collectMarkdownDetailsBlock should keep html body from opening block`() {
+        val content = "<details><summary><strong>More</strong></summary><div>html</div></details>"
+
+        val astTree = parser.buildMarkdownTreeFromString(content)
+        val detailsBlock = collectMarkdownDetailsBlock(astTree.children, 0, content)
+
+        assertNotNull(detailsBlock)
+        assertTrue(detailsBlock?.summaryHtml?.contains("<strong>More</strong>") == true)
+        assertEquals("<div>html</div>", detailsBlock?.contentMarkdown)
+    }
+
+    @Test
+    fun `collectMarkdownDetailsBlock should expose trailing markdown after closing tag`() {
+        val content = "<details><summary>More</summary>hidden</details>after"
+
+        val astTree = parser.buildMarkdownTreeFromString(content)
+        val detailsBlock = collectMarkdownDetailsBlock(astTree.children, 0, content)
+
+        assertNotNull(detailsBlock)
+        assertEquals("after", detailsBlock?.trailingMarkdown)
+    }
+
+    private fun collectRenderedBlocks(content: String): List<Any> {
+        val astTree = parser.buildMarkdownTreeFromString(content)
+        val blocks = mutableListOf<Any>()
+        var index = 0
+
+        while (index < astTree.children.size) {
+            val detailsBlock = collectMarkdownDetailsBlock(astTree.children, index, content)
+            if (detailsBlock != null) {
+                blocks += detailsBlock
+                if (detailsBlock.trailingMarkdown.isNotBlank()) {
+                    blocks.addAll(parser.buildMarkdownTreeFromString(detailsBlock.trailingMarkdown).children)
+                }
+                index += detailsBlock.consumedNodeCount
+            } else {
+                blocks += astTree.children[index]
+                index++
+            }
+        }
+
+        return blocks
+    }
+}


### PR DESCRIPTION
## 概要
- 修复 `<details>` 在紧凑写法和混合 HTML/Markdown 场景下的解析问题
- 保留 `<summary>` 的富文本渲染，不再被降级为纯文本
- 正确处理 `</details>` 后的尾随 Markdown 内容
- 稳定折叠块在流式更新和重新解析过程中的展开状态
- 补充紧凑写法、内联 HTML、尾随内容等回归测试

## 测试
- `./gradlew :app:testDebugUnitTest --tests me.rerere.rikkahub.ui.components.richtext.MarkdownDetailsGroupingTest`
- `./gradlew :app:assembleDebug`

Fixes #1041