### PR TITLE
fix: 修复 Grounding 模式下输出空方括号 [] 导致流中断的问题

### DIFF
--- a/app/src/main/java/me/rerere/rikkahub/ui/components/richtext/Markdown.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/richtext/Markdown.kt
@@ -735,18 +735,25 @@ private fun Paragraph(
     ) {
         val annotatedString = remember(content, enableLatexRendering) {
             buildAnnotatedString {
-                node.children.fastForEach { child ->
-                    appendMarkdownNodeContent(
-                        node = child,
-                        content = content,
-                        inlineContents = inlineContents,
-                        colorScheme = colorScheme,
-                        onClickCitation = onClickCitation,
-                        style = textStyle,
-                        density = density,
-                        trim = trim,
-                        enableLatexRendering = enableLatexRendering,
-                    )
+                // ✅ FIX 1: 添加 try-catch 拦截隐式异常，防止 Compose 崩溃导致协程 Cancel 断流
+                try {
+                    node.children.fastForEach { child ->
+                        appendMarkdownNodeContent(
+                            node = child,
+                            content = content,
+                            inlineContents = inlineContents,
+                            colorScheme = colorScheme,
+                            onClickCitation = onClickCitation,
+                            style = textStyle,
+                            density = density,
+                            trim = trim,
+                            enableLatexRendering = enableLatexRendering,
+                        )
+                    }
+                } catch (e: Exception) {
+                    e.printStackTrace()
+                    // 降级处理：如果 Markdown AST 节点解析越界或失败，直接追加原文，保证流不断
+                    append(node.getTextInNode(content))
                 }
             }
         }
@@ -907,11 +914,14 @@ private fun AnnotatedString.Builder.appendMarkdownNodeContent(
                 node.findChildOfTypeRecursive(MarkdownElementTypes.LINK_DESTINATION)?.getTextInNode(content) ?: ""
             val linkText = node.findChildOfTypeRecursive(MarkdownElementTypes.LINK_TEXT)?.getTextInNode(content)
                 ?.trim { it == '[' || it == ']' } ?: linkDest
+                
             if (linkText.startsWith("citation,")) {
                 // 如果是引用，则特殊处理
                 val domain = linkText.substringAfter("citation,")
                 val id = linkDest
-                if (id.length == 6) {
+                
+                // ✅ FIX 2: 增加 domain.isNotEmpty() 校验，防止计算 width 异常
+                if (id.length == 6 && domain.isNotEmpty()) {
                     inlineContents.putIfAbsent(
                         "citation:$linkDest", InlineTextContent(
                             placeholder = Placeholder(
@@ -943,16 +953,25 @@ private fun AnnotatedString.Builder.appendMarkdownNodeContent(
                             })
                     )
                     appendInlineContent("citation:$linkDest")
+                } else {
+                    // ✅ FIX 3: 缺少 else 分支的致命 BUG！
+                    // 如果模型输出了空的 [] 导致无法解析 citation，降级作为普通文本输出，不再吃掉字符
+                    append(node.getTextInNode(content))
                 }
             } else {
-                withLink(LinkAnnotation.Url(linkDest)) {
-                    withStyle(
-                        SpanStyle(
-                            color = colorScheme.primary, textDecoration = TextDecoration.Underline
-                        )
-                    ) {
-                        append(linkText)
+                // ✅ FIX 4: 防止普通链接 linkDest 为空时，LinkAnnotation.Url 抛出越界或非法参数异常
+                if (linkDest.isNotBlank()) {
+                    withLink(LinkAnnotation.Url(linkDest)) {
+                        withStyle(
+                            SpanStyle(
+                                color = colorScheme.primary, textDecoration = TextDecoration.Underline
+                            )
+                        ) {
+                            append(linkText)
+                        }
                     }
+                } else {
+                    append(node.getTextInNode(content))
                 }
             }
         }


### PR DESCRIPTION
## 问题描述
开启 Grounding (联网检索) 功能时，若模型流式输出正好包含空的方括号 `[]`，客户端的文本渲染会瞬间中断。该异常不会导致 App 崩溃，且最终能正常收到底部的 Token 统计。关闭 Grounding 时则无此现象。

## 根因分析
该问题本质是 Compose UI 层的隐式异常引发了协程的静默取消 (Silent Cancellation)，导致上游 Flow 收集意外终止：
在 `Markdown.kt` 处理引用标记解析时，遇到空括号 `[]` 会被 AST 识别为 `INLINE_LINK`，但提取出的 `linkDest` 和 `domain` 均为空字符串。此时由于未能通过 `id.length == 6` 的校验，且代码缺失对应的 `else` 降级处理分支，引发了组件渲染异常。该异常导致 `buildAnnotatedString` 所在的协程被取消，进而中断了整个流式响应的展示。

## 修复实现
对 `Markdown.kt` 中的解析逻辑进行了防御性修复：
1. **完善链路解析分支:** 在 `INLINE_LINK` 处理逻辑中补充 `domain.isNotEmpty()` 校验。同时增加关键的 `else` 降级分支，当遇到空括号或非法引用格式时，回退将其作为普通文本渲染，避免因解析失败导致字符丢失。
2. **增加协程安全网:** 在 `Paragraph` 组件的 `buildAnnotatedString` 外部包裹 `try-catch` 拦截。若发生 AST 节点越界或解析失败，直接降级追加原文，防止未捕获的解析异常导致协程意外退出，保障流式渲染的稳定性。

## 测试验证
本地真机测试通过。开启 Grounding 并在 Prompt 中尝试要求模型输出 `[]` 时，文本渲染流程完整，未发生流截断现象。

![Image](https://github.com/user-attachments/assets/cc6ca28a-3524-40cd-8f31-c5c5d53444f2)