### PR TITLE
fix: 修复系统相册选择图片导致崩溃

### DIFF
--- a/app/src/main/java/me/rerere/rikkahub/data/files/FilesManager.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/files/FilesManager.kt
@@ -131,15 +131,14 @@ class FilesManager(
             dir.mkdirs()
         }
         uris.forEach { uri ->
-            val sourceName = getFileNameFromUri(uri) ?: uri.lastPathSegment ?: "file"
-            val sourceMime = getFileMimeType(uri)
-            val fileName = buildUuidFileName(displayName = sourceName, mimeType = sourceMime)
-            val file = dir.resolve(fileName)
-            if (!file.exists()) {
-                file.createNewFile()
-            }
-            val newUri = file.toUri()
             runCatching {
+                val sourceName = getFileNameFromUri(uri) ?: uri.lastPathSegment ?: "file"
+                val sourceMime = getFileMimeType(uri)
+                val fileName = buildUuidFileName(displayName = sourceName, mimeType = sourceMime)
+                val file = dir.resolve(fileName)
+                if (!file.exists()) {
+                    file.createNewFile()
+                }
                 context.contentResolver.openInputStream(uri)?.use { inputStream ->
                     file.outputStream().use { outputStream ->
                         inputStream.copyTo(outputStream)
@@ -147,7 +146,7 @@ class FilesManager(
                 }
                 val guessedMime = sourceMime ?: guessMimeType(file, sourceName)
                 trackUploadFile(file = file, displayName = sourceName, mimeType = guessedMime)
-                newUris.add(newUri)
+                newUris.add(file.toUri())
             }.onFailure {
                 it.printStackTrace()
                 Log.e(TAG, "createChatFilesByContents: Failed to save file from $uri", it)
@@ -425,31 +424,39 @@ class FilesManager(
     }
 
     fun getFileNameFromUri(uri: Uri): String? {
-        var fileName: String? = null
-        val projection = arrayOf(
-            OpenableColumns.DISPLAY_NAME,
-            DocumentsContract.Document.COLUMN_DISPLAY_NAME
-        )
-        context.contentResolver.query(uri, projection, null, null, null)?.use { cursor ->
-            if (cursor.moveToFirst()) {
-                val documentDisplayNameIndex =
-                    cursor.getColumnIndex(DocumentsContract.Document.COLUMN_DISPLAY_NAME)
-                if (documentDisplayNameIndex != -1) {
-                    fileName = cursor.getString(documentDisplayNameIndex)
-                } else {
-                    val openableDisplayNameIndex = cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME)
-                    if (openableDisplayNameIndex != -1) {
-                        fileName = cursor.getString(openableDisplayNameIndex)
+        return runCatching {
+            var fileName: String? = null
+            val projection = arrayOf(
+                OpenableColumns.DISPLAY_NAME,
+                DocumentsContract.Document.COLUMN_DISPLAY_NAME
+            )
+            context.contentResolver.query(uri, projection, null, null, null)?.use { cursor ->
+                if (cursor.moveToFirst()) {
+                    val documentDisplayNameIndex =
+                        cursor.getColumnIndex(DocumentsContract.Document.COLUMN_DISPLAY_NAME)
+                    if (documentDisplayNameIndex != -1) {
+                        fileName = cursor.getString(documentDisplayNameIndex)
+                    } else {
+                        val openableDisplayNameIndex = cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME)
+                        if (openableDisplayNameIndex != -1) {
+                            fileName = cursor.getString(openableDisplayNameIndex)
+                        }
                     }
                 }
             }
-        }
-        return fileName
+            fileName
+        }.onFailure {
+            Log.w(TAG, "getFileNameFromUri: Failed to query display name for $uri", it)
+        }.getOrNull()
     }
 
     fun getFileMimeType(uri: Uri): String? {
         return when (uri.scheme) {
-            "content" -> context.contentResolver.getType(uri)
+            "content" -> runCatching {
+                context.contentResolver.getType(uri)
+            }.onFailure {
+                Log.w(TAG, "getFileMimeType: Failed to resolve MIME for $uri", it)
+            }.getOrNull()
             else -> null
         }
     }


### PR DESCRIPTION
## 问题

Android 8.1 上通过系统相册选择图片时，应用因 `SecurityException` 直接崩溃并进入安全模式。

Closes #1039

## 原因

`FilesManager.getFileNameFromUri()` 直接调用 `contentResolver.query()` 查询 URI 元数据，而系统相册返回的 MediaStore URI 在低版本 Android 上需要 `READ_EXTERNAL_STORAGE` 权限才允许元数据查询。该异常发生在 `createChatFilesByContents()` 的 `runCatching` 保护范围之外，导致未被捕获而崩溃。

## 修复

1. **`getFileNameFromUri()`**：将 `contentResolver.query()` 包裹在 `runCatching` 中，失败时返回 `null`，由调用方走既有 fallback 链（`uri.lastPathSegment` → `"file"`）。
2. **`getFileMimeType()`**：同样将 `contentResolver.getType()` 做防御式封装，失败返回 `null`。
3. **`createChatFilesByContents()`**：将 URI 元数据读取、文件名生成、文件创建统一移入 per-URI 的 `runCatching` 范围内，确保单个 URI 异常不影响整批文件处理。

## 验证

- 仅修改 `FilesManager.kt`，改动 +34/-27 行
- 静态检查确认 `FilesManager` 中所有 `contentResolver.query()` 和 `contentResolver.getType()` 调用均已受保护
- 无新增权限，无额外重构