### PR TITLE
fix: 修复工具调用后统计信息显示不准确

### DIFF
--- a/ai/src/main/java/me/rerere/ai/provider/providers/ClaudeProvider.kt
+++ b/ai/src/main/java/me/rerere/ai/provider/providers/ClaudeProvider.kt
@@ -571,7 +571,7 @@ class ClaudeProvider(private val client: OkHttpClient, context: Context? = null)
             promptTokens = promptTokens,
             completionTokens = completionTokens,
             totalTokens = promptTokens + completionTokens,
-            cachedTokens = cachedInputTokens,
+                cachedTokens = cachedInputTokens + cachedCreationTokens,
         )
     }
 }

--- a/ai/src/main/java/me/rerere/ai/ui/Message.kt
+++ b/ai/src/main/java/me/rerere/ai/ui/Message.kt
@@ -27,6 +27,7 @@ data class UIMessage(
     val finishedAt: LocalDateTime? = null,
     val modelId: Uuid? = null,
     val usage: TokenUsage? = null,
+    val pendingUsage: TokenUsage? = null,
     val translation: String? = null
 ) {
     private fun appendChunk(chunk: MessageChunk): UIMessage {

--- a/app/src/main/java/me/rerere/rikkahub/data/ai/GenerationHandler.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/ai/GenerationHandler.kt
@@ -14,8 +14,8 @@ import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 import me.rerere.ai.core.MessageRole
+import me.rerere.ai.core.TokenUsage
 import me.rerere.ai.core.Tool
-import me.rerere.ai.core.merge
 import me.rerere.ai.provider.CustomBody
 import me.rerere.ai.provider.Model
 import me.rerere.ai.provider.Provider
@@ -55,6 +55,11 @@ sealed interface GenerationChunk {
     ) : GenerationChunk
 }
 
+private data class GenerationRoundResult(
+    val messages: List<UIMessage>,
+    val usage: TokenUsage?
+)
+
 class GenerationHandler(
     private val context: Context,
     private val providerManager: ProviderManager,
@@ -78,6 +83,7 @@ class GenerationHandler(
         val providerImpl = providerManager.getProviderByType(provider)
 
         var messages: List<UIMessage> = messages
+        var accumulatedUsage = messages.lastOrNull()?.pendingUsage ?: messages.lastOrNull()?.usage
 
         for (stepIndex in 0 until maxSteps) {
             Log.i(TAG, "streamText: start step #$stepIndex (${model.id})")
@@ -115,7 +121,7 @@ class GenerationHandler(
 
             // Skip generation if we have approved/denied tool calls to handle
             if (pendingTools.isEmpty()) {
-                generateInternal(
+                val generationResult = generateInternal(
                     assistant = assistant,
                     settings = settings,
                     messages = messages,
@@ -147,7 +153,7 @@ class GenerationHandler(
                     memories = memories ?: emptyList(),
                     stream = assistant.streamOutput
                 )
-                messages = messages.visualTransforms(
+                messages = generationResult.messages.visualTransforms(
                     transformers = outputTransformers,
                     context = context,
                     model = model,
@@ -161,17 +167,30 @@ class GenerationHandler(
                     assistant = assistant,
                     settings = settings
                 )
-                messages = messages.slice(0 until messages.lastIndex) + messages.last().copy(
-                    finishedAt = Clock.System.now()
-                        .toLocalDateTime(TimeZone.currentSystemDefault())
-                )
-                emit(GenerationChunk.Messages(messages))
+                accumulatedUsage = accumulateUsage(accumulatedUsage, generationResult.usage)
 
                 val tools = messages.last().getTools().filter { !it.isExecuted }
                 if (tools.isEmpty()) {
-                    // no tool calls, break
+                    messages = messages.updateLastMessage { message ->
+                        message.copy(
+                            usage = accumulatedUsage,
+                            pendingUsage = null,
+                            finishedAt = Clock.System.now()
+                                .toLocalDateTime(TimeZone.currentSystemDefault())
+                        )
+                    }
+                    emit(GenerationChunk.Messages(messages))
                     break
                 }
+
+                messages = messages.updateLastMessage { message ->
+                    message.copy(
+                        usage = null,
+                        pendingUsage = accumulatedUsage,
+                        finishedAt = null
+                    )
+                }
+                emit(GenerationChunk.Messages(messages))
 
                 // Check for tools that need approval
                 var hasPendingApproval = false
@@ -332,7 +351,7 @@ class GenerationHandler(
         tools: List<Tool>,
         memories: List<AssistantMemory>,
         stream: Boolean
-    ) {
+    ): GenerationRoundResult {
         val internalMessages = buildList {
             val system = buildString {
                 // 如果助手有系统提示，则添加到消息中
@@ -367,6 +386,7 @@ class GenerationHandler(
         )
 
         var messages: List<UIMessage> = messages
+        var roundUsage: TokenUsage? = null
         val params = TextGenerationParams(
             model = model,
             temperature = assistant.temperature,
@@ -398,20 +418,7 @@ class GenerationHandler(
                 params = params
             ).collect {
                 messages = messages.handleMessageChunk(chunk = it, model = model)
-                it.usage?.let { usage ->
-                    messages = messages.mapIndexed { index, message ->
-                        if (index == messages.lastIndex) {
-                            val merged = message.usage.merge(usage)
-                            if (message.usage == null || merged.totalTokens >= (message.usage?.totalTokens ?: 0)) {
-                                message.copy(usage = merged)
-                            } else {
-                                message
-                            }
-                        } else {
-                            message
-                        }
-                    }
-                }
+                roundUsage = it.usage ?: roundUsage
                 onUpdateMessages(messages)
             }
         } else {
@@ -429,22 +436,31 @@ class GenerationHandler(
                 params = params,
             )
             messages = messages.handleMessageChunk(chunk = chunk, model = model)
-            chunk.usage?.let { usage ->
-                messages = messages.mapIndexed { index, message ->
-                    if (index == messages.lastIndex) {
-                        val merged = message.usage.merge(usage)
-                        if (message.usage == null || merged.totalTokens >= (message.usage?.totalTokens ?: 0)) {
-                            message.copy(usage = merged)
-                        } else {
-                            message
-                        }
-                    } else {
-                        message
-                    }
-                }
-            }
+            roundUsage = chunk.usage
             onUpdateMessages(messages)
         }
+        return GenerationRoundResult(messages = messages, usage = roundUsage)
+    }
+
+    private fun List<UIMessage>.updateLastMessage(transform: (UIMessage) -> UIMessage): List<UIMessage> {
+        if (isEmpty()) return this
+        return dropLast(1) + transform(last())
+    }
+
+    private fun accumulateUsage(current: TokenUsage?, round: TokenUsage?): TokenUsage? {
+        if (round == null) return current
+        if (current == null) return round
+
+        val promptTokens = current.promptTokens + round.promptTokens
+        val completionTokens = current.completionTokens + round.completionTokens
+        val cachedTokens = current.cachedTokens + round.cachedTokens
+
+        return TokenUsage(
+            promptTokens = promptTokens,
+            completionTokens = completionTokens,
+            cachedTokens = cachedTokens,
+            totalTokens = promptTokens + completionTokens
+        )
     }
 
     fun translateText(

--- a/app/src/main/java/me/rerere/rikkahub/data/ai/GenerationHandler.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/ai/GenerationHandler.kt
@@ -401,7 +401,12 @@ class GenerationHandler(
                 it.usage?.let { usage ->
                     messages = messages.mapIndexed { index, message ->
                         if (index == messages.lastIndex) {
-                            message.copy(usage = message.usage.merge(usage))
+                            val merged = message.usage.merge(usage)
+                            if (message.usage == null || merged.totalTokens >= (message.usage?.totalTokens ?: 0)) {
+                                message.copy(usage = merged)
+                            } else {
+                                message
+                            }
                         } else {
                             message
                         }
@@ -427,9 +432,12 @@ class GenerationHandler(
             chunk.usage?.let { usage ->
                 messages = messages.mapIndexed { index, message ->
                     if (index == messages.lastIndex) {
-                        message.copy(
-                            usage = message.usage.merge(usage)
-                        )
+                        val merged = message.usage.merge(usage)
+                        if (message.usage == null || merged.totalTokens >= (message.usage?.totalTokens ?: 0)) {
+                            message.copy(usage = merged)
+                        } else {
+                            message
+                        }
                     } else {
                         message
                     }


### PR DESCRIPTION
## 问题

当模型触发工具、搜索或 MCP 多轮调用时，底部的 Token 统计信息会在中间轮次提前显示，后续输出阶段不再稳定更新，最终还可能被后续较小的 usage 覆盖，表现为统计值跳低或冻结。

Closes #1030

## 原因

现有实现会在每个 generation round 的 chunk 处理中直接把 provider 返回的 usage 写回同一条 assistant 消息，同时还会在每个 round 结束后提前设置 finishedAt。

这会带来两个问题：

1. provider 返回的 usage 是单次 generation round 的 usage，不是整个多轮工具链的累计 usage；
2. 中间 round 过早写入 usage 和 finishedAt，会让 UI 提前显示统计，并在后续 round 继续输出时出现冻结或覆盖。

## 修复

本次将 usage 结算从 chunk 级别调整为 generation round 级别：

1. generateInternal() 不再在流式 chunk 到来时直接写回 message.usage，而是仅记录当前 round 的最终 usage；
2. 在 generateText() 中按 round 累计 usage，并把中间结果写入隐藏态 pendingUsage；
3. 只有当整次回答真正结束、且不再有后续工具 round 时，才把累计后的 usage 写入可见的 usage，同时设置最终 finishedAt；