### PR TITLE
feat(claude): 支持 Claude 4.6 adaptive thinking 与 effort 参数

### DIFF
--- a/ai/src/main/java/me/rerere/ai/provider/providers/ClaudeProvider.kt
+++ b/ai/src/main/java/me/rerere/ai/provider/providers/ClaudeProvider.kt
@@ -59,6 +59,11 @@ import kotlin.time.Clock
 private const val TAG = "ClaudeProvider"
 private const val ANTHROPIC_VERSION = "2023-06-01"
 
+private data class ClaudeThinkingConfig(
+    val thinking: JsonObject?,
+    val outputConfig: JsonObject? = null
+)
+
 class ClaudeProvider(private val client: OkHttpClient, context: Context? = null) : Provider<ProviderSetting.Claude> {
     private val keyRoulette = if (context != null) KeyRoulette.lru(context) else KeyRoulette.default()
 
@@ -297,23 +302,12 @@ class ClaudeProvider(private val client: OkHttpClient, context: Context? = null)
 
             // 处理 thinking budget
             if (params.model.abilities.contains(ModelAbility.REASONING)) {
-                val level = ReasoningLevel.fromBudgetTokens(params.thinkingBudget ?: 0)
-                put("thinking", buildJsonObject {
-                    when (level) {
-                        ReasoningLevel.OFF -> {
-                            put("type", "disabled")
-                        }
-
-                        ReasoningLevel.AUTO -> {
-                            put("type", "adaptive")
-                        }
-
-                        else -> {
-                            put("type", "enabled")
-                            put("budget_tokens", params.thinkingBudget ?: 1024)
-                        }
-                    }
-                })
+                val thinkingConfig = buildThinkingConfig(
+                    modelId = params.model.modelId,
+                    thinkingBudget = params.thinkingBudget
+                )
+                thinkingConfig.thinking?.let { put("thinking", it) }
+                thinkingConfig.outputConfig?.let { put("output_config", it) }
             }
 
             // 处理工具
@@ -332,6 +326,90 @@ class ClaudeProvider(private val client: OkHttpClient, context: Context? = null)
                 }
             }
         }.mergeCustomBody(params.customBody)
+    }
+
+    private fun buildThinkingConfig(modelId: String, thinkingBudget: Int?): ClaudeThinkingConfig {
+        val exactLevel = thinkingBudget.toExactReasoningLevel()
+
+        if (exactLevel == ReasoningLevel.OFF || (thinkingBudget ?: 0) == 0) {
+            return ClaudeThinkingConfig(
+                thinking = buildJsonObject {
+                    put("type", "disabled")
+                }
+            )
+        }
+
+        if (!supportsAdaptiveThinking(modelId)) {
+            if (exactLevel == ReasoningLevel.AUTO) {
+                return ClaudeThinkingConfig(thinking = null)
+            }
+
+            if ((thinkingBudget ?: 0) > 0) {
+                return ClaudeThinkingConfig(
+                    thinking = buildJsonObject {
+                        put("type", "enabled")
+                        put("budget_tokens", thinkingBudget ?: 1024)
+                    }
+                )
+            }
+
+            return ClaudeThinkingConfig(
+                thinking = buildJsonObject {
+                    put("type", "disabled")
+                }
+            )
+        }
+
+        return when (exactLevel) {
+            ReasoningLevel.AUTO -> ClaudeThinkingConfig(
+                thinking = buildJsonObject {
+                    put("type", "adaptive")
+                }
+            )
+
+            ReasoningLevel.LOW,
+            ReasoningLevel.MEDIUM,
+            ReasoningLevel.HIGH -> ClaudeThinkingConfig(
+                thinking = buildJsonObject {
+                    put("type", "adaptive")
+                },
+                outputConfig = buildJsonObject {
+                    put("effort", exactLevel.effort)
+                }
+            )
+
+            else -> if ((thinkingBudget ?: 0) > 0) {
+                ClaudeThinkingConfig(
+                    thinking = buildJsonObject {
+                        put("type", "enabled")
+                        put("budget_tokens", thinkingBudget ?: 1024)
+                    }
+                )
+            } else {
+                ClaudeThinkingConfig(
+                    thinking = buildJsonObject {
+                        put("type", "disabled")
+                    }
+                )
+            }
+        }
+    }
+
+    private fun supportsAdaptiveThinking(modelId: String): Boolean {
+        val normalizedModelId = modelId.lowercase()
+        return normalizedModelId.contains("claude-opus-4-6") ||
+            normalizedModelId.contains("claude-sonnet-4-6")
+    }
+
+    private fun Int?.toExactReasoningLevel(): ReasoningLevel? {
+        return when (this) {
+            ReasoningLevel.OFF.budgetTokens -> ReasoningLevel.OFF
+            ReasoningLevel.AUTO.budgetTokens -> ReasoningLevel.AUTO
+            ReasoningLevel.LOW.budgetTokens -> ReasoningLevel.LOW
+            ReasoningLevel.MEDIUM.budgetTokens -> ReasoningLevel.MEDIUM
+            ReasoningLevel.HIGH.budgetTokens -> ReasoningLevel.HIGH
+            else -> null
+        }
     }
 
     private fun buildMessages(messages: List<UIMessage>, promptCaching: Boolean) = buildJsonArray {

--- a/ai/src/test/java/me/rerere/ai/provider/providers/ClaudeProviderPromptCacheTest.kt
+++ b/ai/src/test/java/me/rerere/ai/provider/providers/ClaudeProviderPromptCacheTest.kt
@@ -53,6 +53,21 @@ class ClaudeProviderPromptCacheTest {
         )
     }
 
+    private fun reasoningModel(modelId: String): Model {
+        return Model(modelId = modelId, abilities = listOf(ModelAbility.REASONING))
+    }
+
+    private fun reasoningRequest(modelId: String, thinkingBudget: Int?): JsonObject {
+        return buildRequest(
+            providerSetting = ProviderSetting.Claude(),
+            messages = listOf(UIMessage.user("hello")),
+            params = TextGenerationParams(
+                model = reasoningModel(modelId),
+                thinkingBudget = thinkingBudget
+            )
+        )
+    }
+
     @Test
     fun `promptCaching=false should not add cache_control anywhere`() {
         val providerSetting = ProviderSetting.Claude(promptCaching = false)
@@ -205,5 +220,75 @@ class ClaudeProviderPromptCacheTest {
                 assertNull(block.jsonObject["cache_control"])
             }
         }
+    }
+
+    @Test
+    fun `legacy Claude auto should not send adaptive thinking`() {
+        val request = reasoningRequest(
+            modelId = "claude-sonnet-4-5-20250929",
+            thinkingBudget = -1
+        )
+
+        assertNull(request["thinking"])
+        assertNull(request["output_config"])
+    }
+
+    @Test
+    fun `legacy Claude preset budget should keep manual thinking`() {
+        val request = reasoningRequest(
+            modelId = "claude-sonnet-4-5-20250929",
+            thinkingBudget = 1024
+        )
+
+        val thinking = request["thinking"]!!.jsonObject
+        assertEquals("enabled", thinking["type"]!!.jsonPrimitive.content)
+        assertEquals(1024, thinking["budget_tokens"]!!.jsonPrimitive.int)
+        assertNull(request["output_config"])
+    }
+
+    @Test
+    fun `Claude 4_6 auto should use adaptive thinking without effort`() {
+        val request = reasoningRequest(
+            modelId = "claude-sonnet-4-6-20251001",
+            thinkingBudget = -1
+        )
+
+        val thinking = request["thinking"]!!.jsonObject
+        assertEquals("adaptive", thinking["type"]!!.jsonPrimitive.content)
+        assertNull(request["output_config"])
+    }
+
+    @Test
+    fun `Claude 4_6 preset reasoning levels should map to adaptive effort`() {
+        val levels = listOf(
+            1024 to "low",
+            16_000 to "medium",
+            32_000 to "high"
+        )
+
+        levels.forEach { (thinkingBudget, effort) ->
+            val request = reasoningRequest(
+                modelId = "claude-opus-4-6-20251001",
+                thinkingBudget = thinkingBudget
+            )
+
+            val thinking = request["thinking"]!!.jsonObject
+            val outputConfig = request["output_config"]!!.jsonObject
+            assertEquals("adaptive", thinking["type"]!!.jsonPrimitive.content)
+            assertEquals(effort, outputConfig["effort"]!!.jsonPrimitive.content)
+        }
+    }
+
+    @Test
+    fun `Claude 4_6 custom budget should keep manual thinking`() {
+        val request = reasoningRequest(
+            modelId = "claude-opus-4-6-20251001",
+            thinkingBudget = 5000
+        )
+
+        val thinking = request["thinking"]!!.jsonObject
+        assertEquals("enabled", thinking["type"]!!.jsonPrimitive.content)
+        assertEquals(5000, thinking["budget_tokens"]!!.jsonPrimitive.int)
+        assertNull(request["output_config"])
     }
 }


### PR DESCRIPTION
修复 #1038

## 变更内容

为 Claude 4.6 (Opus/Sonnet) 适配 Anthropic 新的 adaptive thinking API：

- **Claude 4.6**: AUTO → `thinking.type: "adaptive"`；预设级别 (Low/Medium/High) → `adaptive` + `output_config.effort`
- **旧版 Claude**: AUTO 不再误发 `adaptive` thinking（之前会导致 API 报错），保持 `enabled` + `budget_tokens` 行为
- **自定义 budget**: 所有版本统一走 `enabled` + `budget_tokens`，不做 effort 映射

## 技术细节

- 新增 `buildThinkingConfig()` 统一处理 thinking 请求体构建
- 通过 `supportsAdaptiveThinking()` 按 modelId 区分新旧模型
- 用精确匹配（非近似）区分预设级别和自定义 budget
- 新增 5 项单元测试覆盖各分支