### PR TITLE
fix: 修复 Markdown 中 details/summary 折叠内容渲染

### DIFF
--- a/app/src/main/java/me/rerere/rikkahub/ui/components/richtext/Markdown.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/richtext/Markdown.kt
@@ -111,6 +111,7 @@ val THINKING_REGEX = Regex("<think>([\\s\\S]*?)(?:</think>|$)", RegexOption.DOT_
 private val CODE_BLOCK_REGEX = Regex("```[\\s\\S]*?```|`[^`\n]*`", RegexOption.DOT_MATCHES_ALL)
 private val BREAK_LINE_REGEX = Regex("(?i)<br\\s*/?>")
 private val LocalDetailsBlocks = compositionLocalOf<Map<String, String>> { emptyMap() }
+private val DETAILS_PLACEHOLDER_TOKEN_REGEX = Regex("""RIKKAHUBDETAILSBLOCK\d+""")
 
 private data class MarkdownParseState(
     val content: String,
@@ -685,7 +686,8 @@ private fun resolveDetailsBlock(node: ASTNode, content: String): String? {
         return null
     }
 
-    return LocalDetailsBlocks.current[text]
+    val placeholder = DETAILS_PLACEHOLDER_TOKEN_REGEX.find(text)?.value ?: return null
+    return LocalDetailsBlocks.current[placeholder]
 }
 
 @Composable

--- a/app/src/main/java/me/rerere/rikkahub/ui/components/richtext/Markdown.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/richtext/Markdown.kt
@@ -28,13 +28,16 @@ import androidx.compose.material3.ProvideTextStyle
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.referentialEqualityPolicy
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -71,12 +74,17 @@ import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.mapLatest
+import me.rerere.common.markdown.extractDetailsBlocks
+import me.rerere.common.markdown.isDetailsPlaceholder
+import me.rerere.common.markdown.parseDetailsBlock
+import me.rerere.common.markdown.prepareDetailsBodyForMarkdown
 import me.rerere.hugeicons.HugeIcons
 import me.rerere.hugeicons.stroke.Tick01
 import me.rerere.rikkahub.ui.components.table.DataTable
 import me.rerere.rikkahub.ui.context.LocalSettings
 import me.rerere.rikkahub.ui.theme.JetbrainsMono
 import me.rerere.rikkahub.utils.toDp
+import org.jsoup.Jsoup
 import org.intellij.markdown.IElementType
 import org.intellij.markdown.MarkdownElementTypes
 import org.intellij.markdown.MarkdownTokenTypes
@@ -102,12 +110,21 @@ private val BLOCK_LATEX_REGEX = Regex("\\\\\\[(.+?)\\\\\\]", RegexOption.DOT_MAT
 val THINKING_REGEX = Regex("<think>([\\s\\S]*?)(?:</think>|$)", RegexOption.DOT_MATCHES_ALL)
 private val CODE_BLOCK_REGEX = Regex("```[\\s\\S]*?```|`[^`\n]*`", RegexOption.DOT_MATCHES_ALL)
 private val BREAK_LINE_REGEX = Regex("(?i)<br\\s*/?>")
+private val LocalDetailsBlocks = compositionLocalOf<Map<String, String>> { emptyMap() }
+
+private data class MarkdownParseState(
+    val content: String,
+    val astTree: ASTNode,
+    val detailsBlocks: Map<String, String>
+)
 
 // 预处理markdown内容
-private fun preProcess(content: String): String {
+private fun parseMarkdown(content: String): MarkdownParseState {
+    val detailsExtraction = extractDetailsBlocks(content)
+
     // 先找出所有代码块的位置
     val codeBlocks = mutableListOf<IntRange>()
-    CODE_BLOCK_REGEX.findAll(content).forEach { match ->
+    CODE_BLOCK_REGEX.findAll(detailsExtraction.content).forEach { match ->
         codeBlocks.add(match.range)
     }
 
@@ -117,7 +134,7 @@ private fun preProcess(content: String): String {
     }
 
     // 替换行内公式 \( ... \) 到 $ ... $，但跳过代码块内的内容
-    var result = INLINE_LATEX_REGEX.replace(content) { matchResult ->
+    var result = INLINE_LATEX_REGEX.replace(detailsExtraction.content) { matchResult ->
         if (isInCodeBlock(matchResult.range.first)) {
             matchResult.value // 保持原样
         } else {
@@ -134,7 +151,11 @@ private fun preProcess(content: String): String {
         }
     }
 
-    return result
+    return MarkdownParseState(
+        content = result,
+        astTree = parser.buildMarkdownTreeFromString(result),
+        detailsBlocks = detailsExtraction.blocks
+    )
 }
 
 @Preview(showBackground = true)
@@ -192,10 +213,8 @@ fun MarkdownBlock(
     onClickCitation: (String) -> Unit = {}
 ) {
     var (data, setData) = remember {
-        val preprocessed = preProcess(content)
-        val astTree = parser.buildMarkdownTreeFromString(preprocessed)
         mutableStateOf(
-            value = preprocessed to astTree,
+            value = parseMarkdown(content),
             policy = referentialEqualityPolicy(),
         )
     }
@@ -205,24 +224,23 @@ fun MarkdownBlock(
     val updatedContent by rememberUpdatedState(content)
     LaunchedEffect(Unit) {
         snapshotFlow { updatedContent }.distinctUntilChanged().mapLatest {
-            val preprocessed = preProcess(it)
-            val astTree = parser.buildMarkdownTreeFromString(preprocessed)
-            preprocessed to astTree
+            parseMarkdown(it)
         }.catch { exception -> exception.printStackTrace() }.flowOn(Dispatchers.Default) // 在后台线程解析AST树
             .collect {
                 setData(it)
             }
     }
 
-    val (preprocessed, astTree) = data
-    ProvideTextStyle(style) {
-        Column(
-            modifier = modifier.padding(start = 4.dp)
-        ) {
-            astTree.children.fastForEach { child ->
-                MarkdownNode(
-                    node = child, content = preprocessed, onClickCitation = onClickCitation
-                )
+    CompositionLocalProvider(LocalDetailsBlocks provides data.detailsBlocks) {
+        ProvideTextStyle(style) {
+            Column(
+                modifier = modifier.padding(start = 4.dp)
+            ) {
+                data.astTree.children.fastForEach { child ->
+                    MarkdownNode(
+                        node = child, content = data.content, onClickCitation = onClickCitation
+                    )
+                }
             }
         }
     }
@@ -270,6 +288,15 @@ private fun MarkdownNode(
     onClickCitation: (String) -> Unit = {},
     listLevel: Int = 0
 ) {
+    resolveDetailsBlock(node = node, content = content)?.let { rawDetailsBlock ->
+        DetailsMarkdownBlock(
+            rawBlock = rawDetailsBlock,
+            modifier = modifier,
+            onClickCitation = onClickCitation
+        )
+        return
+    }
+
     when (node.type) {
         // 文件根节点
         MarkdownElementTypes.MARKDOWN_FILE -> {
@@ -579,6 +606,86 @@ private fun MarkdownNode(
             }
         }
     }
+}
+
+@Composable
+private fun DetailsMarkdownBlock(
+    rawBlock: String,
+    modifier: Modifier = Modifier,
+    onClickCitation: (String) -> Unit = {}
+) {
+    val parsedDetails = remember(rawBlock) {
+        parseDetailsBlock(rawBlock)
+    }
+
+    if (parsedDetails == null) {
+        SimpleHtmlBlock(
+            html = rawBlock,
+            modifier = modifier
+        )
+        return
+    }
+
+    val summaryText = remember(parsedDetails.summaryRaw) {
+        parsedDetails.summaryRaw
+            ?.let { Jsoup.parse(it).text() }
+            ?.takeIf { it.isNotBlank() }
+            ?: "Details"
+    }
+    val preparedBody = remember(rawBlock) {
+        prepareDetailsBodyForMarkdown(parsedDetails.bodyRaw)
+    }
+    var isExpanded by remember(rawBlock) {
+        mutableStateOf(parsedDetails.openByDefault)
+    }
+
+    Column(modifier = modifier.padding(vertical = 4.dp)) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .clickable { isExpanded = !isExpanded }
+                .padding(vertical = 8.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = if (isExpanded) "▼ " else "▶ ",
+                style = MaterialTheme.typography.bodyMedium.copy(
+                    color = MaterialTheme.colorScheme.onSurface
+                )
+            )
+            Text(
+                text = summaryText,
+                style = MaterialTheme.typography.bodyMedium.copy(
+                    color = MaterialTheme.colorScheme.onSurface,
+                    fontWeight = FontWeight.Medium
+                )
+            )
+        }
+
+        if (isExpanded && preparedBody.isNotBlank()) {
+            MarkdownBlock(
+                content = preparedBody,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(start = 16.dp, top = 4.dp),
+                onClickCitation = onClickCitation
+            )
+        }
+    }
+}
+
+@Composable
+private fun resolveDetailsBlock(node: ASTNode, content: String): String? {
+    if (node.type != MarkdownElementTypes.PARAGRAPH && node.type != MarkdownTokenTypes.TEXT) {
+        return null
+    }
+
+    val text = node.getTextInNode(content).trim()
+    if (!isDetailsPlaceholder(text)) {
+        return null
+    }
+
+    return LocalDetailsBlocks.current[text]
 }
 
 @Composable

--- a/common/src/main/java/me/rerere/common/markdown/DetailsBlockProcessor.kt
+++ b/common/src/main/java/me/rerere/common/markdown/DetailsBlockProcessor.kt
@@ -1,0 +1,207 @@
+package me.rerere.common.markdown
+
+data class DetailsBlockExtraction(
+    val content: String,
+    val blocks: Map<String, String>
+)
+
+data class ParsedDetailsBlock(
+    val summaryRaw: String?,
+    val bodyRaw: String,
+    val openByDefault: Boolean
+)
+
+private const val DETAILS_PLACEHOLDER_PREFIX = "RIKKAHUBDETAILSBLOCK"
+private val CODE_BLOCK_REGEX = Regex("```[\\s\\S]*?```|`[^`\n]*`", RegexOption.DOT_MATCHES_ALL)
+private val SUMMARY_REGEX = Regex("^\\s*(<summary\\b[^>]*>[\\s\\S]*?</summary>)\\s*", setOf(RegexOption.IGNORE_CASE))
+private val SIMPLE_CONTAINER_REGEX = Regex(
+    "<(p|div)\\b[^>]*>([\\s\\S]*?)</\\1>",
+    setOf(RegexOption.IGNORE_CASE)
+)
+
+fun extractDetailsBlocks(content: String): DetailsBlockExtraction {
+    val codeRanges = CODE_BLOCK_REGEX.findAll(content).map { it.range }.toList()
+    val blocks = linkedMapOf<String, String>()
+    val result = StringBuilder()
+    var cursor = 0
+
+    while (true) {
+        val openStart = findNextDetailsOpen(content, cursor, codeRanges) ?: break
+        val blockEnd = findMatchingDetailsEnd(content, openStart, codeRanges) ?: break
+        val placeholder = buildDetailsPlaceholder(blocks.size)
+        blocks[placeholder] = content.substring(openStart, blockEnd)
+
+        result.append(content, cursor, openStart)
+        result.append('\n')
+        result.append(placeholder)
+        result.append('\n')
+        cursor = blockEnd
+    }
+
+    result.append(content, cursor, content.length)
+    return DetailsBlockExtraction(
+        content = result.toString(),
+        blocks = blocks
+    )
+}
+
+fun parseDetailsBlock(rawBlock: String): ParsedDetailsBlock? {
+    val openStart = rawBlock.indexOf("<details", ignoreCase = true)
+    if (openStart == -1) {
+        return null
+    }
+
+    val openTagEnd = findTagEnd(rawBlock, openStart) ?: return null
+    val closeStart = rawBlock.lastIndexOf("</details", ignoreCase = true)
+    if (closeStart == -1 || closeStart <= openTagEnd) {
+        return null
+    }
+
+    val openingTag = rawBlock.substring(openStart, openTagEnd + 1)
+    val innerRaw = rawBlock.substring(openTagEnd + 1, closeStart)
+    val summaryMatch = SUMMARY_REGEX.find(innerRaw)
+    val summaryRaw = summaryMatch?.groupValues?.get(1)
+    val bodyRaw = if (summaryMatch != null) {
+        innerRaw.removeRange(summaryMatch.range)
+    } else {
+        innerRaw
+    }
+
+    return ParsedDetailsBlock(
+        summaryRaw = summaryRaw,
+        bodyRaw = bodyRaw,
+        openByDefault = Regex("\\bopen\\b", RegexOption.IGNORE_CASE).containsMatchIn(openingTag)
+    )
+}
+
+fun prepareDetailsBodyForMarkdown(bodyRaw: String): String {
+    var result = bodyRaw.trim('\r', '\n')
+    var previous: String
+
+    do {
+        previous = result
+        result = SIMPLE_CONTAINER_REGEX.replace(result) { matchResult ->
+            "\n${matchResult.groupValues[2].trim('\r', '\n')}\n"
+        }.trim('\r', '\n')
+    } while (result != previous)
+
+    return result
+}
+
+fun isDetailsPlaceholder(text: String): Boolean {
+    return text.trim().startsWith(DETAILS_PLACEHOLDER_PREFIX)
+}
+
+private fun buildDetailsPlaceholder(index: Int): String {
+    return "$DETAILS_PLACEHOLDER_PREFIX$index"
+}
+
+private fun findMatchingDetailsEnd(
+    content: String,
+    openingStart: Int,
+    protectedRanges: List<IntRange>
+): Int? {
+    val openingEnd = findTagEnd(content, openingStart) ?: return null
+    var cursor = openingEnd + 1
+    var depth = 1
+
+    while (cursor < content.length) {
+        val nextTag = findNextDetailsTag(content, cursor, protectedRanges) ?: return null
+        cursor = nextTag.endExclusive
+        depth += if (nextTag.isOpening) 1 else -1
+        if (depth == 0) {
+            return nextTag.endExclusive
+        }
+    }
+
+    return null
+}
+
+private fun findNextDetailsOpen(
+    content: String,
+    startIndex: Int,
+    protectedRanges: List<IntRange>
+): Int? {
+    var index = startIndex
+
+    while (index < content.length) {
+        val candidate = content.indexOf("<details", index, ignoreCase = true)
+        if (candidate == -1) {
+            return null
+        }
+
+        if (!candidate.isInside(protectedRanges) && hasTagBoundary(content, candidate + "<details".length)) {
+            return candidate
+        }
+
+        index = candidate + 1
+    }
+
+    return null
+}
+
+private fun findNextDetailsTag(
+    content: String,
+    startIndex: Int,
+    protectedRanges: List<IntRange>
+): DetailsTagMatch? {
+    var searchIndex = startIndex
+
+    while (searchIndex < content.length) {
+        val nextOpen = content.indexOf("<details", searchIndex, ignoreCase = true).takeIf { it != -1 }
+        val nextClose = content.indexOf("</details", searchIndex, ignoreCase = true).takeIf { it != -1 }
+        val nextIndex = listOfNotNull(nextOpen, nextClose).minOrNull() ?: return null
+        val isOpening = nextIndex == nextOpen
+        val boundaryIndex = nextIndex + if (isOpening) "<details".length else "</details".length
+
+        if (nextIndex.isInside(protectedRanges) || !hasTagBoundary(content, boundaryIndex)) {
+            searchIndex = nextIndex + 1
+            continue
+        }
+
+        val tagEnd = findTagEnd(content, nextIndex) ?: return null
+        return DetailsTagMatch(
+            isOpening = isOpening,
+            endExclusive = tagEnd + 1
+        )
+    }
+
+    return null
+}
+
+private fun findTagEnd(content: String, tagStart: Int): Int? {
+    var index = tagStart
+    var quote: Char? = null
+
+    while (index < content.length) {
+        val char = content[index]
+        when {
+            quote != null && char == quote -> quote = null
+            quote == null && (char == '"' || char == '\'') -> quote = char
+            quote == null && char == '>' -> return index
+        }
+        index++
+    }
+
+    return null
+}
+
+private fun hasTagBoundary(content: String, index: Int): Boolean {
+    if (index >= content.length) {
+        return true
+    }
+
+    return when (val char = content[index]) {
+        '>', '/', ' ', '\t', '\n', '\r' -> true
+        else -> !char.isLetterOrDigit()
+    }
+}
+
+private fun Int.isInside(ranges: List<IntRange>): Boolean {
+    return ranges.any { this in it }
+}
+
+private data class DetailsTagMatch(
+    val isOpening: Boolean,
+    val endExclusive: Int
+)

--- a/common/src/main/java/me/rerere/common/markdown/DetailsBlockProcessor.kt
+++ b/common/src/main/java/me/rerere/common/markdown/DetailsBlockProcessor.kt
@@ -24,20 +24,26 @@ fun extractDetailsBlocks(content: String): DetailsBlockExtraction {
     val codeRanges = findProtectedRanges(content)
     val blocks = linkedMapOf<String, String>()
     val result = StringBuilder()
-    var cursor = 0
+    var writeCursor = 0
+    var scanCursor = 0
 
     while (true) {
-        val openStart = findNextDetailsOpen(content, cursor, codeRanges) ?: break
-        val blockEnd = findMatchingDetailsEnd(content, openStart, codeRanges) ?: break
+        val openStart = findNextDetailsOpen(content, scanCursor, codeRanges) ?: break
+        val blockEnd = findMatchingDetailsEnd(content, openStart, codeRanges)
+        if (blockEnd == null) {
+            scanCursor = openStart + 1
+            continue
+        }
         val placeholder = buildDetailsPlaceholder(blocks.size)
         blocks[placeholder] = content.substring(openStart, blockEnd)
 
-        result.append(content, cursor, openStart)
+        result.append(content, writeCursor, openStart)
         result.append(placeholder)
-        cursor = blockEnd
+        writeCursor = blockEnd
+        scanCursor = blockEnd
     }
 
-    result.append(content, cursor, content.length)
+    result.append(content, writeCursor, content.length)
     return DetailsBlockExtraction(
         content = result.toString(),
         blocks = blocks
@@ -80,9 +86,9 @@ fun prepareDetailsBodyForMarkdown(bodyRaw: String): String {
 
     do {
         previous = result
-        result = SIMPLE_CONTAINER_REGEX.replace(result) { matchResult ->
-            "\n${matchResult.groupValues[2].trim('\r', '\n')}\n"
-        }.trim('\r', '\n')
+        val detailsExtraction = extractDetailsBlocks(result)
+        result = unwrapSimpleContainers(detailsExtraction.content)
+        result = restoreProtectedBlocks(result, detailsExtraction.blocks).trim('\r', '\n')
     } while (result != previous)
 
     return result
@@ -94,6 +100,25 @@ fun isDetailsPlaceholder(text: String): Boolean {
 
 private fun buildDetailsPlaceholder(index: Int): String {
     return "$DETAILS_PLACEHOLDER_PREFIX$index"
+}
+
+private fun unwrapSimpleContainers(content: String): String {
+    val protectedRanges = findProtectedRanges(content)
+    return SIMPLE_CONTAINER_REGEX.replace(content) { matchResult ->
+        if (matchResult.range.first.isInside(protectedRanges) || !matchResult.range.isStandaloneBlock(content)) {
+            matchResult.value
+        } else {
+            "\n${matchResult.groupValues[2].trim('\r', '\n')}\n"
+        }
+    }
+}
+
+private fun restoreProtectedBlocks(content: String, blocks: Map<String, String>): String {
+    var result = content
+    blocks.forEach { (placeholder, rawBlock) ->
+        result = result.replace(placeholder, rawBlock)
+    }
+    return result
 }
 
 private fun findProtectedRanges(content: String): List<IntRange> {
@@ -332,6 +357,14 @@ private fun hasTagBoundary(content: String, index: Int): Boolean {
 
 private fun Int.isInside(ranges: List<IntRange>): Boolean {
     return ranges.any { this in it }
+}
+
+private fun IntRange.isStandaloneBlock(content: String): Boolean {
+    val lineStart = content.lastIndexOf('\n', first).let { if (it == -1) 0 else it + 1 }
+    val lineEnd = content.indexOf('\n', last + 1).let { if (it == -1) content.length else it }
+
+    return content.substring(lineStart, first).isBlank() &&
+        content.substring(last + 1, lineEnd).isBlank()
 }
 
 private data class DetailsTagMatch(

--- a/common/src/main/java/me/rerere/common/markdown/DetailsBlockProcessor.kt
+++ b/common/src/main/java/me/rerere/common/markdown/DetailsBlockProcessor.kt
@@ -34,9 +34,7 @@ fun extractDetailsBlocks(content: String): DetailsBlockExtraction {
         blocks[placeholder] = content.substring(openStart, blockEnd)
 
         result.append(content, cursor, openStart)
-        result.append('\n')
         result.append(placeholder)
-        result.append('\n')
         cursor = blockEnd
     }
 

--- a/common/src/main/java/me/rerere/common/markdown/DetailsBlockProcessor.kt
+++ b/common/src/main/java/me/rerere/common/markdown/DetailsBlockProcessor.kt
@@ -12,7 +12,6 @@ data class ParsedDetailsBlock(
 )
 
 private const val DETAILS_PLACEHOLDER_PREFIX = "RIKKAHUBDETAILSBLOCK"
-private val INLINE_CODE_REGEX = Regex("`[^`\n]*`")
 private val ATTRIBUTE_VALUE_REGEX = Regex("\"[^\"]*\"|'[^']*'")
 private val OPEN_ATTRIBUTE_REGEX = Regex("""(?:^|[\s<])open(?=[\s=/>])""", RegexOption.IGNORE_CASE)
 private val SUMMARY_REGEX = Regex("^\\s*(<summary\\b[^>]*>[\\s\\S]*?</summary>)\\s*", setOf(RegexOption.IGNORE_CASE))
@@ -98,7 +97,7 @@ private fun buildDetailsPlaceholder(index: Int): String {
 }
 
 private fun findProtectedRanges(content: String): List<IntRange> {
-    val inlineCodeRanges = INLINE_CODE_REGEX.findAll(content).map { it.range }
+    val inlineCodeRanges = findInlineCodeRanges(content).asSequence()
     val fencedCodeRanges = findFencedCodeBlockRanges(content).asSequence()
 
     return (inlineCodeRanges + fencedCodeRanges)
@@ -112,6 +111,49 @@ private fun findProtectedRanges(content: String): List<IntRange> {
             }
             ranges
         }
+}
+
+private fun findInlineCodeRanges(content: String): List<IntRange> {
+    val ranges = mutableListOf<IntRange>()
+    var cursor = 0
+
+    while (cursor < content.length) {
+        if (content[cursor] != '`') {
+            cursor++
+            continue
+        }
+
+        val delimiterLength = countRepeatedChar(content, cursor, '`')
+        val closingStart = findClosingInlineCodeDelimiter(content, cursor + delimiterLength, delimiterLength)
+        if (closingStart != -1) {
+            ranges.add(cursor until closingStart + delimiterLength)
+            cursor = closingStart + delimiterLength
+        } else {
+            cursor += delimiterLength
+        }
+    }
+
+    return ranges
+}
+
+private fun findClosingInlineCodeDelimiter(content: String, startIndex: Int, delimiterLength: Int): Int {
+    var cursor = startIndex
+
+    while (cursor < content.length) {
+        val nextBacktick = content.indexOf('`', cursor)
+        if (nextBacktick == -1) {
+            return -1
+        }
+
+        val runLength = countRepeatedChar(content, nextBacktick, '`')
+        if (runLength == delimiterLength) {
+            return nextBacktick
+        }
+
+        cursor = nextBacktick + runLength
+    }
+
+    return -1
 }
 
 private fun findFencedCodeBlockRanges(content: String): List<IntRange> {

--- a/common/src/main/java/me/rerere/common/markdown/DetailsBlockProcessor.kt
+++ b/common/src/main/java/me/rerere/common/markdown/DetailsBlockProcessor.kt
@@ -12,7 +12,9 @@ data class ParsedDetailsBlock(
 )
 
 private const val DETAILS_PLACEHOLDER_PREFIX = "RIKKAHUBDETAILSBLOCK"
-private val CODE_BLOCK_REGEX = Regex("```[\\s\\S]*?```|`[^`\n]*`", RegexOption.DOT_MATCHES_ALL)
+private val INLINE_CODE_REGEX = Regex("`[^`\n]*`")
+private val ATTRIBUTE_VALUE_REGEX = Regex("\"[^\"]*\"|'[^']*'")
+private val OPEN_ATTRIBUTE_REGEX = Regex("""(?:^|[\s<])open(?=[\s=/>])""", RegexOption.IGNORE_CASE)
 private val SUMMARY_REGEX = Regex("^\\s*(<summary\\b[^>]*>[\\s\\S]*?</summary>)\\s*", setOf(RegexOption.IGNORE_CASE))
 private val SIMPLE_CONTAINER_REGEX = Regex(
     "<(p|div)\\b[^>]*>([\\s\\S]*?)</\\1>",
@@ -20,7 +22,7 @@ private val SIMPLE_CONTAINER_REGEX = Regex(
 )
 
 fun extractDetailsBlocks(content: String): DetailsBlockExtraction {
-    val codeRanges = CODE_BLOCK_REGEX.findAll(content).map { it.range }.toList()
+    val codeRanges = findProtectedRanges(content)
     val blocks = linkedMapOf<String, String>()
     val result = StringBuilder()
     var cursor = 0
@@ -66,11 +68,12 @@ fun parseDetailsBlock(rawBlock: String): ParsedDetailsBlock? {
     } else {
         innerRaw
     }
+    val openingTagWithoutAttributeValues = ATTRIBUTE_VALUE_REGEX.replace(openingTag) { "\"\"" }
 
     return ParsedDetailsBlock(
         summaryRaw = summaryRaw,
         bodyRaw = bodyRaw,
-        openByDefault = Regex("\\bopen\\b", RegexOption.IGNORE_CASE).containsMatchIn(openingTag)
+        openByDefault = OPEN_ATTRIBUTE_REGEX.containsMatchIn(openingTagWithoutAttributeValues)
     )
 }
 
@@ -94,6 +97,96 @@ fun isDetailsPlaceholder(text: String): Boolean {
 
 private fun buildDetailsPlaceholder(index: Int): String {
     return "$DETAILS_PLACEHOLDER_PREFIX$index"
+}
+
+private fun findProtectedRanges(content: String): List<IntRange> {
+    val inlineCodeRanges = INLINE_CODE_REGEX.findAll(content).map { it.range }
+    val fencedCodeRanges = findFencedCodeBlockRanges(content).asSequence()
+
+    return (inlineCodeRanges + fencedCodeRanges)
+        .sortedBy { it.first }
+        .fold(mutableListOf()) { ranges, range ->
+            val previous = ranges.lastOrNull()
+            if (previous != null && range.first <= previous.last + 1) {
+                ranges[ranges.lastIndex] = previous.first..maxOf(previous.last, range.last)
+            } else {
+                ranges.add(range)
+            }
+            ranges
+        }
+}
+
+private fun findFencedCodeBlockRanges(content: String): List<IntRange> {
+    val ranges = mutableListOf<IntRange>()
+    var cursor = 0
+    var activeFence: MarkdownFence? = null
+    var fenceStart = -1
+
+    while (cursor < content.length) {
+        val lineEnd = content.indexOf('\n', cursor).let { if (it == -1) content.length else it }
+        val line = content.substring(cursor, lineEnd).removeSuffix("\r")
+
+        if (activeFence == null) {
+            val openingFence = parseFence(line)
+            if (openingFence != null) {
+                activeFence = openingFence
+                fenceStart = cursor
+            }
+        } else if (isClosingFence(line, activeFence)) {
+            val fenceEndExclusive = if (lineEnd < content.length) lineEnd + 1 else lineEnd
+            ranges.add(fenceStart until fenceEndExclusive)
+            activeFence = null
+            fenceStart = -1
+        }
+
+        cursor = if (lineEnd < content.length) lineEnd + 1 else content.length
+    }
+
+    return ranges
+}
+
+private fun parseFence(line: String): MarkdownFence? {
+    val contentStart = line.indexOfFirst { !it.isWhitespace() }
+    if (contentStart !in 0..3) {
+        return null
+    }
+
+    val fenceChar = line.getOrNull(contentStart)
+    if (fenceChar != '`' && fenceChar != '~') {
+        return null
+    }
+
+    val fenceLength = countRepeatedChar(line, contentStart, fenceChar)
+    if (fenceLength < 3) {
+        return null
+    }
+
+    return MarkdownFence(
+        marker = fenceChar,
+        length = fenceLength
+    )
+}
+
+private fun isClosingFence(line: String, fence: MarkdownFence): Boolean {
+    val contentStart = line.indexOfFirst { !it.isWhitespace() }
+    if (contentStart !in 0..3 || line.getOrNull(contentStart) != fence.marker) {
+        return false
+    }
+
+    val fenceLength = countRepeatedChar(line, contentStart, fence.marker)
+    if (fenceLength < fence.length) {
+        return false
+    }
+
+    return line.substring(contentStart + fenceLength).isBlank()
+}
+
+private fun countRepeatedChar(text: String, startIndex: Int, char: Char): Int {
+    var index = startIndex
+    while (index < text.length && text[index] == char) {
+        index++
+    }
+    return index - startIndex
 }
 
 private fun findMatchingDetailsEnd(
@@ -204,4 +297,9 @@ private fun Int.isInside(ranges: List<IntRange>): Boolean {
 private data class DetailsTagMatch(
     val isOpening: Boolean,
     val endExclusive: Int
+)
+
+private data class MarkdownFence(
+    val marker: Char,
+    val length: Int
 )

--- a/common/src/test/java/me/rerere/common/markdown/DetailsBlockProcessorTest.kt
+++ b/common/src/test/java/me/rerere/common/markdown/DetailsBlockProcessorTest.kt
@@ -45,6 +45,16 @@ class DetailsBlockProcessorTest {
     }
 
     @Test
+    fun `extractDetailsBlocks ignores details tags inside multi backtick code spans`() {
+        val sample = "``<details><summary>code sample</summary>still code</details>``"
+
+        val extraction = extractDetailsBlocks(sample)
+
+        assertEquals(0, extraction.blocks.size)
+        assertEquals(sample, extraction.content)
+    }
+
+    @Test
     fun `extractDetailsBlocks preserves list indentation for placeholder`() {
         val sample = """
             - item

--- a/common/src/test/java/me/rerere/common/markdown/DetailsBlockProcessorTest.kt
+++ b/common/src/test/java/me/rerere/common/markdown/DetailsBlockProcessorTest.kt
@@ -73,6 +73,29 @@ class DetailsBlockProcessorTest {
     }
 
     @Test
+    fun `extractDetailsBlocks continues after literal unmatched details token`() {
+        val validBlock = """
+            <details>
+            <summary>ok</summary>
+            body
+            </details>
+        """.trimIndent()
+        val sample = """
+            Here is a literal <details> tag example.
+
+            $validBlock
+        """.trimIndent()
+
+        val extraction = extractDetailsBlocks(sample)
+
+        assertEquals(1, extraction.blocks.size)
+        val placeholder = extraction.blocks.keys.single()
+        assertEquals(validBlock, extraction.blocks.getValue(placeholder))
+        assertTrue(extraction.content.contains("literal <details> tag example"))
+        assertTrue(extraction.content.contains(placeholder))
+    }
+
+    @Test
     fun `prepareDetailsBodyForMarkdown unwraps div body`() {
         val parsed = parseDetailsBlock(
             """
@@ -90,6 +113,31 @@ class DetailsBlockProcessorTest {
             """
             content
             - item
+            """.trimIndent(),
+            prepareDetailsBodyForMarkdown(parsed.bodyRaw)
+        )
+    }
+
+    @Test
+    fun `prepareDetailsBodyForMarkdown keeps html tags inside fenced code blocks`() {
+        val parsed = parseDetailsBlock(
+            """
+            <details>
+            <summary>title</summary>
+            <p>
+            ```html
+            <div>demo</div>
+            ```
+            </p>
+            </details>
+            """.trimIndent()
+        )!!
+
+        assertEquals(
+            """
+            ```html
+            <div>demo</div>
+            ```
             """.trimIndent(),
             prepareDetailsBodyForMarkdown(parsed.bodyRaw)
         )

--- a/common/src/test/java/me/rerere/common/markdown/DetailsBlockProcessorTest.kt
+++ b/common/src/test/java/me/rerere/common/markdown/DetailsBlockProcessorTest.kt
@@ -1,0 +1,148 @@
+package me.rerere.common.markdown
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class DetailsBlockProcessorTest {
+    @Test
+    fun `extractDetailsBlocks keeps multiline details together`() {
+        val sample = """
+            <details>
+            <summary>title</summary>
+            <p>
+            content
+            
+            **item**
+            </p>
+            </details>
+        """.trimIndent()
+
+        val extraction = extractDetailsBlocks(sample)
+
+        assertEquals(1, extraction.blocks.size)
+        val placeholder = extraction.blocks.keys.single()
+        assertEquals(sample, extraction.blocks.getValue(placeholder))
+        assertTrue(extraction.content.contains(placeholder))
+        assertTrue(!extraction.content.contains("**item**"))
+    }
+
+    @Test
+    fun `prepareDetailsBodyForMarkdown unwraps div body`() {
+        val parsed = parseDetailsBlock(
+            """
+            <details>
+            <summary>title</summary>
+            <div>
+            content
+            - item
+            </div>
+            </details>
+            """.trimIndent()
+        )!!
+
+        assertEquals(
+            """
+            content
+            - item
+            """.trimIndent(),
+            prepareDetailsBodyForMarkdown(parsed.bodyRaw)
+        )
+    }
+
+    @Test
+    fun `prepareDetailsBodyForMarkdown unwraps paragraph body without losing markdown`() {
+        val parsed = parseDetailsBlock(
+            """
+            <details>
+            <summary>title</summary>
+            <p>
+            content
+            **item**
+            </p>
+            </details>
+            """.trimIndent()
+        )!!
+
+        assertEquals(
+            """
+            content
+            **item**
+            """.trimIndent(),
+            prepareDetailsBodyForMarkdown(parsed.bodyRaw)
+        )
+    }
+
+    @Test
+    fun `prepareDetailsBodyForMarkdown keeps blank lines inside paragraph body`() {
+        val parsed = parseDetailsBlock(
+            """
+            <details>
+            <summary>title</summary>
+            <p>
+            content
+            
+            **item**
+            </p>
+            </details>
+            """.trimIndent()
+        )!!
+
+        assertEquals(
+            """
+            content
+            
+            **item**
+            """.trimIndent(),
+            prepareDetailsBodyForMarkdown(parsed.bodyRaw)
+        )
+    }
+
+    @Test
+    fun `prepareDetailsBodyForMarkdown keeps direct markdown lines`() {
+        val parsed = parseDetailsBlock(
+            """
+            <details>
+            <summary>title</summary>
+            *content*
+            **item**
+            </details>
+            """.trimIndent()
+        )!!
+
+        assertEquals(
+            """
+            *content*
+            **item**
+            """.trimIndent(),
+            prepareDetailsBodyForMarkdown(parsed.bodyRaw)
+        )
+    }
+
+    @Test
+    fun `prepareDetailsBodyForMarkdown preserves nested details blocks`() {
+        val parsed = parseDetailsBlock(
+            """
+            <details>
+            <summary>outer</summary>
+            <p>
+            content
+            **item**
+            </p>
+            <details>
+            <summary>inner</summary>
+            <p>nested</p>
+            </details>
+            </details>
+            """.trimIndent()
+        )!!
+
+        val body = prepareDetailsBodyForMarkdown(parsed.bodyRaw)
+
+        assertTrue(body.contains("content"))
+        assertTrue(body.contains("**item**"))
+        assertTrue(body.contains("<details>"))
+        assertTrue(body.contains("<summary>inner</summary>"))
+        assertTrue(body.contains("nested"))
+    }
+}

--- a/common/src/test/java/me/rerere/common/markdown/DetailsBlockProcessorTest.kt
+++ b/common/src/test/java/me/rerere/common/markdown/DetailsBlockProcessorTest.kt
@@ -45,6 +45,24 @@ class DetailsBlockProcessorTest {
     }
 
     @Test
+    fun `extractDetailsBlocks preserves list indentation for placeholder`() {
+        val sample = """
+            - item
+              <details>
+              <summary>more</summary>
+              body
+              </details>
+            - next
+        """.trimIndent()
+
+        val extraction = extractDetailsBlocks(sample)
+
+        assertEquals(1, extraction.blocks.size)
+        val placeholder = extraction.blocks.keys.single()
+        assertTrue(extraction.content.contains("\n  $placeholder\n"))
+    }
+
+    @Test
     fun `prepareDetailsBodyForMarkdown unwraps div body`() {
         val parsed = parseDetailsBlock(
             """

--- a/common/src/test/java/me/rerere/common/markdown/DetailsBlockProcessorTest.kt
+++ b/common/src/test/java/me/rerere/common/markdown/DetailsBlockProcessorTest.kt
@@ -28,6 +28,23 @@ class DetailsBlockProcessorTest {
     }
 
     @Test
+    fun `extractDetailsBlocks ignores details tags inside tilde fenced code blocks`() {
+        val sample = """
+            ~~~markdown
+            <details>
+            <summary>code sample</summary>
+            still code
+            </details>
+            ~~~
+        """.trimIndent()
+
+        val extraction = extractDetailsBlocks(sample)
+
+        assertEquals(0, extraction.blocks.size)
+        assertEquals(sample, extraction.content)
+    }
+
+    @Test
     fun `prepareDetailsBodyForMarkdown unwraps div body`() {
         val parsed = parseDetailsBlock(
             """
@@ -71,6 +88,48 @@ class DetailsBlockProcessorTest {
             """.trimIndent(),
             prepareDetailsBodyForMarkdown(parsed.bodyRaw)
         )
+    }
+
+    @Test
+    fun `parseDetailsBlock does not treat open in attribute values as open attribute`() {
+        val parsed = parseDetailsBlock(
+            """
+            <details class="open panel">
+            <summary>title</summary>
+            content
+            </details>
+            """.trimIndent()
+        )!!
+
+        assertEquals(false, parsed.openByDefault)
+    }
+
+    @Test
+    fun `parseDetailsBlock ignores open token inside quoted attribute text`() {
+        val parsed = parseDetailsBlock(
+            """
+            <details title="starts open by default">
+            <summary>title</summary>
+            content
+            </details>
+            """.trimIndent()
+        )!!
+
+        assertEquals(false, parsed.openByDefault)
+    }
+
+    @Test
+    fun `parseDetailsBlock keeps real open attribute`() {
+        val parsed = parseDetailsBlock(
+            """
+            <details class="panel" open>
+            <summary>title</summary>
+            content
+            </details>
+            """.trimIndent()
+        )!!
+
+        assertEquals(true, parsed.openByDefault)
     }
 
     @Test


### PR DESCRIPTION
#1041 

<table>
<tr>
<td width="50%">

**原效果：**
![0a49ceb974e7c0b5818d085b287052f6](https://github.com/user-attachments/assets/3c738f32-9862-4e41-9cce-2e2997845e8c)

</td>
<td width="50%">

**修复效果：**
![Screenshot_2026_0410_000310](https://github.com/user-attachments/assets/a40a9a1d-37b3-4d7e-bd69-12ae382ae6c2)

</td>
</tr>
</table>

## 变更概述

修复了 Markdown 中 `<details>` 折叠块解析与渲染异常的系列问题。具体修复的场景包括：
- `<details>` 内部存在空行时，下半部分内容溢出折叠块。
- 内部内容被 `<div>` 包裹时，被降级渲染为单行纯文本，丢失原有样式。
- 内部直接编写的纯 Markdown 文本渲染丢失。
- 嵌套使用 `<details>` 时出现的结构错位与内容解析异常。

## 根因分析

现有代码中，问题出现在AST 解析阶段：当前项目使用的 org.intellij.markdown.MarkdownParser 在包含空行、块级内容或嵌套结构的 details 场景下，不能稳定地将其保留为单一的完整块节点，而可能将其拆分为多个 AST 节点。这导致后续 UI 渲染层接收到的节点树已经残缺，从而无法正确划定折叠块的边界，也无法准确还原其内部的 Markdown 语义。

## 修复方案

鉴于在 AST 节点生成后进行补救存在局限性，本次修复采用**解析前预处理**与**复用现有渲染链路**相结合的方案：

1. **解析前预提取**：在原始文本进入 `MarkdownParser` 前，提前提取完整、闭合的 `<details>...</details>` 块，并替换为占位符，从而保护其结构在 AST 构建阶段不被破坏。
2. **独立组件渲染**：在 Compose 渲染层解析到对应占位符时，映射并挂载专用的 `DetailsMarkdownBlock` 组件。
3. **内部语境恢复**：对于提取出的 `<details>` 正文，剥离掉可能存在的冗余 HTML 容器（如 `<p>`、`<div>`），随后将其重新递归送入现有的 `MarkdownBlock` 渲染链路。这确保了内部的列表、加粗、代码块等 Markdown 语法的表现与外部完全一致，且无需维护两套解析逻辑。

## 核心代码变更

- **`DetailsBlockProcessor.kt`**
  新增 Markdown 预处理逻辑。通过字符串扫描、标签边界判断和深度计数提取平衡的 details 块，并跳过代码块与行内代码中的伪标签，支持解析多层嵌套结构，并包含对代码块（Code Block）内部伪标签的自动过滤，避免误匹配。
- **`Markdown.kt` 及 `DetailsMarkdownBlock`**
  * `Markdown.kt`：接入占位符恢复，并在渲染阶段映射到 DetailsMarkdownBlock
  * `DetailsBlockProcessor.kt`：负责 details 提取、summary/body 解析，以及 prepareDetailsBodyForMarkdown() 中的最外层 p/div 解包
- **`DetailsBlockProcessorTest.kt`**
  补充相关回归测试。覆盖了空行、div/p 包裹、直接 Markdown 文本以及嵌套 details 等核心边界场景。

## 验证

**编译与测试：**
- 单元测试验证通过：
  `./gradlew :common:testDebugUnitTest --tests me.rerere.common.markdown.DetailsBlockProcessorTest`
- App 编译通过：
  `./gradlew :app:compileDebugKotlin`

**复杂场景人工验证样例**
<details>
<summary>展开查看测试用例 Markdown 源码</summary>

````markdown
<details>
<summary>第一层</summary>
<p>
这里是被折叠的内容，  
支持**加粗**、*斜体*、甚至 [链接](https://github.com)。

也可以包含列表：
- 第一项
- 第二项

> 以及引用块也能正常渲染

代码示例：

```JavaScript
console.log("Hello")
```

<details>
<summary>第二层</summary>
<p>
这里是被折叠的内容，  
支持**加粗**、*斜体*、甚至 [链接](https://github.com)。

也可以包含列表：
- 第一项
- 第二项

> 以及引用块也能正常渲染

代码示例：

```JavaScript
console.log("Hello")
```

</p>
</details>

</p>
</details>
````
</details>