### PR TITLE
fix(claude): 修复 OpenRouter 下 thinking 签名拆分

### DIFF
--- a/ai/src/main/java/me/rerere/ai/ui/Message.kt
+++ b/ai/src/main/java/me/rerere/ai/ui/Message.kt
@@ -33,6 +33,40 @@ data class UIMessage(
         val choice = chunk.choices.getOrNull(0)
         val message = choice?.delta ?: choice?.message
         return message?.let { delta ->
+            fun mergeMetadata(existing: JsonObject?, incoming: JsonObject?): JsonObject? {
+                return when {
+                    existing == null -> incoming
+                    incoming == null -> existing
+                    else -> JsonObject(existing + incoming)
+                }
+            }
+
+            fun List<UIMessagePart>.mergeSignatureOnlyReasoning(
+                deltaPart: UIMessagePart.Reasoning
+            ): List<UIMessagePart> {
+                val unfinishedIndex = indexOfLast {
+                    it is UIMessagePart.Reasoning && it.finishedAt == null
+                }
+                val targetIndex = if (unfinishedIndex >= 0) {
+                    unfinishedIndex
+                } else {
+                    indexOfLast { it is UIMessagePart.Reasoning }
+                }
+
+                if (targetIndex < 0) return this
+
+                return mapIndexed { index, part ->
+                    if (index == targetIndex) {
+                        val reasoningPart = part as UIMessagePart.Reasoning
+                        reasoningPart.copy().also {
+                            it.metadata = mergeMetadata(reasoningPart.metadata, deltaPart.metadata)
+                        }
+                    } else {
+                        part
+                    }
+                }
+            }
+
             // Handle Parts
             var newParts = delta.parts.fold(parts) { acc, deltaPart ->
                 when (deltaPart) {
@@ -73,6 +107,13 @@ data class UIMessage(
                         // Skip empty reasoning deltas
                         if (deltaPart.reasoning.isEmpty() && deltaPart.metadata == null) {
                             acc
+                        } else if (
+                            deltaPart.reasoning.isEmpty() &&
+                            deltaPart.metadata?.containsKey("signature") == true
+                        ) {
+                            // Anthropic/OpenRouter may send signature_delta after text content.
+                            // Attach it to the nearest reasoning block instead of creating an empty one.
+                            acc.mergeSignatureOnlyReasoning(deltaPart)
                         } else {
                             val lastPart = acc.lastOrNull()
                             if (lastPart is UIMessagePart.Reasoning) {
@@ -82,7 +123,7 @@ data class UIMessage(
                                     createdAt = lastPart.createdAt,
                                     finishedAt = null,
                                 ).also {
-                                    it.metadata = deltaPart.metadata ?: lastPart.metadata
+                                    it.metadata = mergeMetadata(lastPart.metadata, deltaPart.metadata)
                                 }
                             } else {
                                 // Create new Reasoning part

--- a/ai/src/test/java/me/rerere/ai/provider/providers/ClaudeProviderMessageTest.kt
+++ b/ai/src/test/java/me/rerere/ai/provider/providers/ClaudeProviderMessageTest.kt
@@ -1,9 +1,11 @@
 package me.rerere.ai.provider.providers
 
 import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
 import me.rerere.ai.core.MessageRole
 import me.rerere.ai.ui.UIMessage
 import me.rerere.ai.ui.UIMessagePart
@@ -184,6 +186,42 @@ class ClaudeProviderMessageTest {
         }?.jsonObject
         assertEquals("Let me think about this...",
             thinkingBlock?.get("thinking")?.jsonPrimitive?.content)
+    }
+
+    @Test
+    fun `thinking block should keep signature in the same content block`() {
+        val assistantMessage = UIMessage(
+            role = MessageRole.ASSISTANT,
+            parts = listOf(
+                UIMessagePart.Reasoning(
+                    reasoning = "Let me think about this...",
+                    metadata = buildJsonObject {
+                        put("signature", "sig-1")
+                    }
+                ),
+                UIMessagePart.Text("Here is my response")
+            )
+        )
+
+        val result = invokeBuildMessages(
+            listOf(
+                UIMessage.user("Question"),
+                assistantMessage
+            )
+        )
+
+        val assistantMsg = result.find {
+            it.jsonObject["role"]?.jsonPrimitive?.content == "assistant"
+        }!!.jsonObject
+
+        val thinkingBlocks = assistantMsg["content"]!!.jsonArray.filter {
+            it.jsonObject["type"]?.jsonPrimitive?.content == "thinking"
+        }
+
+        assertEquals(1, thinkingBlocks.size)
+        val thinkingBlock = thinkingBlocks.single().jsonObject
+        assertEquals("Let me think about this...", thinkingBlock["thinking"]?.jsonPrimitive?.content)
+        assertEquals("sig-1", thinkingBlock["signature"]?.jsonPrimitive?.content)
     }
 
     @Test

--- a/ai/src/test/java/me/rerere/ai/ui/MessageTest.kt
+++ b/ai/src/test/java/me/rerere/ai/ui/MessageTest.kt
@@ -1,5 +1,8 @@
 package me.rerere.ai.ui
 
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
 import kotlinx.serialization.json.JsonPrimitive
 import me.rerere.ai.core.MessageRole
 import org.junit.Assert.assertEquals
@@ -173,6 +176,142 @@ class MessageTest {
         )
 
         assertTrue(message.isValidToUpload())
+    }
+
+    @Test
+    fun `handleMessageChunk should merge signature-only reasoning delta into existing reasoning`() {
+        val messages = listOf(
+            UIMessage(
+                role = MessageRole.ASSISTANT,
+                parts = listOf(
+                    UIMessagePart.Reasoning(
+                        reasoning = "thinking",
+                        finishedAt = null
+                    )
+                )
+            )
+        )
+
+        val chunk = MessageChunk(
+            id = "chunk-1",
+            model = "claude-test",
+            choices = listOf(
+                UIMessageChoice(
+                    index = 0,
+                    delta = UIMessage(
+                        role = MessageRole.ASSISTANT,
+                        parts = listOf(
+                            UIMessagePart.Reasoning(
+                                reasoning = "",
+                                finishedAt = null,
+                                metadata = buildJsonObject {
+                                    put("signature", "sig-1")
+                                }
+                            )
+                        )
+                    ),
+                    message = null,
+                    finishReason = null
+                )
+            )
+        )
+
+        val result = messages.handleMessageChunk(chunk)
+        val reasoning = result.single().parts.single() as UIMessagePart.Reasoning
+
+        assertEquals(1, result.single().parts.size)
+        assertEquals("thinking", reasoning.reasoning)
+        assertEquals("sig-1", reasoning.metadata?.get("signature")?.jsonPrimitive?.content)
+    }
+
+    @Test
+    fun `handleMessageChunk should merge signature-only reasoning delta to latest reasoning after text`() {
+        val messages = listOf(
+            UIMessage(
+                role = MessageRole.ASSISTANT,
+                parts = listOf(
+                    UIMessagePart.Reasoning(
+                        reasoning = "thinking",
+                        finishedAt = null
+                    ),
+                    UIMessagePart.Text("visible text")
+                )
+            )
+        )
+
+        val chunk = MessageChunk(
+            id = "chunk-2",
+            model = "claude-test",
+            choices = listOf(
+                UIMessageChoice(
+                    index = 0,
+                    delta = UIMessage(
+                        role = MessageRole.ASSISTANT,
+                        parts = listOf(
+                            UIMessagePart.Reasoning(
+                                reasoning = "",
+                                finishedAt = null,
+                                metadata = buildJsonObject {
+                                    put("signature", "sig-2")
+                                }
+                            )
+                        )
+                    ),
+                    message = null,
+                    finishReason = null
+                )
+            )
+        )
+
+        val result = messages.handleMessageChunk(chunk)
+        val parts = result.single().parts
+
+        assertEquals(2, parts.size)
+        assertTrue(parts[0] is UIMessagePart.Reasoning)
+        assertTrue(parts[1] is UIMessagePart.Text)
+        assertEquals("sig-2", (parts[0] as UIMessagePart.Reasoning).metadata?.get("signature")?.jsonPrimitive?.content)
+        assertEquals("visible text", (parts[1] as UIMessagePart.Text).text)
+    }
+
+    @Test
+    fun `handleMessageChunk should ignore orphan signature-only reasoning delta`() {
+        val messages = listOf(
+            UIMessage(
+                role = MessageRole.ASSISTANT,
+                parts = listOf(UIMessagePart.Text("visible text"))
+            )
+        )
+
+        val chunk = MessageChunk(
+            id = "chunk-3",
+            model = "claude-test",
+            choices = listOf(
+                UIMessageChoice(
+                    index = 0,
+                    delta = UIMessage(
+                        role = MessageRole.ASSISTANT,
+                        parts = listOf(
+                            UIMessagePart.Reasoning(
+                                reasoning = "",
+                                finishedAt = null,
+                                metadata = buildJsonObject {
+                                    put("signature", "sig-3")
+                                }
+                            )
+                        )
+                    ),
+                    message = null,
+                    finishReason = null
+                )
+            )
+        )
+
+        val result = messages.handleMessageChunk(chunk)
+        val parts = result.single().parts
+
+        assertEquals(1, parts.size)
+        assertTrue(parts.single() is UIMessagePart.Text)
+        assertEquals("visible text", (parts.single() as UIMessagePart.Text).text)
     }
 
     // ==================== migrateToolMessages Tests ====================


### PR DESCRIPTION
## 问题

使用 OpenRouter 以 Anthropic 格式请求 Claude 时，流式返回的 `signature_delta` 可能晚于 `thinking_delta` 或正文内容到达，导致应用把同一个 thinking block 拆成两个 `Reasoning` part。下一轮请求回传历史 thinking 时，`thinking` 内容和 `signature` 被分离，进而触发签名校验错误。

Closes #1075

## 原因

`UIMessage.appendChunk()` 在处理 reasoning delta 时，只会在“当前最后一个 part 也是 `Reasoning`”的情况下执行合并。

但 OpenRouter 转发 Anthropic stream 时，`signature_delta` 可能在 reasoning 文本之后，甚至在 text part 之后单独到达。现有逻辑会把这类 delta 落成一个新的空 `Reasoning` part，而不是挂回前面的 reasoning。

## 修复

1. 对只包含 `metadata.signature` 的 reasoning delta，优先合并到最近的未结束 `Reasoning`；如果没有未结束项，则回退到最近的 `Reasoning`。
2. 合并时保留原有 `reasoning` 文本，只补充 `signature` 元数据，不再创建空的 reasoning part。
3. 如果当前消息里根本没有任何 `Reasoning`，则忽略这类孤立签名 delta，避免制造新的异常数据。
4. 补充消息合并层与 Claude 序列化层回归测试，覆盖 signature 晚到、text 插入后晚到，以及带 `signature` 的 thinking block 仍序列化为单个 content block 的场景。
