### PR TITLE
fix(claude): 更新 Anthropic thinking 与 effort 参数

### DIFF
--- a/ai/src/main/java/me/rerere/ai/provider/providers/ClaudeProvider.kt
+++ b/ai/src/main/java/me/rerere/ai/provider/providers/ClaudeProvider.kt
@@ -54,10 +54,29 @@ import okhttp3.Response
 import okhttp3.sse.EventSource
 import okhttp3.sse.EventSourceListener
 import okhttp3.sse.EventSources
+import kotlin.math.abs
 import kotlin.time.Clock
 
 private const val TAG = "ClaudeProvider"
 private const val ANTHROPIC_VERSION = "2023-06-01"
+private const val CLAUDE_DEFAULT_MANUAL_THINKING_BUDGET = 1024
+
+private enum class ClaudeThinkingModelFamily {
+    LEGACY,
+    ADAPTIVE_WITH_MANUAL_BUDGET,
+    ADAPTIVE_ONLY,
+}
+
+private data class ClaudeThinkingConfig(
+    val thinking: JsonObject,
+    val outputConfig: JsonObject? = null,
+)
+
+private val CLAUDE_EFFORT_LEVELS = listOf(
+    ReasoningLevel.LOW,
+    ReasoningLevel.MEDIUM,
+    ReasoningLevel.HIGH,
+)
 
 class ClaudeProvider(private val client: OkHttpClient, context: Context? = null) : Provider<ProviderSetting.Claude> {
     private val keyRoulette = if (context != null) KeyRoulette.lru(context) else KeyRoulette.default()
@@ -297,23 +316,12 @@ class ClaudeProvider(private val client: OkHttpClient, context: Context? = null)
 
             // 处理 thinking budget
             if (params.model.abilities.contains(ModelAbility.REASONING)) {
-                val level = ReasoningLevel.fromBudgetTokens(params.thinkingBudget ?: 0)
-                put("thinking", buildJsonObject {
-                    when (level) {
-                        ReasoningLevel.OFF -> {
-                            put("type", "disabled")
-                        }
-
-                        ReasoningLevel.AUTO -> {
-                            put("type", "adaptive")
-                        }
-
-                        else -> {
-                            put("type", "enabled")
-                            put("budget_tokens", params.thinkingBudget ?: 1024)
-                        }
-                    }
-                })
+                val thinkingConfig = buildThinkingConfig(
+                    modelId = params.model.modelId,
+                    thinkingBudget = params.thinkingBudget,
+                )
+                put("thinking", thinkingConfig.thinking)
+                thinkingConfig.outputConfig?.let { put("output_config", it) }
             }
 
             // 处理工具
@@ -388,6 +396,95 @@ class ClaudeProvider(private val client: OkHttpClient, context: Context? = null)
                 JsonObject(obj + mapOf("content" to newContent))
             } else msg
         })
+    }
+
+    private fun buildThinkingConfig(modelId: String, thinkingBudget: Int?): ClaudeThinkingConfig {
+        return when (classifyThinkingModel(modelId)) {
+            ClaudeThinkingModelFamily.LEGACY -> when {
+                thinkingBudget == ReasoningLevel.AUTO.budgetTokens -> ClaudeThinkingConfig(
+                    manualThinking(CLAUDE_DEFAULT_MANUAL_THINKING_BUDGET)
+                )
+
+                thinkingBudget != null && thinkingBudget > 0 -> {
+                    ClaudeThinkingConfig(manualThinking(thinkingBudget))
+                }
+
+                else -> ClaudeThinkingConfig(disabledThinking())
+            }
+
+            ClaudeThinkingModelFamily.ADAPTIVE_WITH_MANUAL_BUDGET -> when {
+                thinkingBudget == ReasoningLevel.AUTO.budgetTokens -> ClaudeThinkingConfig(adaptiveThinking())
+                thinkingBudget != null && thinkingBudget > 0 -> {
+                    val exactEffortLevel = exactEffortLevel(thinkingBudget)
+                    if (exactEffortLevel != null) {
+                        adaptiveThinkingWithEffort(exactEffortLevel)
+                    } else {
+                        ClaudeThinkingConfig(manualThinking(thinkingBudget))
+                    }
+                }
+
+                else -> ClaudeThinkingConfig(disabledThinking())
+            }
+
+            ClaudeThinkingModelFamily.ADAPTIVE_ONLY -> when {
+                thinkingBudget == ReasoningLevel.AUTO.budgetTokens -> ClaudeThinkingConfig(adaptiveThinking())
+                thinkingBudget != null && thinkingBudget > 0 -> {
+                    val effortLevel = exactEffortLevel(thinkingBudget)
+                        ?: closestEffortLevel(thinkingBudget)
+                    adaptiveThinkingWithEffort(effortLevel)
+                }
+
+                else -> ClaudeThinkingConfig(disabledThinking())
+            }
+        }
+    }
+
+    private fun classifyThinkingModel(modelId: String): ClaudeThinkingModelFamily {
+        val normalizedModelId = modelId.lowercase().replace('.', '-')
+
+        return when {
+            normalizedModelId.contains("claude") &&
+                normalizedModelId.contains("opus") &&
+                normalizedModelId.contains("4-7") -> ClaudeThinkingModelFamily.ADAPTIVE_ONLY
+
+            normalizedModelId.contains("claude") &&
+                normalizedModelId.contains("4-6") &&
+                (normalizedModelId.contains("sonnet") || normalizedModelId.contains("opus")) -> {
+                ClaudeThinkingModelFamily.ADAPTIVE_WITH_MANUAL_BUDGET
+            }
+
+            else -> ClaudeThinkingModelFamily.LEGACY
+        }
+    }
+
+    private fun exactEffortLevel(thinkingBudget: Int): ReasoningLevel? {
+        return CLAUDE_EFFORT_LEVELS.firstOrNull { it.budgetTokens == thinkingBudget }
+    }
+
+    private fun closestEffortLevel(thinkingBudget: Int): ReasoningLevel {
+        return CLAUDE_EFFORT_LEVELS.minByOrNull { abs(it.budgetTokens - thinkingBudget) } ?: ReasoningLevel.LOW
+    }
+
+    private fun disabledThinking() = buildJsonObject {
+        put("type", "disabled")
+    }
+
+    private fun adaptiveThinking() = buildJsonObject {
+        put("type", "adaptive")
+    }
+
+    private fun manualThinking(thinkingBudget: Int) = buildJsonObject {
+        put("type", "enabled")
+        put("budget_tokens", thinkingBudget)
+    }
+
+    private fun adaptiveThinkingWithEffort(level: ReasoningLevel): ClaudeThinkingConfig {
+        return ClaudeThinkingConfig(
+            thinking = adaptiveThinking(),
+            outputConfig = buildJsonObject {
+                put("effort", level.effort)
+            }
+        )
     }
 
     private fun JsonArrayBuilder.addAssistantMessage(message: UIMessage) {

--- a/ai/src/test/java/me/rerere/ai/provider/providers/ClaudeProviderPromptCacheTest.kt
+++ b/ai/src/test/java/me/rerere/ai/provider/providers/ClaudeProviderPromptCacheTest.kt
@@ -53,6 +53,21 @@ class ClaudeProviderPromptCacheTest {
         )
     }
 
+    private fun reasoningModel(modelId: String): Model {
+        return Model(modelId = modelId, abilities = listOf(ModelAbility.REASONING))
+    }
+
+    private fun reasoningRequest(modelId: String, thinkingBudget: Int?): JsonObject {
+        return buildRequest(
+            providerSetting = ProviderSetting.Claude(),
+            messages = listOf(UIMessage.user("hello")),
+            params = TextGenerationParams(
+                model = reasoningModel(modelId),
+                thinkingBudget = thinkingBudget
+            )
+        )
+    }
+
     @Test
     fun `promptCaching=false should not add cache_control anywhere`() {
         val providerSetting = ProviderSetting.Claude(promptCaching = false)
@@ -204,6 +219,136 @@ class ClaudeProviderPromptCacheTest {
             content?.forEach { block ->
                 assertNull(block.jsonObject["cache_control"])
             }
+        }
+    }
+
+    @Test
+    fun `legacy Claude auto should fall back to default manual thinking budget`() {
+        val request = reasoningRequest(
+            modelId = "claude-sonnet-4-5-20250929",
+            thinkingBudget = -1
+        )
+
+        val thinking = request["thinking"]!!.jsonObject
+        assertEquals("enabled", thinking["type"]!!.jsonPrimitive.content)
+        assertEquals(1024, thinking["budget_tokens"]!!.jsonPrimitive.content.toInt())
+        assertNull(request["output_config"])
+    }
+
+    @Test
+    fun `legacy Claude custom budget should keep manual thinking`() {
+        val request = reasoningRequest(
+            modelId = "claude-sonnet-4-5-20250929",
+            thinkingBudget = 500
+        )
+
+        val thinking = request["thinking"]!!.jsonObject
+        assertEquals("enabled", thinking["type"]!!.jsonPrimitive.content)
+        assertEquals(500, thinking["budget_tokens"]!!.jsonPrimitive.content.toInt())
+        assertNull(request["output_config"])
+    }
+
+    @Test
+    fun `Claude 4_6 auto should use adaptive thinking without effort`() {
+        val request = reasoningRequest(
+            modelId = "claude-sonnet-4-6-20251001",
+            thinkingBudget = -1
+        )
+
+        val thinking = request["thinking"]!!.jsonObject
+        assertEquals("adaptive", thinking["type"]!!.jsonPrimitive.content)
+        assertNull(thinking["budget_tokens"])
+        assertNull(request["output_config"])
+    }
+
+    @Test
+    fun `Claude 4_6 preset budget should use adaptive thinking with effort`() {
+        val request = reasoningRequest(
+            modelId = "claude-sonnet-4-6-20251001",
+            thinkingBudget = 16_000
+        )
+
+        val thinking = request["thinking"]!!.jsonObject
+        val outputConfig = request["output_config"]!!.jsonObject
+        assertEquals("adaptive", thinking["type"]!!.jsonPrimitive.content)
+        assertNull(thinking["budget_tokens"])
+        assertEquals("medium", outputConfig["effort"]!!.jsonPrimitive.content)
+    }
+
+    @Test
+    fun `Claude 4_6 custom budget should keep manual thinking`() {
+        val request = reasoningRequest(
+            modelId = "claude-sonnet-4-6-20251001",
+            thinkingBudget = 500
+        )
+
+        val thinking = request["thinking"]!!.jsonObject
+        assertEquals("enabled", thinking["type"]!!.jsonPrimitive.content)
+        assertEquals(500, thinking["budget_tokens"]!!.jsonPrimitive.content.toInt())
+        assertNull(request["output_config"])
+    }
+
+    @Test
+    fun `Claude 4_7 auto should use adaptive thinking without effort`() {
+        val request = reasoningRequest(
+            modelId = "claude-opus-4-7-20260301",
+            thinkingBudget = -1
+        )
+
+        val thinking = request["thinking"]!!.jsonObject
+        assertEquals("adaptive", thinking["type"]!!.jsonPrimitive.content)
+        assertNull(thinking["budget_tokens"])
+        assertNull(request["output_config"])
+    }
+
+    @Test
+    fun `Claude 4_7 preset budget should use adaptive thinking with effort`() {
+        val request = reasoningRequest(
+            modelId = "claude-opus-4-7-20260301",
+            thinkingBudget = 32_000
+        )
+
+        val thinking = request["thinking"]!!.jsonObject
+        val outputConfig = request["output_config"]!!.jsonObject
+        assertEquals("adaptive", thinking["type"]!!.jsonPrimitive.content)
+        assertNull(thinking["budget_tokens"])
+        assertEquals("high", outputConfig["effort"]!!.jsonPrimitive.content)
+    }
+
+    @Test
+    fun `Claude 4_7 custom budget should approximate to nearest effort`() {
+        val request = reasoningRequest(
+            modelId = "claude-opus-4-7-20260301",
+            thinkingBudget = 500
+        )
+
+        val thinking = request["thinking"]!!.jsonObject
+        val outputConfig = request["output_config"]!!.jsonObject
+        assertEquals("adaptive", thinking["type"]!!.jsonPrimitive.content)
+        assertNull(thinking["budget_tokens"])
+        assertEquals("low", outputConfig["effort"]!!.jsonPrimitive.content)
+    }
+
+    @Test
+    fun `Claude reasoning off should stay disabled across model families`() {
+        val legacyRequest = reasoningRequest(
+            modelId = "claude-sonnet-4-5-20250929",
+            thinkingBudget = 0
+        )
+        val adaptiveRequest = reasoningRequest(
+            modelId = "claude-sonnet-4-6-20251001",
+            thinkingBudget = 0
+        )
+        val adaptiveOnlyRequest = reasoningRequest(
+            modelId = "claude-opus-4-7-20260301",
+            thinkingBudget = 0
+        )
+
+        listOf(legacyRequest, adaptiveRequest, adaptiveOnlyRequest).forEach { request ->
+            val thinking = request["thinking"]!!.jsonObject
+            assertEquals("disabled", thinking["type"]!!.jsonPrimitive.content)
+            assertNull(thinking["budget_tokens"])
+            assertNull(request["output_config"])
         }
     }
 }

--- a/app/src/main/java/me/rerere/rikkahub/data/ai/GenerationHandler.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/ai/GenerationHandler.kt
@@ -14,6 +14,7 @@ import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 import me.rerere.ai.core.MessageRole
+import me.rerere.ai.core.ReasoningLevel
 import me.rerere.ai.core.Tool
 import me.rerere.ai.core.merge
 import me.rerere.ai.provider.CustomBody
@@ -47,6 +48,30 @@ import java.util.Locale
 import kotlin.time.Clock
 
 private const val TAG = "GenerationHandler"
+internal const val CLAUDE_47_THINKING_BUDGET_WARNING =
+    "当前 Claude 型号不支持手动 thinking budget，已重置到最近 effort "
+
+private val CLAUDE_EFFORT_PRESET_BUDGETS = setOf(
+    ReasoningLevel.LOW.budgetTokens,
+    ReasoningLevel.MEDIUM.budgetTokens,
+    ReasoningLevel.HIGH.budgetTokens,
+)
+
+internal fun buildAnthropicThinkingBudgetWarning(modelId: String, thinkingBudget: Int?): String? {
+    val normalizedModelId = modelId.lowercase().replace('.', '-')
+    val isClaude47Model = normalizedModelId.contains("claude") &&
+        normalizedModelId.contains("opus") &&
+        normalizedModelId.contains("4-7")
+    val isCustomPositiveBudget = thinkingBudget != null &&
+        thinkingBudget > 0 &&
+        thinkingBudget !in CLAUDE_EFFORT_PRESET_BUDGETS
+
+    return if (isClaude47Model && isCustomPositiveBudget) {
+        CLAUDE_47_THINKING_BUDGET_WARNING
+    } else {
+        null
+    }
+}
 
 @Serializable
 sealed interface GenerationChunk {

--- a/app/src/main/java/me/rerere/rikkahub/service/ChatService.kt
+++ b/app/src/main/java/me/rerere/rikkahub/service/ChatService.kt
@@ -51,6 +51,7 @@ import me.rerere.rikkahub.R
 import me.rerere.rikkahub.RouteActivity
 import me.rerere.rikkahub.data.ai.GenerationChunk
 import me.rerere.rikkahub.data.ai.GenerationHandler
+import me.rerere.rikkahub.data.ai.buildAnthropicThinkingBudgetWarning
 import me.rerere.rikkahub.data.ai.mcp.McpManager
 import me.rerere.rikkahub.data.ai.tools.LocalTools
 import me.rerere.rikkahub.data.ai.tools.createSearchTools
@@ -476,6 +477,16 @@ class ChatService(
             checkInvalidMessages(conversationId)
             val conversation = getConversationFlow(conversationId).value
 
+            buildAnthropicThinkingBudgetWarning(
+                modelId = model.modelId,
+                thinkingBudget = assistant.thinkingBudget,
+            )?.let { warning ->
+                addError(
+                    error = IllegalStateException(warning),
+                    conversationId = conversationId,
+                )
+            }
+
             // start generating
             generationHandler.generateText(
                 settings = settings,
@@ -487,8 +498,8 @@ class ChatService(
                         it
                     }
                 },
-                assistant = settings.getCurrentAssistant(),
-                memories = if (settings.getCurrentAssistant().useGlobalMemory) {
+                assistant = assistant,
+                memories = if (assistant.useGlobalMemory) {
                     memoryRepository.getGlobalMemories()
                 } else {
                     memoryRepository.getMemoriesOfAssistant(settings.assistantId.toString())
@@ -502,8 +513,7 @@ class ChatService(
                     if (settings.enableWebSearch) {
                         addAll(createSearchTools(settings))
                     }
-                    addAll(localTools.getTools(settings.getCurrentAssistant().localTools))
-                    val assistant = settings.getCurrentAssistant()
+                    addAll(localTools.getTools(assistant.localTools))
                     if (assistant.enabledSkills.isNotEmpty()) {
                         addAll(
                             createSkillTools(

--- a/app/src/test/java/me/rerere/rikkahub/data/ai/AnthropicThinkingBudgetWarningTest.kt
+++ b/app/src/test/java/me/rerere/rikkahub/data/ai/AnthropicThinkingBudgetWarningTest.kt
@@ -1,0 +1,75 @@
+package me.rerere.rikkahub.data.ai
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class AnthropicThinkingBudgetWarningTest {
+    @Test
+    fun `Claude 4_7 custom positive budgets should show warning`() {
+        assertEquals(
+            CLAUDE_47_THINKING_BUDGET_WARNING,
+            buildAnthropicThinkingBudgetWarning(
+                modelId = "claude-opus-4.7-20260301",
+                thinkingBudget = 5000
+            )
+        )
+        assertEquals(
+            CLAUDE_47_THINKING_BUDGET_WARNING,
+            buildAnthropicThinkingBudgetWarning(
+                modelId = "claude-opus-4-7-20260301",
+                thinkingBudget = 20_000
+            )
+        )
+    }
+
+    @Test
+    fun `Claude 4_7 off auto and preset budgets should not show warning`() {
+        assertNull(
+            buildAnthropicThinkingBudgetWarning(
+                modelId = "claude-opus-4-7-20260301",
+                thinkingBudget = 0
+            )
+        )
+        assertNull(
+            buildAnthropicThinkingBudgetWarning(
+                modelId = "claude-opus-4-7-20260301",
+                thinkingBudget = -1
+            )
+        )
+        assertNull(
+            buildAnthropicThinkingBudgetWarning(
+                modelId = "claude-opus-4-7-20260301",
+                thinkingBudget = 1024
+            )
+        )
+        assertNull(
+            buildAnthropicThinkingBudgetWarning(
+                modelId = "claude-opus-4-7-20260301",
+                thinkingBudget = 16_000
+            )
+        )
+        assertNull(
+            buildAnthropicThinkingBudgetWarning(
+                modelId = "claude-opus-4-7-20260301",
+                thinkingBudget = 32_000
+            )
+        )
+    }
+
+    @Test
+    fun `legacy Claude and Claude 4_6 should not show warning`() {
+        assertNull(
+            buildAnthropicThinkingBudgetWarning(
+                modelId = "claude-sonnet-4-5-20250929",
+                thinkingBudget = 20_000
+            )
+        )
+        assertNull(
+            buildAnthropicThinkingBudgetWarning(
+                modelId = "claude-sonnet-4-6-20251001",
+                thinkingBudget = 20_000
+            )
+        )
+    }
+}


### PR DESCRIPTION
## 问题

Anthropic 新增 adaptive thinking 和 effort 相关 API 语义
当前Claude 4.6 无法按官方推荐发送 `adaptive + output_config.effort`；Claude 4.7 上输入自定义正整数 thinking budget 时，会构造出当前模型不支持的请求

Closes #1090

## 原因

`ClaudeProvider` 当前只根据 `ReasoningLevel.fromBudgetTokens(...)` 统一生成三种 thinking 请求：

- `OFF -> disabled`
- `AUTO -> adaptive`
- 其他 -> `enabled + budget_tokens`

这套逻辑没有区分旧 Claude、和更新后的 Claude 4.6、Claude 4.7 的 Anthropic API 更新

## 修复

1. 按模型拆分 Claude thinking 参数映射：旧 Claude 的 `AUTO` 换为默认手动 budget 1024；Claude 4.6、4.7 的预设档位改为 `adaptive + output_config.effort`；自定义正整数 budget 改为 `adaptive + 最近 effort`
2. 最近 effort 只在 `Low / Medium / High` 三档内取最近值
3. 在聊天生成入口补充 4.7 自定义 budget 的红色错误卡片提示，当请求被自动近似为 effort 时明确告知用户。

还有测试。
