### PR TITLE
fix: preserve manual model display name casing

### DIFF
--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingProviderDetailPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingProviderDetailPage.kt
@@ -504,7 +504,7 @@ private fun ModelSettingsForm(
         onModelChange(
             model.copy(
                 modelId = id,
-                displayName = id.uppercase(),
+                displayName = id,
                 inputModalities = inputModality,
                 outputModalities = outputModality,
                 abilities = abilities


### PR DESCRIPTION
体验优化，减小强迫症用户手动添加模型的使用摩擦，不再在输入模型id的时候，模型名称小写字母自动补全为大写。