### PR TITLE
fix: 图片保存来源解析与 Mermaid CacheBuilder 编译修复

### DIFF
--- a/app/src/main/java/me/rerere/rikkahub/data/files/FilesManager.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/files/FilesManager.kt
@@ -292,42 +292,66 @@ class FilesManager(
     @OptIn(ExperimentalEncodingApi::class)
     suspend fun saveMessageImage(activityContext: Context, image: String) = withContext(Dispatchers.IO) {
         val activity = requireNotNull(activityContext.getActivity()) { "Activity not found" }
-        when {
-            image.startsWith("data:image") -> {
-                val byteArray = Base64.decode(image.substringAfter("base64,").toByteArray())
-                val bitmap = BitmapFactory.decodeByteArray(byteArray, 0, byteArray.size)
-                activityContext.exportImage(activity, bitmap)
+        when (val source = parseImageSource(image)) {
+            is ImageSource.DataUri -> {
+                exportBase64Image(activityContext, activity, source.base64Data)
             }
 
-            image.startsWith("file:") -> {
-                val file = image.toUri().toFile()
+            is ImageSource.RawBase64 -> {
+                exportBase64Image(activityContext, activity, source.base64Data)
+            }
+
+            is ImageSource.FileUri -> {
+                val file = source.raw.toUri().toFile()
                 activityContext.exportImageFile(activity, file)
             }
 
-            image.startsWith("/") -> {
-                activityContext.exportImageFile(activity, File(image))
+            is ImageSource.LocalPath -> {
+                activityContext.exportImageFile(activity, File(source.raw))
             }
 
-            image.startsWith("http") -> {
-                runCatching {
-                    val url = URL(image)
-                    val connection = url.openConnection() as HttpURLConnection
-                    connection.connect()
+            is ImageSource.ContentUri -> {
+                val bitmap = activityContext.contentResolver.openInputStream(source.raw.toUri())?.use { input ->
+                    BitmapFactory.decodeStream(input)
+                } ?: error("Unable to open image")
+                requireNotNull(bitmap) { "Unable to decode image" }
+                activityContext.exportImage(activity, bitmap)
+            }
 
-                    if (connection.responseCode == HttpURLConnection.HTTP_OK) {
-                        val bitmap = BitmapFactory.decodeStream(connection.inputStream)
-                        activityContext.exportImage(activity, bitmap)
-                    } else {
+            is ImageSource.RemoteUrl -> {
+                val connection = (URL(source.raw).openConnection() as HttpURLConnection).apply {
+                    connect()
+                }
+                try {
+                    if (connection.responseCode != HttpURLConnection.HTTP_OK) {
                         Log.e(
                             TAG,
-                            "saveMessageImage: Failed to download image from $image, response code: ${connection.responseCode}"
+                            "saveMessageImage: Failed to download image from ${source.raw}, response code: ${connection.responseCode}"
                         )
+                        error("Failed to download image: HTTP ${connection.responseCode}")
                     }
-                }.getOrNull()
+                    val bitmap = connection.inputStream.use { input ->
+                        BitmapFactory.decodeStream(input)
+                    }
+                    requireNotNull(bitmap) { "Unable to decode downloaded image" }
+                    activityContext.exportImage(activity, bitmap)
+                } finally {
+                    connection.disconnect()
+                }
             }
-
-            else -> error("Invalid image format")
         }
+    }
+
+    @OptIn(ExperimentalEncodingApi::class)
+    private fun exportBase64Image(
+        activityContext: Context,
+        activity: android.app.Activity,
+        base64Data: String
+    ) {
+        val byteArray = Base64.decode(base64Data.toByteArray())
+        val bitmap = BitmapFactory.decodeByteArray(byteArray, 0, byteArray.size)
+        requireNotNull(bitmap) { "Unable to decode image" }
+        activityContext.exportImage(activity, bitmap)
     }
 
     suspend fun syncFolder(folder: String = FileFolders.UPLOAD): Int = withContext(Dispatchers.IO) {
@@ -548,4 +572,102 @@ class FilesManager(
 object FileFolders {
     const val UPLOAD = "upload"
     const val SKILLS = "skills"
+}
+
+internal sealed interface ImageSource {
+    val raw: String
+
+    data class DataUri(
+        override val raw: String,
+        val base64Data: String,
+    ) : ImageSource
+
+    data class RawBase64(
+        override val raw: String,
+        val base64Data: String,
+    ) : ImageSource
+
+    data class RemoteUrl(
+        override val raw: String,
+    ) : ImageSource
+
+    data class FileUri(
+        override val raw: String,
+    ) : ImageSource
+
+    data class ContentUri(
+        override val raw: String,
+    ) : ImageSource
+
+    data class LocalPath(
+        override val raw: String,
+    ) : ImageSource
+}
+
+private val WINDOWS_ABSOLUTE_PATH = Regex("^[A-Za-z]:[\\\\/].+")
+private val BASE64_PATTERN = Regex("^[A-Za-z0-9+/=_-]+$")
+
+@OptIn(ExperimentalEncodingApi::class)
+internal fun parseImageSource(raw: String): ImageSource {
+    val image = raw.trim()
+    require(image.isNotBlank()) { "Image source is empty" }
+
+    if (image.startsWith("data:", ignoreCase = true) && image.contains(";base64,", ignoreCase = true)) {
+        val base64Data = image.substringAfter(";base64,", "")
+        require(base64Data.isNotBlank()) { "Image data is empty" }
+        require(looksLikeBase64Image(base64Data)) { "Invalid image format" }
+        return ImageSource.DataUri(raw = image, base64Data = base64Data)
+    }
+
+    if (image.startsWith("http://", ignoreCase = true) || image.startsWith("https://", ignoreCase = true)) {
+        return ImageSource.RemoteUrl(image)
+    }
+
+    if (image.startsWith("file://", ignoreCase = true)) {
+        return ImageSource.FileUri(image)
+    }
+
+    if (image.startsWith("content://", ignoreCase = true)) {
+        return ImageSource.ContentUri(image)
+    }
+
+    if (image.startsWith("/") || WINDOWS_ABSOLUTE_PATH.matches(image) || File(image).isAbsolute) {
+        return ImageSource.LocalPath(image)
+    }
+
+    if (looksLikeBase64Image(image)) {
+        return ImageSource.RawBase64(raw = image, base64Data = image)
+    }
+
+    error("Invalid image format")
+}
+
+@OptIn(ExperimentalEncodingApi::class)
+private fun looksLikeBase64Image(raw: String): Boolean {
+    val normalized = raw.filterNot(Char::isWhitespace)
+    if (normalized.length < 16 || normalized.length % 4 != 0) return false
+    if (!BASE64_PATTERN.matches(normalized)) return false
+
+    val bytes = runCatching { Base64.decode(normalized.toByteArray()) }.getOrNull() ?: return false
+    return bytes.hasImageMagic()
+}
+
+private fun ByteArray.hasImageMagic(): Boolean {
+    if (startsWithBytes(0x89, 0x50, 0x4E, 0x47)) return true
+    if (startsWithBytes(0xFF, 0xD8, 0xFF)) return true
+    if (startsWithBytes(0x47, 0x49, 0x46, 0x38)) return true
+    if (startsWithBytes(0x52, 0x49, 0x46, 0x46) && size >= 12 && sliceArray(8..11)
+            .contentEquals(byteArrayOf(0x57, 0x45, 0x42, 0x50))
+    ) {
+        return true
+    }
+    return false
+}
+
+private fun ByteArray.startsWithBytes(vararg values: Int): Boolean {
+    if (size < values.size) return false
+    for (i in values.indices) {
+        if ((this[i].toInt() and 0xFF) != values[i]) return false
+    }
+    return true
 }

--- a/app/src/main/java/me/rerere/rikkahub/ui/components/richtext/Mermaid.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/richtext/Mermaid.kt
@@ -33,7 +33,6 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.dokar.sonner.ToastType
-import com.google.common.cache.CacheBuilder
 import me.rerere.hugeicons.HugeIcons
 import me.rerere.hugeicons.stroke.Cancel01
 import me.rerere.hugeicons.stroke.Download01
@@ -47,9 +46,11 @@ import me.rerere.rikkahub.utils.escapeHtml
 import me.rerere.rikkahub.utils.exportImage
 import me.rerere.rikkahub.utils.toCssHex
 
-private val mermaidHeightCache = CacheBuilder.newBuilder()
-    .maximumSize(100)
-    .build<String, Int>()
+private val mermaidHeightCache = object : LinkedHashMap<String, Int>(100, 0.75f, true) {
+    override fun removeEldestEntry(eldest: MutableMap.MutableEntry<String, Int>?): Boolean {
+        return size > 100
+    }
+}
 
 /**
  * A component that renders Mermaid diagrams.
@@ -69,7 +70,7 @@ fun Mermaid(
     val activity = LocalActivity.current
     val toaster = LocalToaster.current
 
-    var contentHeight by remember { mutableIntStateOf(mermaidHeightCache.getIfPresent(code) ?: 150) }
+    var contentHeight by remember { mutableIntStateOf(mermaidHeightCache[code] ?: 150) }
     val height = with(density) {
         contentHeight.toDp()
     }
@@ -79,7 +80,7 @@ fun Mermaid(
                 // 需要乘以density
                 // https://stackoverflow.com/questions/43394498/how-to-get-the-full-height-of-in-android-webview
                 contentHeight = (height * density.density).toInt()
-                mermaidHeightCache.put(code, contentHeight)
+                mermaidHeightCache[code] = contentHeight
             },
             onExportImage = { base64Image ->
                 runCatching {

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/imggen/ImgGenPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/imggen/ImgGenPage.kt
@@ -75,6 +75,7 @@ import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import androidx.core.net.toUri
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.paging.compose.collectAsLazyPagingItems
 import androidx.paging.compose.itemContentType
@@ -263,7 +264,7 @@ private fun ImageGenScreen(
 
                 if (showPreview) {
                     ImagePreviewDialog(
-                        images = listOf(image.filePath),
+                        images = listOf(File(image.filePath).toUri().toString()),
                         onDismissRequest = { showPreview = false },
                     )
                 }
@@ -458,7 +459,10 @@ private fun ImageGalleryScreen(
                                             onClick = {
                                                 scope.launch {
                                                     try {
-                                                        filesManager.saveMessageImage(context, "file://${it.filePath}")
+                                                        filesManager.saveMessageImage(
+                                                            context,
+                                                            File(it.filePath).toUri().toString()
+                                                        )
                                                         toaster.show(
                                                             message = context.getString(R.string.imggen_page_image_saved_success),
                                                             type = ToastType.Success
@@ -501,7 +505,7 @@ private fun ImageGalleryScreen(
 
                         if (showPreview) {
                             ImagePreviewDialog(
-                                images = listOf(it.filePath),
+                                images = listOf(File(it.filePath).toUri().toString()),
                                 onDismissRequest = { showPreview = false }
                             )
                         }

--- a/app/src/test/java/me/rerere/rikkahub/data/files/ImageSourceParsingTest.kt
+++ b/app/src/test/java/me/rerere/rikkahub/data/files/ImageSourceParsingTest.kt
@@ -1,0 +1,61 @@
+package me.rerere.rikkahub.data.files
+
+import java.nio.file.Files
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ImageSourceParsingTest {
+    @Test
+    fun `parse accepts base64 data uri with generic mime`() {
+        val source = parseImageSource("data:application/octet-stream;base64,$PNG_BASE64")
+
+        assertTrue(source is ImageSource.DataUri)
+        assertEquals(PNG_BASE64, (source as ImageSource.DataUri).base64Data)
+    }
+
+    @Test
+    fun `parse accepts raw base64 image payload`() {
+        val source = parseImageSource(PNG_BASE64)
+
+        assertTrue(source is ImageSource.RawBase64)
+        assertEquals(PNG_BASE64, (source as ImageSource.RawBase64).base64Data)
+    }
+
+    @Test
+    fun `parse accepts content uri`() {
+        val source = parseImageSource("content://media/external/images/media/42")
+
+        assertTrue(source is ImageSource.ContentUri)
+    }
+
+    @Test
+    fun `parse accepts file uri`() {
+        val source = parseImageSource("file:///data/user/0/me.rerere.rikkahub/files/images/test.png")
+
+        assertTrue(source is ImageSource.FileUri)
+    }
+
+    @Test
+    fun `parse accepts local absolute file path`() {
+        val tempFile = Files.createTempFile("image-source", ".png").toFile()
+
+        try {
+            val source = parseImageSource(tempFile.absolutePath)
+
+            assertTrue(source is ImageSource.LocalPath)
+            assertEquals(tempFile.absolutePath, source.raw)
+        } finally {
+            tempFile.delete()
+        }
+    }
+
+    @Test(expected = IllegalStateException::class)
+    fun `parse rejects unsupported image source`() {
+        parseImageSource("not-an-image")
+    }
+
+    private companion object {
+        const val PNG_BASE64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+yf9kAAAAASUVORK5CYII="
+    }
+}


### PR DESCRIPTION
## 修复 #1120

### 改动

**FilesManager.kt** — 统一图片保存入口，新增来源解析器（line 577），分别处理 \ile://\、绝对路径、\content://\、\http(s)\、原始 base64、\data:*;base64\ 等格式。

**ImgGenPage.kt** — 图片生成页本地图片统一转为 \ile://\ URI（line 265/462/506）。

**Mermaid.kt** — 移除 Guava CacheBuilder 依赖，替换为 LinkedHashMap LRU 缓存，消除编译挡板。

**ImageSourceParsingTest.kt** — 针对各解析分支的单测。

### 验证

gradlew testDebugUnitTest BUILD SUCCESSFUL