### PR TITLE
feat: New Injection mode IN_MESSAGE

### DIFF
--- a/app/src/main/java/me/rerere/rikkahub/data/ai/transformers/PlaceholderTransformer.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/ai/transformers/PlaceholderTransformer.kt
@@ -162,21 +162,45 @@ object PlaceholderTransformer : InputMessageTransformer, KoinComponent {
         ctx: TransformerContext,
         settingsStore: SettingsStore
     ): String {
-        var result = text
-
-        val ctx = PlaceholderCtx(
+        return resolveText(
+            text = text,
             context = ctx.context,
             settingsStore = settingsStore,
             model = ctx.model,
             assistant = ctx.assistant
         )
+    }
+
+    /**
+     * 将文本中的占位符替换为实际值
+     *
+     * @param text 原文本
+     * @param context Android Context
+     * @param settingsStore 设置存储
+     * @param model 当前模型
+     * @param assistant 当前助手
+     * @return 替换后的文本
+     */
+    fun resolveText(
+        text: String,
+        context: android.content.Context,
+        settingsStore: SettingsStore,
+        model: me.rerere.ai.provider.Model,
+        assistant: Assistant
+    ): String {
+        val ctx = PlaceholderCtx(
+            context = context,
+            settingsStore = settingsStore,
+            model = model,
+            assistant = assistant
+        )
+        var result = text
         defaultProvider.placeholders.forEach { (key, placeholderInfo) ->
             val value = placeholderInfo.resolver(ctx)
             result = result
                 .replace(oldValue = "{{$key}}", newValue = value, ignoreCase = true)
                 .replace(oldValue = "{$key}", newValue = value, ignoreCase = true)
         }
-
         return result
     }
 }

--- a/app/src/main/java/me/rerere/rikkahub/data/ai/transformers/PromptInjectionTransformer.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/ai/transformers/PromptInjectionTransformer.kt
@@ -1,14 +1,19 @@
 package me.rerere.rikkahub.data.ai.transformers
 
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
 import me.rerere.ai.core.MessageRole
+import me.rerere.ai.provider.Model
 import me.rerere.ai.ui.UIMessage
 import me.rerere.ai.ui.UIMessagePart
 import me.rerere.rikkahub.data.model.Assistant
 import me.rerere.rikkahub.data.model.InjectionPosition
+import me.rerere.rikkahub.data.model.InMessagePosition
 import me.rerere.rikkahub.data.model.PromptInjection
 import me.rerere.rikkahub.data.model.Lorebook
 import me.rerere.rikkahub.data.model.extractContextForMatching
 import me.rerere.rikkahub.data.model.isTriggered
+import me.rerere.rikkahub.data.datastore.SettingsStore
 
 /**
  * 提示词注入转换器
@@ -101,7 +106,8 @@ internal fun collectInjections(
  */
 internal fun applyInjections(
     messages: List<UIMessage>,
-    byPosition: Map<InjectionPosition, List<PromptInjection>>
+    byPosition: Map<InjectionPosition, List<PromptInjection>>,
+    transformInjectedContent: ((String) -> String)? = null,
 ): List<UIMessage> {
     val result = messages.toMutableList()
 
@@ -201,6 +207,45 @@ internal fun applyInjections(
         }
     }
 
+    // 处理 IN_MESSAGE：注入到最后一条用户消息的内容内部（作为 parts 的一部分）
+    val inMessageInjections = byPosition[InjectionPosition.IN_MESSAGE]
+    if (!inMessageInjections.isNullOrEmpty()) {
+        val lastUserIndex = result.indexOfLast { it.role == MessageRole.USER }
+        if (lastUserIndex >= 0) {
+            val lastUserMessage = result[lastUserIndex]
+
+            // 按 inMessagePosition 分组：BEFORE 和 AFTER
+            val beforeParts = mutableListOf<UIMessagePart>()
+            val afterParts = mutableListOf<UIMessagePart>()
+
+            inMessageInjections
+                .sortedByDescending { it.priority }
+                .forEach { injection ->
+                    val content = transformInjectedContent?.invoke(injection.content) ?: injection.content
+                    val metadata = if (!injection.visibleInHistory) {
+                        JsonObject(mapOf("injection_visible" to JsonPrimitive(false)))
+                    } else {
+                        null
+                    }
+                    val textPart = UIMessagePart.Text(content, metadata = metadata)
+                    val pos = injection.inMessagePosition ?: InMessagePosition.AFTER
+                    when (pos) {
+                        InMessagePosition.BEFORE -> beforeParts.add(textPart)
+                        InMessagePosition.AFTER -> afterParts.add(textPart)
+                    }
+                }
+
+            if (beforeParts.isNotEmpty() || afterParts.isNotEmpty()) {
+                val newParts = buildList {
+                    addAll(beforeParts)
+                    addAll(lastUserMessage.parts)
+                    addAll(afterParts)
+                }
+                result[lastUserIndex] = lastUserMessage.copy(parts = newParts)
+            }
+        }
+    }
+
     return result
 }
 
@@ -247,4 +292,59 @@ internal fun findSafeInsertIndex(messages: List<UIMessage>, targetIndex: Int): I
     }
 
     return index
+}
+
+/**
+ * 应用 persistToHistory=true 的注入到消息列表
+ *
+ * 用于在保存前将需要持久化的注入内容写入消息，以提高 KV Cache 命中率。
+ * 当 persistToHistory=true 时，注入内容会保存到对话历史中。
+ *
+ * @param messages 消息列表
+ * @param assistant 当前助手配置
+ * @param modeInjections 模式注入列表
+ * @param lorebooks 世界书列表
+ * @return 应用了持久化注入的消息列表
+ */
+fun applyPersistInjections(
+    messages: List<UIMessage>,
+    assistant: Assistant,
+    modeInjections: List<PromptInjection.ModeInjection>,
+    lorebooks: List<Lorebook>,
+    context: android.content.Context? = null,
+    model: Model? = null,
+    settingsStore: SettingsStore? = null,
+): List<UIMessage> {
+    // 收集所有注入
+    val allInjections = collectInjections(
+        messages = messages,
+        assistant = assistant,
+        modeInjections = modeInjections,
+        lorebooks = lorebooks
+    )
+
+    // 只保留 persistToHistory=true 的注入
+    val persistInjections = allInjections.filter { it.persistToHistory }
+    if (persistInjections.isEmpty()) return messages
+
+    // 按位置和优先级分组
+    val byPosition = persistInjections
+        .sortedByDescending { it.priority }
+        .groupBy { it.position }
+
+    val transformInjectedContent = if (context != null && model != null && settingsStore != null) {
+        { content: String ->
+            PlaceholderTransformer.resolveText(
+                text = content,
+                context = context,
+                settingsStore = settingsStore,
+                model = model,
+                assistant = assistant
+            )
+        }
+    } else {
+        null
+    }
+
+    return applyInjections(messages, byPosition, transformInjectedContent = transformInjectedContent)
 }

--- a/app/src/main/java/me/rerere/rikkahub/data/model/Assistant.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/model/Assistant.kt
@@ -120,6 +120,30 @@ enum class InjectionPosition {
 
     @SerialName("at_depth")
     AT_DEPTH,               // 在指定深度位置插入（从最新消息往前数）
+
+    @SerialName("in_message")
+    IN_MESSAGE,             // 注入到消息内容内部（作为 parts 的一部分）
+}
+
+/**
+ * 消息内注入位置
+ */
+@Serializable
+enum class InMessagePosition {
+    @SerialName("before")
+    BEFORE,  // 注入到消息内容之前
+
+    @SerialName("after")
+    AFTER    // 注入到消息内容之后（默认）
+}
+
+/**
+ * 注入内容类型
+ */
+@Serializable
+enum class InjectionContentType {
+    @SerialName("text")
+    TEXT  // 文本类型，未来可扩展 IMAGE 等
 }
 
 /**
@@ -138,6 +162,10 @@ sealed class PromptInjection {
     abstract val content: String
     abstract val injectDepth: Int  // 当 position 为 AT_DEPTH 时使用，表示从最新消息往前数的位置
     abstract val role: MessageRole  // 注入角色：USER 或 ASSISTANT
+    abstract val inMessagePosition: InMessagePosition?  // position=IN_MESSAGE 时使用，旧版为 null
+    abstract val contentType: InjectionContentType       // 内容类型，默认 TEXT
+    abstract val persistToHistory: Boolean               // 是否保存注入内容到历史，默认 false
+    abstract val visibleInHistory: Boolean               // 持久化后是否在 UI 中可见，默认 true
 
     /**
      * 模式注入 - 基于开关状态触发
@@ -153,6 +181,10 @@ sealed class PromptInjection {
         override val content: String = "",
         override val injectDepth: Int = 4,
         override val role: MessageRole = MessageRole.USER,
+        override val inMessagePosition: InMessagePosition? = null,
+        override val contentType: InjectionContentType = InjectionContentType.TEXT,
+        override val persistToHistory: Boolean = false,
+        override val visibleInHistory: Boolean = true,
     ) : PromptInjection()
 
     /**
@@ -169,6 +201,10 @@ sealed class PromptInjection {
         override val content: String = "",
         override val injectDepth: Int = 4,
         override val role: MessageRole = MessageRole.USER,
+        override val inMessagePosition: InMessagePosition? = null,
+        override val contentType: InjectionContentType = InjectionContentType.TEXT,
+        override val persistToHistory: Boolean = false,
+        override val visibleInHistory: Boolean = true,
         val keywords: List<String> = emptyList(),  // 触发关键词
         val useRegex: Boolean = false,             // 是否使用正则匹配
         val caseSensitive: Boolean = false,        // 大小写敏感

--- a/app/src/main/java/me/rerere/rikkahub/di/AppModule.kt
+++ b/app/src/main/java/me/rerere/rikkahub/di/AppModule.kt
@@ -9,6 +9,7 @@ import me.rerere.highlight.Highlighter
 import me.rerere.rikkahub.AppScope
 import me.rerere.rikkahub.data.ai.AILoggingManager
 import me.rerere.rikkahub.data.ai.tools.LocalTools
+import me.rerere.rikkahub.data.ai.transformers.PromptInjectionTransformer
 import me.rerere.rikkahub.data.event.AppEventBus
 import me.rerere.rikkahub.service.ChatService
 import me.rerere.rikkahub.utils.EmojiData
@@ -75,6 +76,7 @@ val appModule = module {
             memoryRepository = get(),
             generationHandler = get(),
             templateTransformer = get(),
+            promptInjectionTransformer = PromptInjectionTransformer,
             providerManager = get(),
             localTools = get(),
             mcpManager = get(),

--- a/app/src/main/java/me/rerere/rikkahub/service/ChatService.kt
+++ b/app/src/main/java/me/rerere/rikkahub/service/ChatService.kt
@@ -67,6 +67,7 @@ import me.rerere.rikkahub.data.ai.transformers.RegexOutputTransformer
 import me.rerere.rikkahub.data.ai.transformers.TemplateTransformer
 import me.rerere.rikkahub.data.ai.transformers.ThinkTagTransformer
 import me.rerere.rikkahub.data.ai.transformers.TimeReminderTransformer
+import me.rerere.rikkahub.data.ai.transformers.applyPersistInjections
 import me.rerere.rikkahub.data.datastore.SettingsStore
 import me.rerere.rikkahub.data.datastore.findModelById
 import me.rerere.rikkahub.data.datastore.findProvider
@@ -125,6 +126,7 @@ class ChatService(
     private val memoryRepository: MemoryRepository,
     private val generationHandler: GenerationHandler,
     private val templateTransformer: TemplateTransformer,
+    private val promptInjectionTransformer: PromptInjectionTransformer,
     private val providerManager: ProviderManager,
     private val localTools: LocalTools,
     val mcpManager: McpManager,
@@ -556,8 +558,18 @@ class ChatService(
             }.collect { chunk ->
                 when (chunk) {
                     is GenerationChunk.Messages -> {
+                        // 应用 persistToHistory=true 的注入
+                        val messagesToSave = applyPersistInjections(
+                            messages = chunk.messages,
+                            assistant = settings.getCurrentAssistant(),
+                            modeInjections = settings.modeInjections,
+                            lorebooks = settings.lorebooks,
+                            context = context,
+                            model = model,
+                            settingsStore = settingsStore
+                        )
                         val updatedConversation = getConversationFlow(conversationId).value
-                            .updateCurrentMessages(chunk.messages)
+                            .updateCurrentMessages(messagesToSave)
                         updateConversation(conversationId, updatedConversation)
 
                         // 如果应用不在前台，发送 Live Update 通知

--- a/app/src/main/java/me/rerere/rikkahub/ui/components/message/ChatMessage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/message/ChatMessage.kt
@@ -60,6 +60,7 @@ import androidx.core.net.toFile
 import androidx.core.net.toUri
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.debounce
+import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
@@ -307,8 +308,17 @@ private fun MessagePartsBlock(
             }
     }
 
+    // 过滤不可见的注入 parts（metadata 中标记 injection_visible=false 的文本部分）
+    fun isPartVisible(part: UIMessagePart): Boolean {
+        val metadata = part.metadata ?: return true
+        if (metadata !is JsonObject) return true
+        val visible = metadata["injection_visible"] ?: return true
+        return visible.jsonPrimitive.content.toBoolean()
+    }
+    val visibleParts = parts.filter(::isPartVisible)
+
     // Render parts in original order (group thinking/tool as chain-of-thought)
-    val groupedParts = remember(parts) { parts.groupMessageParts() }
+    val groupedParts = remember(visibleParts) { visibleParts.groupMessageParts() }
     groupedParts.fastForEach { block ->
         when (block) {
             is MessagePartBlock.ThinkingBlock -> {

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/extensions/PromptPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/extensions/PromptPage.kt
@@ -87,6 +87,8 @@ import me.rerere.rikkahub.data.export.ModeInjectionSerializer
 import me.rerere.rikkahub.data.export.rememberExporter
 import me.rerere.rikkahub.data.export.rememberImporter
 import me.rerere.rikkahub.data.model.InjectionPosition
+import me.rerere.rikkahub.data.model.InMessagePosition
+import me.rerere.rikkahub.data.model.InjectionContentType
 import me.rerere.rikkahub.data.model.Lorebook
 import me.rerere.rikkahub.data.model.PromptInjection
 import me.rerere.rikkahub.ui.components.nav.BackButton
@@ -481,14 +483,64 @@ private fun ModeInjectionEditSheet(
                     )
                 }
 
-                Text(
-                    stringResource(R.string.prompt_page_injection_role),
-                    style = MaterialTheme.typography.titleSmall
-                )
-                InjectionRoleSelector(
-                    role = injection.role,
-                    onSelect = { onEdit(injection.copy(role = it)) }
-                )
+                AnimatedVisibility(visible = injection.position == InjectionPosition.IN_MESSAGE) {
+                    Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
+                        Text(
+                            stringResource(R.string.prompt_page_in_message_position),
+                            style = MaterialTheme.typography.titleSmall
+                        )
+                        InMessagePositionSelector(
+                            position = injection.inMessagePosition ?: InMessagePosition.AFTER,
+                            onSelect = { onEdit(injection.copy(inMessagePosition = it)) }
+                        )
+
+                        Text(
+                            stringResource(R.string.prompt_page_content_type),
+                            style = MaterialTheme.typography.titleSmall
+                        )
+                        InjectionContentTypeSelector2(
+                            contentType = injection.contentType,
+                            onSelect = { onEdit(injection.copy(contentType = it)) }
+                        )
+
+                        FormItem(
+                            label = { Text(stringResource(R.string.prompt_page_persist_to_history)) },
+                            description = { Text(stringResource(R.string.prompt_page_persist_to_history_desc)) },
+                            tail = {
+                                Switch(
+                                    checked = injection.persistToHistory,
+                                    onCheckedChange = { onEdit(injection.copy(persistToHistory = it)) }
+                                )
+                            }
+                        )
+
+                        AnimatedVisibility(visible = injection.persistToHistory) {
+                            FormItem(
+                                label = { Text(stringResource(R.string.prompt_page_visible_in_history)) },
+                                description = { Text(stringResource(R.string.prompt_page_visible_in_history_desc)) },
+                                tail = {
+                                    Switch(
+                                        checked = injection.visibleInHistory,
+                                        onCheckedChange = { onEdit(injection.copy(visibleInHistory = it)) }
+                                    )
+                                }
+                            )
+                        }
+                    }
+                }
+
+                AnimatedVisibility(visible = injection.position != InjectionPosition.IN_MESSAGE) {
+                    Column {
+                        Text(
+                            stringResource(R.string.prompt_page_injection_role),
+                            style = MaterialTheme.typography.titleSmall
+                        )
+                        InjectionRoleSelector(
+                            role = injection.role,
+                            onSelect = { onEdit(injection.copy(role = it)) }
+                        )
+                    }
+                }
 
                 OutlinedTextField(
                     value = injection.content,
@@ -537,6 +589,7 @@ private fun getPositionLabel(position: InjectionPosition): String = when (positi
     InjectionPosition.TOP_OF_CHAT -> stringResource(R.string.prompt_page_position_top_of_chat)
     InjectionPosition.BOTTOM_OF_CHAT -> stringResource(R.string.prompt_page_position_bottom_of_chat)
     InjectionPosition.AT_DEPTH -> stringResource(R.string.prompt_page_position_at_depth)
+    InjectionPosition.IN_MESSAGE -> stringResource(R.string.prompt_page_position_in_message)
 }
 
 @Composable
@@ -1049,6 +1102,65 @@ private fun RegexInjectionEditDialog(
                     )
                 }
 
+                AnimatedVisibility(visible = entry.position == InjectionPosition.IN_MESSAGE) {
+                    Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
+                        Text(
+                            stringResource(R.string.prompt_page_in_message_position),
+                            style = MaterialTheme.typography.titleSmall
+                        )
+                        InMessagePositionSelector(
+                            position = entry.inMessagePosition ?: InMessagePosition.AFTER,
+                            onSelect = { onEdit(entry.copy(inMessagePosition = it)) }
+                        )
+
+                        Text(
+                            stringResource(R.string.prompt_page_content_type),
+                            style = MaterialTheme.typography.titleSmall
+                        )
+                        InjectionContentTypeSelector2(
+                            contentType = entry.contentType,
+                            onSelect = { onEdit(entry.copy(contentType = it)) }
+                        )
+
+                        FormItem(
+                            label = { Text(stringResource(R.string.prompt_page_persist_to_history)) },
+                            description = { Text(stringResource(R.string.prompt_page_persist_to_history_desc)) },
+                            tail = {
+                                Switch(
+                                    checked = entry.persistToHistory,
+                                    onCheckedChange = { onEdit(entry.copy(persistToHistory = it)) }
+                                )
+                            }
+                        )
+
+                        AnimatedVisibility(visible = entry.persistToHistory) {
+                            FormItem(
+                                label = { Text(stringResource(R.string.prompt_page_visible_in_history)) },
+                                description = { Text(stringResource(R.string.prompt_page_visible_in_history_desc)) },
+                                tail = {
+                                    Switch(
+                                        checked = entry.visibleInHistory,
+                                        onCheckedChange = { onEdit(entry.copy(visibleInHistory = it)) }
+                                    )
+                                }
+                            )
+                        }
+                    }
+                }
+
+                AnimatedVisibility(visible = entry.position != InjectionPosition.IN_MESSAGE) {
+                    Column {
+                        Text(
+                            stringResource(R.string.prompt_page_injection_role),
+                            style = MaterialTheme.typography.titleSmall
+                        )
+                        InjectionRoleSelector(
+                            role = entry.role,
+                            onSelect = { onEdit(entry.copy(role = it)) }
+                        )
+                    }
+                }
+
                 // 关键词
                 Text(stringResource(R.string.prompt_page_keywords_label), style = MaterialTheme.typography.titleSmall)
                 FlowRow(
@@ -1173,4 +1285,45 @@ private fun RegexInjectionEditDialog(
             }
         }
     )
+}
+
+// ==================== IN_MESSAGE Helpers ====================
+
+@Composable
+private fun InMessagePositionSelector(
+    position: InMessagePosition,
+    onSelect: (InMessagePosition) -> Unit
+) {
+    Select(
+        options = InMessagePosition.entries,
+        selectedOption = position,
+        onOptionSelected = onSelect,
+        optionToString = { getInMessagePositionLabel(it) },
+        modifier = Modifier.fillMaxWidth()
+    )
+}
+
+@Composable
+private fun getInMessagePositionLabel(position: InMessagePosition): String = when (position) {
+    InMessagePosition.BEFORE -> stringResource(R.string.prompt_page_in_message_before)
+    InMessagePosition.AFTER -> stringResource(R.string.prompt_page_in_message_after)
+}
+
+@Composable
+private fun InjectionContentTypeSelector2(
+    contentType: InjectionContentType,
+    onSelect: (InjectionContentType) -> Unit
+) {
+    Select(
+        options = InjectionContentType.entries,
+        selectedOption = contentType,
+        onOptionSelected = onSelect,
+        optionToString = { getContentTypeLabel2(it) },
+        modifier = Modifier.fillMaxWidth()
+    )
+}
+
+@Composable
+private fun getContentTypeLabel2(type: InjectionContentType): String = when (type) {
+    InjectionContentType.TEXT -> stringResource(R.string.prompt_page_content_type_text)
 }


### PR DESCRIPTION
总结一下：对模式注入会导致缓存破坏的一种新增模式方法的修复。

新增注入位置`IN_MESSAGE`/ `在消息内容内`，兼容所有旧版的JSON导入。

特性：
如有一条消息：
messages:
["0":{"role":"system","content":"you are a helpful assistant."},"1":{"role":"user","content":"hello"},"2":{"role":"assistant","content":"hello! How can I help you today?"},"3":{"role":"user","content":"nice to meet you"}]

IN_MESSAGE: 在当前消息注入，也就是在`"3"`内。目前只有文本注入，将来可以考虑支持image_url注入。注入后的状态如下：

"3":{"role":"user","content":{"0":["type":"text","text":"插入位置_BEFORE_内容之前"],"1":["type":"text","text":"nice to meet you"],"2":["type":"text","text":"插入位置_AFTER_内容之后"]}

<img width="1437" height="1424" alt="Screenshot_2026-05-03-08-52-39-657_me rerere rikkahub debug" src="https://github.com/user-attachments/assets/4702b538-f9dc-4060-aaf2-4643944ad514" />

`保存到历史`是这样的：如果选中，将不应用临时注入，而是拦下注入应用一个永久注入在ChatService mseeage。消息将会不是临时的注入聊天。

而基于此又加了个基于Metadata的`在历史中可见`按钮：若永久注入历史（保存到历史），可选注入消息的可见性，因为注入永久message意味着在UI层显示。

如上就是所有更改。