### PR TITLE
优化聊天建议发送体验

### DIFF
--- a/app/src/main/java/me/rerere/rikkahub/service/ChatService.kt
+++ b/app/src/main/java/me/rerere/rikkahub/service/ChatService.kt
@@ -721,7 +721,7 @@ class ChatService(
                         settings.suggestionPrompt.applyPlaceholders(
                             "locale" to Locale.getDefault().displayName,
                             "content" to conversation.currentMessages
-                                .takeLast(8).joinToString("\n\n") { it.summaryAsText() }),
+                                .joinToString("\n\n") { it.summaryAsText() }),
                     )
                 ),
                 params = TextGenerationParams(

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ChatPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ChatPage.kt
@@ -403,7 +403,9 @@ private fun ChatPageContent(
                 },
                 onClickSuggestion = { suggestion ->
                     inputState.editingMessage = null
-                    inputState.setMessageText(suggestion)
+                    if (suggestion.isNotBlank()) {
+                        vm.handleMessageSend(listOf(UIMessagePart.Text(suggestion)))
+                    }
                 },
                 onTranslate = { message, locale ->
                     vm.translateMessage(message, locale)


### PR DESCRIPTION
## 摘要

- 点击聊天建议时直接发送建议内容，不再只是填入输入框。
- 生成聊天建议时使用当前完整对话上下文，不再只截取最近 8 条消息。

## 测试

- 已在拆分前运行 `./gradlew assembleDebug`
- Debug APK 构建成功：`BUILD SUCCESSFUL`

## 说明

这个改动让聊天建议更接近快捷回复：用户点击建议即表示采用该建议并发送，减少一次手动确认。