### PR TITLE
Add prompt cache control to Claude tool results

### DIFF
--- a/ai/src/main/java/me/rerere/ai/provider/providers/ClaudeProvider.kt
+++ b/ai/src/main/java/me/rerere/ai/provider/providers/ClaudeProvider.kt
@@ -357,7 +357,7 @@ class ClaudeProvider(private val client: OkHttpClient, context: Context? = null)
             .filter { it.isValidToUpload() && it.role != MessageRole.SYSTEM }
             .forEach { message ->
                 if (message.role == MessageRole.ASSISTANT) {
-                    addAssistantMessage(message)
+                    addAssistantMessage(message, promptCaching, promptCacheTtl)
                 } else {
                     addUserMessage(message)
                 }
@@ -408,7 +408,11 @@ class ClaudeProvider(private val client: OkHttpClient, context: Context? = null)
         })
     }
 
-    private fun JsonArrayBuilder.addAssistantMessage(message: UIMessage) {
+    private fun JsonArrayBuilder.addAssistantMessage(
+        message: UIMessage,
+        promptCaching: Boolean,
+        promptCacheTtl: ClaudePromptCacheTtl
+    ) {
         val groups = groupPartsByToolBoundary(message.parts)
         val contentBuffer = mutableListOf<JsonObject>()
 
@@ -433,7 +437,9 @@ class ClaudeProvider(private val client: OkHttpClient, context: Context? = null)
                     add(buildJsonObject {
                         put("role", "user")
                         putJsonArray("content") {
-                            group.tools.forEach { add(it.toToolResultBlock()) }
+                            group.tools.forEach {
+                                add(it.toToolResultBlock(promptCaching, promptCacheTtl))
+                            }
                         }
                     })
                 }
@@ -495,11 +501,17 @@ class ClaudeProvider(private val client: OkHttpClient, context: Context? = null)
         put("input", inputAsJson())
     }
 
-    private fun UIMessagePart.Tool.toToolResultBlock() = buildJsonObject {
+    private fun UIMessagePart.Tool.toToolResultBlock(
+        promptCaching: Boolean,
+        promptCacheTtl: ClaudePromptCacheTtl
+    ) = buildJsonObject {
         put("type", "tool_result")
         put("tool_use_id", toolCallId)
         putJsonArray("content") {
             output.mapNotNull { it.toContentBlock() }.forEach { add(it) }
+        }
+        if (promptCaching) {
+            put("cache_control", cacheControlEphemeral(promptCacheTtl))
         }
     }
 

--- a/ai/src/test/java/me/rerere/ai/provider/providers/ClaudeProviderMessageTest.kt
+++ b/ai/src/test/java/me/rerere/ai/provider/providers/ClaudeProviderMessageTest.kt
@@ -5,6 +5,7 @@ import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import me.rerere.ai.core.MessageRole
+import me.rerere.ai.provider.ClaudePromptCacheTtl
 import me.rerere.ai.ui.UIMessage
 import me.rerere.ai.ui.UIMessagePart
 import okhttp3.OkHttpClient
@@ -37,10 +38,11 @@ class ClaudeProviderMessageTest {
         val method = ClaudeProvider::class.java.getDeclaredMethod(
             "buildMessages",
             List::class.java,
-            Boolean::class.javaPrimitiveType
+            Boolean::class.javaPrimitiveType,
+            ClaudePromptCacheTtl::class.java
         )
         method.isAccessible = true
-        return method.invoke(provider, messages, false) as JsonArray
+        return method.invoke(provider, messages, false, ClaudePromptCacheTtl.FIVE_MINUTES) as JsonArray
     }
 
     @Test

--- a/ai/src/test/java/me/rerere/ai/provider/providers/ClaudeProviderPromptCacheTest.kt
+++ b/ai/src/test/java/me/rerere/ai/provider/providers/ClaudeProviderPromptCacheTest.kt
@@ -4,6 +4,7 @@ import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
+import me.rerere.ai.core.MessageRole
 import me.rerere.ai.core.InputSchema
 import me.rerere.ai.core.Tool
 import me.rerere.ai.provider.ClaudePromptCacheTtl
@@ -12,6 +13,7 @@ import me.rerere.ai.provider.ModelAbility
 import me.rerere.ai.provider.ProviderSetting
 import me.rerere.ai.provider.TextGenerationParams
 import me.rerere.ai.ui.UIMessage
+import me.rerere.ai.ui.UIMessagePart
 import okhttp3.OkHttpClient
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
@@ -249,5 +251,64 @@ class ClaudeProviderPromptCacheTest {
                 assertNull(block.jsonObject["cache_control"])
             }
         }
+    }
+
+    @Test
+    fun `promptCaching=true should add cache_control to tool_result blocks`() {
+        val providerSetting = ProviderSetting.Claude(promptCaching = true)
+        val messages = listOf(
+            UIMessage(
+                role = MessageRole.ASSISTANT,
+                parts = listOf(
+                    UIMessagePart.Tool(
+                        toolCallId = "call_1",
+                        toolName = "search",
+                        input = "{}",
+                        output = listOf(UIMessagePart.Text("tool output"))
+                    )
+                )
+            )
+        )
+        val params = TextGenerationParams(
+            model = Model(modelId = "claude-test", abilities = listOf(ModelAbility.TOOL)),
+            tools = emptyList()
+        )
+
+        val request = buildRequest(providerSetting, messages, params)
+        val msgs = request["messages"]!!.jsonArray
+        val toolResult = msgs.first { msg ->
+            msg.jsonObject["role"]?.jsonPrimitive?.content == "user"
+        }.jsonObject["content"]!!.jsonArray.first().jsonObject
+        val cacheControl = toolResult["cache_control"]!!.jsonObject
+        assertEquals("ephemeral", cacheControl["type"]!!.jsonPrimitive.content)
+    }
+
+    @Test
+    fun `promptCaching=false should not add cache_control to tool_result blocks`() {
+        val providerSetting = ProviderSetting.Claude(promptCaching = false)
+        val messages = listOf(
+            UIMessage(
+                role = MessageRole.ASSISTANT,
+                parts = listOf(
+                    UIMessagePart.Tool(
+                        toolCallId = "call_1",
+                        toolName = "search",
+                        input = "{}",
+                        output = listOf(UIMessagePart.Text("tool output"))
+                    )
+                )
+            )
+        )
+        val params = TextGenerationParams(
+            model = Model(modelId = "claude-test", abilities = listOf(ModelAbility.TOOL)),
+            tools = emptyList()
+        )
+
+        val request = buildRequest(providerSetting, messages, params)
+        val msgs = request["messages"]!!.jsonArray
+        val toolResult = msgs.first { msg ->
+            msg.jsonObject["role"]?.jsonPrimitive?.content == "user"
+        }.jsonObject["content"]!!.jsonArray.first().jsonObject
+        assertNull(toolResult["cache_control"])
     }
 }


### PR DESCRIPTION
## Summary

- add `cache_control` to Claude `tool_result` blocks when prompt caching is enabled
- keep `tool_result` blocks unchanged when prompt caching is disabled
- update Claude provider message tests for the current `buildMessages` signature

## Why

RikkaHub already applies Anthropic prompt caching to system and tool definitions, but generated Claude `tool_result` blocks were not marked cacheable. For MCP-heavy conversations, large tool outputs can become part of the reusable prompt prefix, so applying the same cache control helps those results participate in prompt caching.

## Tests

- `:ai:testDebugUnitTest --tests me.rerere.ai.provider.providers.ClaudeProviderPromptCacheTest`
- `:ai:testDebugUnitTest --tests me.rerere.ai.provider.providers.ClaudeProviderMessageTest`