### PR TITLE
fix(ai): 适配 aihubmix gemini 图片模型响应

### DIFF
--- a/ai/src/main/java/me/rerere/ai/provider/providers/openai/ChatCompletionsAPI.kt
+++ b/ai/src/main/java/me/rerere/ai/provider/providers/openai/ChatCompletionsAPI.kt
@@ -42,6 +42,7 @@ import me.rerere.ai.util.KeyRoulette
 import me.rerere.ai.util.configureReferHeaders
 import me.rerere.ai.util.encodeBase64
 import me.rerere.ai.util.json
+import me.rerere.ai.util.matchesHostOrSubdomain
 import me.rerere.ai.util.mergeCustomBody
 import me.rerere.ai.util.parseErrorDetail
 import me.rerere.ai.util.stringSafe
@@ -264,7 +265,7 @@ class ChatCompletionsAPI(
 
             put("stream", stream)
             if (stream) {
-                if (host != "api.mistral.ai") { // mistral 不支持 stream_options
+                if (!host.matchesHostOrSubdomain("api.mistral.ai")) { // mistral 不支持 stream_options
                     put("stream_options", buildJsonObject {
                         put("include_usage", true)
                     })
@@ -272,12 +273,12 @@ class ChatCompletionsAPI(
             }
 
             if (params.model.outputModalities.contains(Modality.IMAGE)) {
-                if (host == "openrouter.ai") {
+                if (host.matchesHostOrSubdomain("openrouter.ai")) {
                     put("modalities", buildJsonArray {
                         add("image")
                         add("text")
                     })
-                } else if (host == "aihubmix.com") {
+                } else if (host.matchesHostOrSubdomain("aihubmix.com")) {
                     put("modalities", buildJsonArray {
                         add("text")
                         add("image")
@@ -287,8 +288,8 @@ class ChatCompletionsAPI(
 
             if (params.model.abilities.contains(ModelAbility.REASONING)) {
                 val level = params.reasoningLevel
-                when (host) {
-                    "openrouter.ai" -> {
+                when {
+                    host.matchesHostOrSubdomain("openrouter.ai") -> {
                         // https://openrouter.ai/docs/use-cases/reasoning-tokens
                         put("reasoning", buildJsonObject {
                             when (level) {
@@ -299,31 +300,31 @@ class ChatCompletionsAPI(
                         })
                     }
 
-                    "dashscope.aliyuncs.com" -> {
+                    host.matchesHostOrSubdomain("dashscope.aliyuncs.com") -> {
                         // 阿里云百炼
                         // https://bailian.console.aliyun.com/console?tab=doc#/doc/?type=model&url=https%3A%2F%2Fhelp.aliyun.com%2Fdocument_detail%2F2870973.html&renderType=iframe
                         put("enable_thinking", level.isEnabled)
                         if (level != ReasoningLevel.AUTO) put("thinking_budget", level.budgetTokens)
                     }
 
-                    "ark.cn-beijing.volces.com" -> {
+                    host.matchesHostOrSubdomain("ark.cn-beijing.volces.com") -> {
                         // 豆包 (火山)
                         put("thinking", buildJsonObject {
                             put("type", if (!level.isEnabled) "disabled" else "enabled")
                         })
                     }
 
-                    "api.mistral.ai" -> {
+                    host.matchesHostOrSubdomain("api.mistral.ai") -> {
                         // Mistral 不支持
                     }
 
-                    "chat.intern-ai.org.cn" -> {
+                    host.matchesHostOrSubdomain("chat.intern-ai.org.cn") -> {
                         // 书生
                         // https://internlm.intern-ai.org.cn/api/document?lang=zh
                         put("thinking_mode", level.isEnabled)
                     }
 
-                    "api.siliconflow.cn" -> {
+                    host.matchesHostOrSubdomain("api.siliconflow.cn") -> {
                         // https://docs.siliconflow.cn/cn/userguide/capabilities/reasoning#3-1-api-%E5%8F%82%E6%95%B0
                         val modelId = params.model.modelId
                         val siliconflowThinkingModels = setOf(
@@ -358,19 +359,19 @@ class ChatCompletionsAPI(
                         }
                     }
 
-                    "open.bigmodel.cn" -> {
+                    host.matchesHostOrSubdomain("open.bigmodel.cn") -> {
                         put("thinking", buildJsonObject {
                             put("type", if (!level.isEnabled) "disabled" else "enabled")
                         })
                     }
 
-                    "api.moonshot.cn" -> {
+                    host.matchesHostOrSubdomain("api.moonshot.cn") -> {
                         put("thinking", buildJsonObject {
                             put("type", if (!level.isEnabled) "disabled" else "enabled")
                         })
                     }
 
-                    "api.deepseek.com" -> {
+                    host.matchesHostOrSubdomain("api.deepseek.com") -> {
                         put("thinking", buildJsonObject {
                             put("type", if (!level.isEnabled) "disabled" else "enabled")
                         })
@@ -379,7 +380,7 @@ class ChatCompletionsAPI(
                         }
                     }
 
-                    "integrate.api.nvidia.com" -> {
+                    host.matchesHostOrSubdomain("integrate.api.nvidia.com") -> {
                         if ("deepseek-v4" in params.model.modelId.lowercase()) {
                             if (level != ReasoningLevel.AUTO) {
                                 val effort = when (level) {
@@ -690,9 +691,15 @@ class ChatCompletionsAPI(
                 multiModContent.forEach { item ->
                     val obj = item.jsonObjectOrNull ?: return@forEach
                     val inlineData = (obj["inlineData"] ?: obj["inline_data"])?.jsonObjectOrNull
-                    val data = inlineData?.get("data")?.jsonPrimitive?.contentOrNull
+                    val data = inlineData?.get("data")?.jsonPrimitiveOrNull?.contentOrNull
                     val rawMime = (inlineData?.get("mimeType") ?: inlineData?.get("mime_type"))
-                        ?.jsonPrimitive?.contentOrNull
+                        ?.jsonPrimitiveOrNull?.contentOrNull
+                    if (content.isEmpty()) {
+                        val text = obj["text"]?.jsonPrimitiveOrNull?.contentOrNull
+                        if (!text.isNullOrEmpty()) {
+                            add(UIMessagePart.Text(text))
+                        }
+                    }
                     if (!data.isNullOrEmpty()) {
                         val parsedImage = parseImageContent(data, rawMime)
                         add(
@@ -703,12 +710,6 @@ class ChatCompletionsAPI(
                                 }
                             )
                         )
-                    }
-                    if (content.isEmpty()) {
-                        val text = obj["text"]?.jsonPrimitive?.contentOrNull
-                        if (!text.isNullOrEmpty()) {
-                            add(UIMessagePart.Text(text))
-                        }
                     }
                 }
             },
@@ -756,11 +757,13 @@ class ChatCompletionsAPI(
 
     private fun normalizeImageMime(mime: String?): String {
         val cleaned = mime?.trim()?.lowercase()
-        return when {
-            cleaned.isNullOrBlank() -> "image/png"
-            cleaned == "jpg" || cleaned == "image/jpg" -> "image/jpeg"
-            cleaned.startsWith("image/") -> cleaned
-            else -> "image/$cleaned"
+        return when (cleaned) {
+            null, "" -> "image/png"
+            "jpg", "jpeg", "image/jpg", "image/jpeg" -> "image/jpeg"
+            "png", "image/png" -> "image/png"
+            "webp", "image/webp" -> "image/webp"
+            "gif", "image/gif" -> "image/gif"
+            else -> "image/png"
         }
     }
 

--- a/ai/src/main/java/me/rerere/ai/provider/providers/openai/ChatCompletionsAPI.kt
+++ b/ai/src/main/java/me/rerere/ai/provider/providers/openai/ChatCompletionsAPI.kt
@@ -271,12 +271,16 @@ class ChatCompletionsAPI(
                 }
             }
 
-            // open router适配
-            if(host == "openrouter.ai") {
-                if(params.model.outputModalities.contains(Modality.IMAGE)) {
+            if (params.model.outputModalities.contains(Modality.IMAGE)) {
+                if (host == "openrouter.ai") {
                     put("modalities", buildJsonArray {
                         add("image")
                         add("text")
+                    })
+                } else if (host == "aihubmix.com") {
+                    put("modalities", buildJsonArray {
+                        add("text")
+                        add("image")
                     })
                 }
             }
@@ -633,9 +637,10 @@ class ChatCompletionsAPI(
                 arr.jsonArrayOrNull?.getOrNull(0)?.jsonObject?.get("thinking")?.jsonArrayOrNull?.getOrNull(0)?.jsonObjectOrNull?.get(
                     "text"
                 )?.jsonPrimitiveOrNull?.contentOrNull
-            }
+        }
         val toolCalls = jsonObject["tool_calls"] as? JsonArray ?: JsonArray(emptyList())
         val images = jsonObject["images"] as? JsonArray ?: JsonArray(emptyList())
+        val multiModContent = jsonObject["multi_mod_content"] as? JsonArray ?: JsonArray(emptyList())
 
         return UIMessage(
             role = role,
@@ -672,8 +677,39 @@ class ChatCompletionsAPI(
                     val type = imageObject["type"]?.jsonPrimitive?.contentOrNull ?: return@forEach
                     if (type != "image_url") return@forEach
                     val url = imageObject["image_url"]?.jsonObjectOrNull?.get("url")?.jsonPrimitive?.contentOrNull ?: return@forEach
-                    require(url.startsWith("data:image")) { "Only data uri is supported" }
-                    add(UIMessagePart.Image(url.substringAfter("data:image/png;base64,")))
+                    val parsedImage = parseImageContent(url, allowRawBase64 = false)
+                    add(
+                        UIMessagePart.Image(
+                            url = parsedImage.base64,
+                            metadata = buildJsonObject {
+                                put("mimeType", parsedImage.mimeType)
+                            }
+                        )
+                    )
+                }
+                multiModContent.forEach { item ->
+                    val obj = item.jsonObjectOrNull ?: return@forEach
+                    val inlineData = (obj["inlineData"] ?: obj["inline_data"])?.jsonObjectOrNull
+                    val data = inlineData?.get("data")?.jsonPrimitive?.contentOrNull
+                    val rawMime = (inlineData?.get("mimeType") ?: inlineData?.get("mime_type"))
+                        ?.jsonPrimitive?.contentOrNull
+                    if (!data.isNullOrEmpty()) {
+                        val parsedImage = parseImageContent(data, rawMime)
+                        add(
+                            UIMessagePart.Image(
+                                url = parsedImage.base64,
+                                metadata = buildJsonObject {
+                                    put("mimeType", parsedImage.mimeType)
+                                }
+                            )
+                        )
+                    }
+                    if (content.isEmpty()) {
+                        val text = obj["text"]?.jsonPrimitive?.contentOrNull
+                        if (!text.isNullOrEmpty()) {
+                            add(UIMessagePart.Text(text))
+                        }
+                    }
                 }
             },
             annotations = parseAnnotations(
@@ -682,6 +718,50 @@ class ChatCompletionsAPI(
                 )
             ),
         )
+    }
+
+    private data class ParsedImageContent(
+        val base64: String,
+        val mimeType: String,
+    )
+
+    private fun parseImageContent(
+        data: String,
+        mime: String? = null,
+        allowRawBase64: Boolean = true
+    ): ParsedImageContent {
+        if (data.startsWith("data:", ignoreCase = true)) {
+            require(data.startsWith("data:image", ignoreCase = true)) {
+                "Only data uri is supported"
+            }
+            val base64Marker = "base64,"
+            val base64Index = data.indexOf(base64Marker, ignoreCase = true)
+            require(base64Index >= 0) {
+                "Only base64 data uri is supported"
+            }
+            val mimeType = data.substring("data:".length, base64Index).substringBefore(";")
+            return ParsedImageContent(
+                base64 = data.substring(base64Index + base64Marker.length),
+                mimeType = normalizeImageMime(mimeType)
+            )
+        }
+        require(allowRawBase64) {
+            "Only data uri is supported"
+        }
+        return ParsedImageContent(
+            base64 = data,
+            mimeType = normalizeImageMime(mime)
+        )
+    }
+
+    private fun normalizeImageMime(mime: String?): String {
+        val cleaned = mime?.trim()?.lowercase()
+        return when {
+            cleaned.isNullOrBlank() -> "image/png"
+            cleaned == "jpg" || cleaned == "image/jpg" -> "image/jpeg"
+            cleaned.startsWith("image/") -> cleaned
+            else -> "image/$cleaned"
+        }
     }
 
     private fun parseAnnotations(jsonArray: JsonArray): List<UIMessageAnnotation> {

--- a/ai/src/main/java/me/rerere/ai/provider/providers/openai/ChatCompletionsAPI.kt
+++ b/ai/src/main/java/me/rerere/ai/provider/providers/openai/ChatCompletionsAPI.kt
@@ -117,7 +117,7 @@ class ChatCompletionsAPI(
                 UIMessageChoice(
                     index = 0,
                     delta = null,
-                    message = parseMessage(message),
+                    message = parseMessage(message, wrapImagesAsDataUri = true),
                     finishReason = finishReason
                 )
             ),
@@ -300,7 +300,7 @@ class ChatCompletionsAPI(
                         })
                     }
 
-                    host.matchesHostOrSubdomain("dashscope.aliyuncs.com") -> {
+                    host.matchesDashScopeHost() -> {
                         // 阿里云百炼
                         // https://bailian.console.aliyun.com/console?tab=doc#/doc/?type=model&url=https%3A%2F%2Fhelp.aliyun.com%2Fdocument_detail%2F2870973.html&renderType=iframe
                         put("enable_thinking", level.isEnabled)
@@ -623,7 +623,12 @@ class ChatCompletionsAPI(
         })
     }
 
-    private fun parseMessage(jsonObject: JsonObject): UIMessage {
+    private fun parseMessage(jsonObject: JsonObject): UIMessage = parseMessage(
+        jsonObject = jsonObject,
+        wrapImagesAsDataUri = false
+    )
+
+    private fun parseMessage(jsonObject: JsonObject, wrapImagesAsDataUri: Boolean): UIMessage {
         val role = MessageRole.valueOf(
             jsonObject["role"]?.jsonPrimitive?.contentOrNull?.uppercase() ?: "ASSISTANT"
         )
@@ -681,7 +686,7 @@ class ChatCompletionsAPI(
                     val parsedImage = parseImageContent(url, allowRawBase64 = false)
                     add(
                         UIMessagePart.Image(
-                            url = parsedImage.base64,
+                            url = parsedImage.toImageUrl(wrapImagesAsDataUri),
                             metadata = buildJsonObject {
                                 put("mimeType", parsedImage.mimeType)
                             }
@@ -704,7 +709,7 @@ class ChatCompletionsAPI(
                         val parsedImage = parseImageContent(data, rawMime)
                         add(
                             UIMessagePart.Image(
-                                url = parsedImage.base64,
+                                url = parsedImage.toImageUrl(wrapImagesAsDataUri),
                                 metadata = buildJsonObject {
                                     put("mimeType", parsedImage.mimeType)
                                 }
@@ -724,7 +729,11 @@ class ChatCompletionsAPI(
     private data class ParsedImageContent(
         val base64: String,
         val mimeType: String,
-    )
+    ) {
+        fun toImageUrl(wrapAsDataUri: Boolean): String {
+            return if (wrapAsDataUri) "data:$mimeType;base64,$base64" else base64
+        }
+    }
 
     private fun parseImageContent(
         data: String,
@@ -763,8 +772,16 @@ class ChatCompletionsAPI(
             "png", "image/png" -> "image/png"
             "webp", "image/webp" -> "image/webp"
             "gif", "image/gif" -> "image/gif"
-            else -> "image/png"
+            "avif", "image/avif" -> "image/avif"
+            "heic", "image/heic" -> "image/heic"
+            "svg", "svg+xml", "image/svg", "image/svg+xml" -> "image/svg+xml"
+            else -> if (cleaned.startsWith("image/")) cleaned else "image/png"
         }
+    }
+
+    private fun String.matchesDashScopeHost(): Boolean {
+        return matchesHostOrSubdomain("dashscope.aliyuncs.com") ||
+            matchesHostOrSubdomain("dashscope-intl.aliyuncs.com")
     }
 
     private fun parseAnnotations(jsonArray: JsonArray): List<UIMessageAnnotation> {

--- a/ai/src/main/java/me/rerere/ai/provider/providers/openai/ResponseAPI.kt
+++ b/ai/src/main/java/me/rerere/ai/provider/providers/openai/ResponseAPI.kt
@@ -38,6 +38,7 @@ import me.rerere.ai.util.KeyRoulette
 import me.rerere.ai.util.configureReferHeaders
 import me.rerere.ai.util.encodeBase64
 import me.rerere.ai.util.json
+import me.rerere.ai.util.matchesHostOrSubdomain
 import me.rerere.ai.util.mergeCustomBody
 import me.rerere.ai.util.parseErrorDetail
 import me.rerere.ai.util.stringSafe
@@ -767,8 +768,8 @@ internal data class ResponseProviderCapabilities(
 )
 
 internal fun resolveResponseProviderCapabilities(host: String): ResponseProviderCapabilities {
-    return when (host) {
-        "ark.cn-beijing.volces.com" -> ResponseProviderCapabilities(
+    return when {
+        host.matchesHostOrSubdomain("ark.cn-beijing.volces.com") -> ResponseProviderCapabilities(
             supportsReasoningSummary = false,
             supportEncryptedContent = false
         )

--- a/ai/src/main/java/me/rerere/ai/ui/Message.kt
+++ b/ai/src/main/java/me/rerere/ai/ui/Message.kt
@@ -7,6 +7,8 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonPrimitive
 import me.rerere.ai.core.MessageRole
 import me.rerere.ai.core.TokenUsage
 import me.rerere.ai.provider.Model
@@ -62,8 +64,13 @@ data class UIMessage(
                             )
                         } else {
                             // Create new Image part
+                            val mime = deltaPart.metadata
+                                ?.get("mimeType")
+                                ?.jsonPrimitive
+                                ?.contentOrNull
+                                ?: "image/png"
                             acc + UIMessagePart.Image(
-                                url = "data:image/png;base64,${deltaPart.url}",
+                                url = "data:$mime;base64,${deltaPart.url}",
                                 metadata = deltaPart.metadata,
                             )
                         }

--- a/ai/src/main/java/me/rerere/ai/ui/Message.kt
+++ b/ai/src/main/java/me/rerere/ai/ui/Message.kt
@@ -69,8 +69,13 @@ data class UIMessage(
                                 ?.jsonPrimitive
                                 ?.contentOrNull
                                 ?: "image/png"
+                            val url = if (deltaPart.url.startsWith("data:", ignoreCase = true)) {
+                                deltaPart.url
+                            } else {
+                                "data:$mime;base64,${deltaPart.url}"
+                            }
                             acc + UIMessagePart.Image(
-                                url = "data:$mime;base64,${deltaPart.url}",
+                                url = url,
                                 metadata = deltaPart.metadata,
                             )
                         }

--- a/ai/src/main/java/me/rerere/ai/util/Request.kt
+++ b/ai/src/main/java/me/rerere/ai/util/Request.kt
@@ -21,19 +21,19 @@ fun List<CustomHeader>.toHeaders(): Headers {
     }.build()
 }
 
+fun String.matchesHostOrSubdomain(base: String): Boolean {
+    val lowered = lowercase()
+    val baseLowered = base.lowercase()
+    return lowered == baseLowered || lowered.endsWith(".$baseLowered")
+}
+
 fun Request.Builder.configureReferHeaders(url: String): Request.Builder {
-    val httpUrl = url.toHttpUrl()
-    return when (httpUrl.host) {
-        "aihubmix.com" -> {
-            addHeader("APP-Code", "DKHA9468")
-        }
-
-        "openrouter.ai" -> {
-            this
-                .addHeader("X-Title", "RikkaHub")
-                .addHeader("HTTP-Referer", "https://rikka-ai.com")
-        }
-
+    val host = url.toHttpUrl().host
+    return when {
+        host.matchesHostOrSubdomain("aihubmix.com") -> addHeader("APP-Code", "DKHA9468")
+        host.matchesHostOrSubdomain("openrouter.ai") -> this
+            .addHeader("X-Title", "RikkaHub")
+            .addHeader("HTTP-Referer", "https://rikka-ai.com")
         else -> this
     }
 }

--- a/ai/src/test/java/me/rerere/ai/provider/providers/openai/ChatCompletionsAPIMessageTest.kt
+++ b/ai/src/test/java/me/rerere/ai/provider/providers/openai/ChatCompletionsAPIMessageTest.kt
@@ -602,6 +602,92 @@ class ChatCompletionsAPIMessageTest {
         assertEquals("text", openrouterModalities[1].jsonPrimitive.content)
     }
 
+    @Test
+    fun `buildChatCompletionRequest should match aihubmix subdomain hosts`() {
+        val imageModel = Model(
+            modelId = "gemini-2.5-flash-image-preview",
+            outputModalities = listOf(Modality.TEXT, Modality.IMAGE)
+        )
+        val request = invokeBuildChatCompletionRequest(
+            providerSetting = ProviderSetting.OpenAI(baseUrl = "https://api.aihubmix.com/v1"),
+            model = imageModel
+        )
+
+        val modalities = request["modalities"]!!.jsonArray
+        assertEquals(2, modalities.size)
+        assertEquals("text", modalities[0].jsonPrimitive.content)
+        assertEquals("image", modalities[1].jsonPrimitive.content)
+    }
+
+    @Test
+    fun `parseMessage should normalize aihubmix raw base64 with jpeg shorthand mime`() {
+        val message = buildJsonObject {
+            put("role", "assistant")
+            put("content", "")
+            put("multi_mod_content", buildJsonArray {
+                add(buildJsonObject {
+                    put("inlineData", buildJsonObject {
+                        put("data", "JPEG_SHORTHAND_BASE64")
+                        put("mimeType", "jpeg")
+                    })
+                })
+            })
+        }
+
+        val result = invokeParseMessage(message)
+
+        assertEquals(1, result.parts.size)
+        val image = result.parts.single() as UIMessagePart.Image
+        assertEquals("JPEG_SHORTHAND_BASE64", image.url)
+        assertEquals("image/jpeg", image.metadata?.get("mimeType")?.jsonPrimitive?.content)
+    }
+
+    @Test
+    fun `parseMessage should order multi modal text before image within same item`() {
+        val message = buildJsonObject {
+            put("role", "assistant")
+            put("content", "")
+            put("multi_mod_content", buildJsonArray {
+                add(buildJsonObject {
+                    put("text", "hello")
+                    put("inlineData", buildJsonObject {
+                        put("data", "BASE64")
+                        put("mimeType", "png")
+                    })
+                })
+            })
+        }
+
+        val result = invokeParseMessage(message)
+
+        assertEquals(2, result.parts.size)
+        assertEquals("hello", (result.parts[0] as UIMessagePart.Text).text)
+        val image = result.parts[1] as UIMessagePart.Image
+        assertEquals("BASE64", image.url)
+    }
+
+    @Test
+    fun `parseMessage should tolerate non-primitive multi modal fields`() {
+        val message = buildJsonObject {
+            put("role", "assistant")
+            put("content", "")
+            put("multi_mod_content", buildJsonArray {
+                add(buildJsonObject {
+                    put("text", buildJsonObject { put("nested", "object") })
+                    put("inlineData", buildJsonObject {
+                        put("data", buildJsonArray { add(JsonPrimitive("not-a-string")) })
+                        put("mimeType", buildJsonObject { put("garbage", true) })
+                    })
+                })
+            })
+        }
+
+        val result = invokeParseMessage(message)
+
+        assertTrue(result.parts.none { it is UIMessagePart.Image })
+        assertTrue(result.parts.none { it is UIMessagePart.Text })
+    }
+
     // ==================== Helper Functions ====================
 
     private fun createExecutedTool(

--- a/ai/src/test/java/me/rerere/ai/provider/providers/openai/ChatCompletionsAPIMessageTest.kt
+++ b/ai/src/test/java/me/rerere/ai/provider/providers/openai/ChatCompletionsAPIMessageTest.kt
@@ -1,13 +1,24 @@
 package me.rerere.ai.provider.providers.openai
 
 import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import me.rerere.ai.core.MessageRole
+import me.rerere.ai.provider.Modality
+import me.rerere.ai.provider.Model
+import me.rerere.ai.provider.ProviderSetting
+import me.rerere.ai.provider.TextGenerationParams
+import me.rerere.ai.ui.MessageChunk
 import me.rerere.ai.ui.UIMessage
+import me.rerere.ai.ui.UIMessageChoice
 import me.rerere.ai.ui.UIMessagePart
+import me.rerere.ai.ui.handleMessageChunk
 import me.rerere.ai.util.KeyRoulette
 import okhttp3.OkHttpClient
 import org.junit.Assert.assertEquals
@@ -37,6 +48,36 @@ class ChatCompletionsAPIMessageTest {
         )
         method.isAccessible = true
         return method.invoke(api, messages) as JsonArray
+    }
+
+    private fun invokeParseMessage(message: JsonObject): UIMessage {
+        val method = ChatCompletionsAPI::class.java.getDeclaredMethod(
+            "parseMessage",
+            JsonObject::class.java
+        )
+        method.isAccessible = true
+        return method.invoke(api, message) as UIMessage
+    }
+
+    private fun invokeBuildChatCompletionRequest(
+        providerSetting: ProviderSetting.OpenAI,
+        model: Model,
+    ): JsonObject {
+        val method = ChatCompletionsAPI::class.java.getDeclaredMethod(
+            "buildChatCompletionRequest",
+            List::class.java,
+            TextGenerationParams::class.java,
+            ProviderSetting.OpenAI::class.java,
+            Boolean::class.javaPrimitiveType
+        )
+        method.isAccessible = true
+        return method.invoke(
+            api,
+            listOf(UIMessage.user("Generate an image")),
+            TextGenerationParams(model = model),
+            providerSetting,
+            false
+        ) as JsonObject
     }
 
     @Test
@@ -344,6 +385,221 @@ class ChatCompletionsAPIMessageTest {
         assertEquals("assistant", result[1].jsonObject["role"]?.jsonPrimitive?.content)
         assertEquals("thinking", result[1].jsonObject["reasoning_content"]?.jsonPrimitive?.content)
         assertEquals("", result[1].jsonObject["content"]?.jsonPrimitive?.content)
+    }
+
+    @Test
+    fun `parseMessage should parse aihubmix camelCase multi modal image as raw base64 with normalized mime`() {
+        val message = buildJsonObject {
+            put("role", "assistant")
+            put("content", "Generated image")
+            put("multi_mod_content", buildJsonArray {
+                add(buildJsonObject {
+                    put("text", "")
+                    put("inlineData", buildJsonObject {
+                        put("data", "CAMEL_BASE64")
+                        put("mimeType", "png")
+                    })
+                })
+            })
+        }
+
+        val result = invokeParseMessage(message)
+
+        assertEquals(MessageRole.ASSISTANT, result.role)
+        assertEquals(2, result.parts.size)
+        assertEquals("Generated image", (result.parts[0] as UIMessagePart.Text).text)
+        val image = result.parts[1] as UIMessagePart.Image
+        assertEquals("CAMEL_BASE64", image.url)
+        assertEquals("image/png", image.metadata?.get("mimeType")?.jsonPrimitive?.content)
+    }
+
+    @Test
+    fun `parseMessage should parse aihubmix snake_case multi modal image and normalize jpeg mime`() {
+        val message = buildJsonObject {
+            put("role", "assistant")
+            put("content", "")
+            put("multi_mod_content", buildJsonArray {
+                add(buildJsonObject {
+                    put("text", "")
+                    put("inline_data", buildJsonObject {
+                        put("data", "SNAKE_BASE64")
+                        put("mime_type", " image/JPG ")
+                    })
+                })
+            })
+        }
+
+        val result = invokeParseMessage(message)
+
+        assertEquals(1, result.parts.size)
+        val image = result.parts.single() as UIMessagePart.Image
+        assertEquals("SNAKE_BASE64", image.url)
+        assertEquals("image/jpeg", image.metadata?.get("mimeType")?.jsonPrimitive?.content)
+    }
+
+    @Test
+    fun `parseMessage should keep image png mime and normalize jpg shorthand`() {
+        val message = buildJsonObject {
+            put("role", "assistant")
+            put("content", "")
+            put("multi_mod_content", buildJsonArray {
+                add(buildJsonObject {
+                    put("inlineData", buildJsonObject {
+                        put("data", "PNG_BASE64")
+                        put("mimeType", "image/png")
+                    })
+                })
+                add(buildJsonObject {
+                    put("inlineData", buildJsonObject {
+                        put("data", "JPG_BASE64")
+                        put("mimeType", "jpg")
+                    })
+                })
+            })
+        }
+
+        val result = invokeParseMessage(message)
+        val images = result.parts.filterIsInstance<UIMessagePart.Image>()
+
+        assertEquals(2, images.size)
+        assertEquals("PNG_BASE64", images[0].url)
+        assertEquals("image/png", images[0].metadata?.get("mimeType")?.jsonPrimitive?.content)
+        assertEquals("JPG_BASE64", images[1].url)
+        assertEquals("image/jpeg", images[1].metadata?.get("mimeType")?.jsonPrimitive?.content)
+    }
+
+    @Test
+    fun `parseMessage should skip empty multi modal inline data`() {
+        val message = buildJsonObject {
+            put("role", "assistant")
+            put("content", "")
+            put("multi_mod_content", buildJsonArray {
+                add(buildJsonObject {
+                    put("inlineData", buildJsonObject {})
+                })
+            })
+        }
+
+        val result = invokeParseMessage(message)
+
+        assertTrue(result.parts.none { it is UIMessagePart.Image })
+    }
+
+    @Test
+    fun `parseMessage should avoid duplicated multi modal text when top-level content exists`() {
+        val message = buildJsonObject {
+            put("role", "assistant")
+            put("content", "Top level text")
+            put("multi_mod_content", buildJsonArray {
+                add(buildJsonObject {
+                    put("text", "Top level text")
+                    put("inlineData", buildJsonObject {})
+                })
+            })
+        }
+
+        val result = invokeParseMessage(message)
+
+        val texts = result.parts.filterIsInstance<UIMessagePart.Text>()
+        assertEquals(1, texts.size)
+        assertEquals("Top level text", texts.single().text)
+        assertTrue(result.parts.none { it is UIMessagePart.Image })
+    }
+
+    @Test
+    fun `parseMessage should add multi modal text when top-level content is empty`() {
+        val message = buildJsonObject {
+            put("role", "assistant")
+            put("content", "")
+            put("multi_mod_content", buildJsonArray {
+                add(buildJsonObject {
+                    put("text", "Text from multi modal content")
+                    put("inlineData", buildJsonObject {})
+                })
+            })
+        }
+
+        val result = invokeParseMessage(message)
+
+        assertEquals(1, result.parts.size)
+        assertEquals("Text from multi modal content", (result.parts.single() as UIMessagePart.Text).text)
+    }
+
+    @Test
+    fun `parseMessage should parse openrouter jpeg data uri as raw base64 with mime metadata`() {
+        val message = buildJsonObject {
+            put("role", "assistant")
+            put("content", "")
+            put("images", buildJsonArray {
+                add(buildJsonObject {
+                    put("type", "image_url")
+                    put("image_url", buildJsonObject {
+                        put("url", "data:image/jpeg;base64,JPEG_BASE64")
+                    })
+                })
+            })
+        }
+
+        val result = invokeParseMessage(message)
+
+        assertEquals(1, result.parts.size)
+        val image = result.parts.single() as UIMessagePart.Image
+        assertEquals("JPEG_BASE64", image.url)
+        assertEquals("image/jpeg", image.metadata?.get("mimeType")?.jsonPrimitive?.content)
+    }
+
+    @Test
+    fun `handleMessageChunk should prefix image with mime metadata exactly once`() {
+        val messages = listOf(UIMessage.user("Generate an image"))
+        val chunk = MessageChunk(
+            id = "chunk-id",
+            model = "model-id",
+            choices = listOf(
+                UIMessageChoice(
+                    index = 0,
+                    delta = null,
+                    message = UIMessage(
+                        role = MessageRole.ASSISTANT,
+                        parts = listOf(
+                            UIMessagePart.Image(
+                                url = "JPEG_BASE64",
+                                metadata = buildJsonObject { put("mimeType", "image/jpeg") }
+                            )
+                        )
+                    ),
+                    finishReason = "stop"
+                )
+            )
+        )
+
+        val result = messages.handleMessageChunk(chunk)
+        val image = result.last().parts.single() as UIMessagePart.Image
+
+        assertEquals("data:image/jpeg;base64,JPEG_BASE64", image.url)
+    }
+
+    @Test
+    fun `buildChatCompletionRequest should send provider-specific image modalities`() {
+        val imageModel = Model(
+            modelId = "gemini-2.5-flash-image-preview",
+            outputModalities = listOf(Modality.TEXT, Modality.IMAGE)
+        )
+        val aihubmixRequest = invokeBuildChatCompletionRequest(
+            providerSetting = ProviderSetting.OpenAI(baseUrl = "https://aihubmix.com/v1"),
+            model = imageModel
+        )
+        val openrouterRequest = invokeBuildChatCompletionRequest(
+            providerSetting = ProviderSetting.OpenAI(baseUrl = "https://openrouter.ai/api/v1"),
+            model = imageModel
+        )
+
+        val aihubmixModalities = aihubmixRequest["modalities"]!!.jsonArray
+        assertEquals("text", aihubmixModalities[0].jsonPrimitive.content)
+        assertEquals("image", aihubmixModalities[1].jsonPrimitive.content)
+
+        val openrouterModalities = openrouterRequest["modalities"]!!.jsonArray
+        assertEquals("image", openrouterModalities[0].jsonPrimitive.content)
+        assertEquals("text", openrouterModalities[1].jsonPrimitive.content)
     }
 
     // ==================== Helper Functions ====================

--- a/ai/src/test/java/me/rerere/ai/provider/providers/openai/ChatCompletionsAPIMessageTest.kt
+++ b/ai/src/test/java/me/rerere/ai/provider/providers/openai/ChatCompletionsAPIMessageTest.kt
@@ -10,8 +10,10 @@ import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import me.rerere.ai.core.MessageRole
+import me.rerere.ai.core.ReasoningLevel
 import me.rerere.ai.provider.Modality
 import me.rerere.ai.provider.Model
+import me.rerere.ai.provider.ModelAbility
 import me.rerere.ai.provider.ProviderSetting
 import me.rerere.ai.provider.TextGenerationParams
 import me.rerere.ai.ui.MessageChunk
@@ -59,9 +61,20 @@ class ChatCompletionsAPIMessageTest {
         return method.invoke(api, message) as UIMessage
     }
 
+    private fun invokeParseMessage(message: JsonObject, wrapImagesAsDataUri: Boolean): UIMessage {
+        val method = ChatCompletionsAPI::class.java.getDeclaredMethod(
+            "parseMessage",
+            JsonObject::class.java,
+            Boolean::class.javaPrimitiveType
+        )
+        method.isAccessible = true
+        return method.invoke(api, message, wrapImagesAsDataUri) as UIMessage
+    }
+
     private fun invokeBuildChatCompletionRequest(
         providerSetting: ProviderSetting.OpenAI,
         model: Model,
+        reasoningLevel: ReasoningLevel = ReasoningLevel.OFF,
     ): JsonObject {
         val method = ChatCompletionsAPI::class.java.getDeclaredMethod(
             "buildChatCompletionRequest",
@@ -74,7 +87,7 @@ class ChatCompletionsAPIMessageTest {
         return method.invoke(
             api,
             listOf(UIMessage.user("Generate an image")),
-            TextGenerationParams(model = model),
+            TextGenerationParams(model = model, reasoningLevel = reasoningLevel),
             providerSetting,
             false
         ) as JsonObject
@@ -414,6 +427,49 @@ class ChatCompletionsAPIMessageTest {
     }
 
     @Test
+    fun `parseMessage default should keep raw image chunks for streaming`() {
+        val message = buildJsonObject {
+            put("role", "assistant")
+            put("content", "")
+            put("multi_mod_content", buildJsonArray {
+                add(buildJsonObject {
+                    put("inlineData", buildJsonObject {
+                        put("data", "STREAM_BASE64")
+                        put("mimeType", "png")
+                    })
+                })
+            })
+        }
+
+        val result = invokeParseMessage(message)
+
+        val image = result.parts.single() as UIMessagePart.Image
+        assertEquals("STREAM_BASE64", image.url)
+    }
+
+    @Test
+    fun `parseMessage should wrap final aihubmix image as data uri`() {
+        val message = buildJsonObject {
+            put("role", "assistant")
+            put("content", "")
+            put("multi_mod_content", buildJsonArray {
+                add(buildJsonObject {
+                    put("inlineData", buildJsonObject {
+                        put("data", "CAMEL_BASE64")
+                        put("mimeType", "png")
+                    })
+                })
+            })
+        }
+
+        val result = invokeParseMessage(message, wrapImagesAsDataUri = true)
+
+        val image = result.parts.single() as UIMessagePart.Image
+        assertEquals("data:image/png;base64,CAMEL_BASE64", image.url)
+        assertEquals("image/png", image.metadata?.get("mimeType")?.jsonPrimitive?.content)
+    }
+
+    @Test
     fun `parseMessage should parse aihubmix snake_case multi modal image and normalize jpeg mime`() {
         val message = buildJsonObject {
             put("role", "assistant")
@@ -466,6 +522,37 @@ class ChatCompletionsAPIMessageTest {
         assertEquals("image/png", images[0].metadata?.get("mimeType")?.jsonPrimitive?.content)
         assertEquals("JPG_BASE64", images[1].url)
         assertEquals("image/jpeg", images[1].metadata?.get("mimeType")?.jsonPrimitive?.content)
+    }
+
+    @Test
+    fun `parseMessage should preserve full image mime values`() {
+        val message = buildJsonObject {
+            put("role", "assistant")
+            put("content", "")
+            put("multi_mod_content", buildJsonArray {
+                add(buildJsonObject {
+                    put("inlineData", buildJsonObject {
+                        put("data", "SVG_BASE64")
+                        put("mimeType", "image/svg+xml")
+                    })
+                })
+                add(buildJsonObject {
+                    put("inlineData", buildJsonObject {
+                        put("data", "OCTET_BASE64")
+                        put("mimeType", "application/octet-stream")
+                    })
+                })
+            })
+        }
+
+        val result = invokeParseMessage(message, wrapImagesAsDataUri = true)
+        val images = result.parts.filterIsInstance<UIMessagePart.Image>()
+
+        assertEquals(2, images.size)
+        assertEquals("data:image/svg+xml;base64,SVG_BASE64", images[0].url)
+        assertEquals("image/svg+xml", images[0].metadata?.get("mimeType")?.jsonPrimitive?.content)
+        assertEquals("data:image/png;base64,OCTET_BASE64", images[1].url)
+        assertEquals("image/png", images[1].metadata?.get("mimeType")?.jsonPrimitive?.content)
     }
 
     @Test
@@ -549,6 +636,28 @@ class ChatCompletionsAPIMessageTest {
     }
 
     @Test
+    fun `parseMessage should wrap final openrouter jpeg image as data uri`() {
+        val message = buildJsonObject {
+            put("role", "assistant")
+            put("content", "")
+            put("images", buildJsonArray {
+                add(buildJsonObject {
+                    put("type", "image_url")
+                    put("image_url", buildJsonObject {
+                        put("url", "data:image/jpeg;base64,JPEG_BASE64")
+                    })
+                })
+            })
+        }
+
+        val result = invokeParseMessage(message, wrapImagesAsDataUri = true)
+
+        val image = result.parts.single() as UIMessagePart.Image
+        assertEquals("data:image/jpeg;base64,JPEG_BASE64", image.url)
+        assertEquals("image/jpeg", image.metadata?.get("mimeType")?.jsonPrimitive?.content)
+    }
+
+    @Test
     fun `handleMessageChunk should prefix image with mime metadata exactly once`() {
         val messages = listOf(UIMessage.user("Generate an image"))
         val chunk = MessageChunk(
@@ -563,6 +672,36 @@ class ChatCompletionsAPIMessageTest {
                         parts = listOf(
                             UIMessagePart.Image(
                                 url = "JPEG_BASE64",
+                                metadata = buildJsonObject { put("mimeType", "image/jpeg") }
+                            )
+                        )
+                    ),
+                    finishReason = "stop"
+                )
+            )
+        )
+
+        val result = messages.handleMessageChunk(chunk)
+        val image = result.last().parts.single() as UIMessagePart.Image
+
+        assertEquals("data:image/jpeg;base64,JPEG_BASE64", image.url)
+    }
+
+    @Test
+    fun `handleMessageChunk should not double prefix image data uri`() {
+        val messages = listOf(UIMessage.user("Generate an image"))
+        val chunk = MessageChunk(
+            id = "chunk-id",
+            model = "model-id",
+            choices = listOf(
+                UIMessageChoice(
+                    index = 0,
+                    delta = null,
+                    message = UIMessage(
+                        role = MessageRole.ASSISTANT,
+                        parts = listOf(
+                            UIMessagePart.Image(
+                                url = "data:image/jpeg;base64,JPEG_BASE64",
                                 metadata = buildJsonObject { put("mimeType", "image/jpeg") }
                             )
                         )
@@ -617,6 +756,26 @@ class ChatCompletionsAPIMessageTest {
         assertEquals(2, modalities.size)
         assertEquals("text", modalities[0].jsonPrimitive.content)
         assertEquals("image", modalities[1].jsonPrimitive.content)
+    }
+
+    @Test
+    fun `buildChatCompletionRequest should route dashscope intl reasoning params`() {
+        val reasoningModel = Model(
+            modelId = "qwen3-max",
+            abilities = listOf(ModelAbility.REASONING)
+        )
+
+        val request = invokeBuildChatCompletionRequest(
+            providerSetting = ProviderSetting.OpenAI(
+                baseUrl = "https://dashscope-intl.aliyuncs.com/compatible-mode/v1"
+            ),
+            model = reasoningModel,
+            reasoningLevel = ReasoningLevel.HIGH
+        )
+
+        assertEquals("true", request["enable_thinking"]?.jsonPrimitive?.content)
+        assertEquals("8000", request["thinking_budget"]?.jsonPrimitive?.content)
+        assertTrue(!request.containsKey("reasoning_effort"))
     }
 
     @Test


### PR DESCRIPTION
## 问题

通过 aihubmix 调用 gemini-image 系列模型时，对话内的图片显示空白；token 用量显示模型确实生成了图片，且同一模型在 OpenRouter 上图片可以正常显示，关闭流式输出后 aihubmix 依旧空白。

Closes #1228

## 原因

`ChatCompletionsAPI` 早先只识别 OpenRouter 的图片响应格式：

1. 请求构造时只针对 `openrouter.ai` 注入 `modalities: ["image","text"]`，aihubmix 没有任何提示，模型按纯文本通道返回。
2. 响应解析时只读 OpenRouter 自定义的 `images` 字段，而 aihubmix gemini 走的是 `multi_mod_content` + `inlineData`/`inline_data` 通道，整段图片数据被直接丢弃。
3. 即便后续支持解析，原本流式合并 `Image` part 时硬编码 `data:image/png;base64,`，gemini 实际返回的 jpeg 会被错误 MIME 污染，渲染端仍无法正确显示。

## 修复

1. **请求侧**：`buildChatCompletionRequest` 中对 `aihubmix.com` 也注入 `modalities` 参数，顺序与官方示例对齐（`text` 在前、`image` 在后）。
2. **响应侧**：`parseMessage` 新增 `multi_mod_content` 解析分支，兼容 `inlineData`/`inline_data` 与 `mimeType`/`mime_type` 两种命名；空 `inlineData` 跳过，文本字段仅在 top-level `content` 为空时回填以避免重复。
3. **MIME 归一化**：抽出 `parseImageContent` + `normalizeImageMime`，同时支持 data URI 与裸 base64；`jpg`/`JPG` 等简写统一归一到 `image/jpeg`，OpenRouter 分支也走同一路径，顺带修掉对非 png MIME 的丢失。
4. **流式合并**：`UIMessage.appendChunk()` 拼接 `Image` 时改为从 metadata 读取 mime，而不是硬编码 `image/png`。
5. **测试**：补充 aihubmix camel/snake case、jpeg/png 归一化、空 `inlineData`、文本去重、流式 mime 前缀，以及 aihubmix 与 OpenRouter modalities 顺序差异等回归用例。