### PR TITLE
fix(ai): 修复跨 Provider 工具与 reasoning 历史兼容

### DIFF
--- a/ai/src/main/java/me/rerere/ai/provider/providers/ClaudeProvider.kt
+++ b/ai/src/main/java/me/rerere/ai/provider/providers/ClaudeProvider.kt
@@ -268,7 +268,13 @@ class ClaudeProvider(private val client: OkHttpClient, context: Context? = null)
             put("model", params.model.modelId)
             put(
                 "messages",
-                buildMessages(messages, providerSetting.promptCaching, providerSetting.promptCacheTtl)
+                buildMessages(
+                    messages,
+                    params.model,
+                    providerSetting,
+                    providerSetting.promptCaching,
+                    providerSetting.promptCacheTtl
+                )
             )
             put("max_tokens", params.maxTokens ?: 64_000)
 
@@ -357,12 +363,29 @@ class ClaudeProvider(private val client: OkHttpClient, context: Context? = null)
         messages: List<UIMessage>,
         promptCaching: Boolean,
         promptCacheTtl: ClaudePromptCacheTtl
+    ) = buildMessages(messages, promptCaching, promptCacheTtl) { true }
+
+    private fun buildMessages(
+        messages: List<UIMessage>,
+        currentModel: Model,
+        providerSetting: ProviderSetting.Claude,
+        promptCaching: Boolean,
+        promptCacheTtl: ClaudePromptCacheTtl
+    ) = buildMessages(messages, promptCaching, promptCacheTtl) {
+        it.shouldIncludeProviderReasoning(currentModel, providerSetting)
+    }
+
+    private fun buildMessages(
+        messages: List<UIMessage>,
+        promptCaching: Boolean,
+        promptCacheTtl: ClaudePromptCacheTtl,
+        shouldIncludeReasoning: (UIMessage) -> Boolean
     ) = buildJsonArray {
         messages
             .filter { it.isValidToUpload() && it.role != MessageRole.SYSTEM }
             .forEach { message ->
                 if (message.role == MessageRole.ASSISTANT) {
-                    addAssistantMessage(message)
+                    addAssistantMessage(message, includeReasoning = shouldIncludeReasoning(message))
                 } else {
                     addUserMessage(message)
                 }
@@ -413,14 +436,16 @@ class ClaudeProvider(private val client: OkHttpClient, context: Context? = null)
         })
     }
 
-    private fun JsonArrayBuilder.addAssistantMessage(message: UIMessage) {
+    private fun JsonArrayBuilder.addAssistantMessage(message: UIMessage, includeReasoning: Boolean) {
         val groups = groupPartsByToolBoundary(message.parts)
         val contentBuffer = mutableListOf<JsonObject>()
 
         for (group in groups) {
             when (group) {
                 is PartGroup.Content -> {
-                    group.parts.mapNotNull { it.toContentBlock() }.forEach { contentBuffer.add(it) }
+                    group.parts
+                        .mapNotNull { it.toContentBlock(includeReasoning) }
+                        .forEach { contentBuffer.add(it) }
                 }
 
                 is PartGroup.Tools -> {
@@ -463,7 +488,7 @@ class ClaudeProvider(private val client: OkHttpClient, context: Context? = null)
         })
     }
 
-    private fun UIMessagePart.toContentBlock(): JsonObject? = when (this) {
+    private fun UIMessagePart.toContentBlock(includeReasoning: Boolean = true): JsonObject? = when (this) {
         is UIMessagePart.Text -> buildJsonObject {
             put("type", "text")
             put("text", text)
@@ -484,11 +509,13 @@ class ClaudeProvider(private val client: OkHttpClient, context: Context? = null)
             }
         }
 
-        is UIMessagePart.Reasoning -> buildJsonObject {
-            put("type", "thinking")
-            put("thinking", reasoning)
-            metadata?.forEach { (key, value) -> put(key, value) }
-        }
+        is UIMessagePart.Reasoning -> if (includeReasoning) {
+            buildJsonObject {
+                put("type", "thinking")
+                put("thinking", reasoning)
+                metadata?.forEach { (key, value) -> put(key, value) }
+            }
+        } else null
 
         else -> null
     }

--- a/ai/src/main/java/me/rerere/ai/provider/providers/ProviderMessageUtils.kt
+++ b/ai/src/main/java/me/rerere/ai/provider/providers/ProviderMessageUtils.kt
@@ -1,5 +1,8 @@
 package me.rerere.ai.provider.providers
 
+import me.rerere.ai.provider.Model
+import me.rerere.ai.provider.ProviderSetting
+import me.rerere.ai.ui.UIMessage
 import me.rerere.ai.ui.UIMessagePart
 
 /**
@@ -43,7 +46,7 @@ internal fun groupPartsByToolBoundary(parts: List<UIMessagePart>): List<PartGrou
     }
 
     for (part in parts) {
-        if (part is UIMessagePart.Tool && part.isExecuted) {
+        if (part is UIMessagePart.Tool && part.isExecuted && part.toolName.isNotBlank()) {
             flushContent()
             currentTools.add(part)
         } else {
@@ -55,4 +58,12 @@ internal fun groupPartsByToolBoundary(parts: List<UIMessagePart>): List<PartGrou
     flushContent()
     flushTools()
     return groups
+}
+
+internal fun UIMessage.shouldIncludeProviderReasoning(
+    currentModel: Model,
+    providerSetting: ProviderSetting
+): Boolean {
+    val sourceModelId = modelId ?: return true
+    return sourceModelId == currentModel.id || providerSetting.models.any { it.id == sourceModelId }
 }

--- a/ai/src/main/java/me/rerere/ai/provider/providers/openai/ChatCompletionsAPI.kt
+++ b/ai/src/main/java/me/rerere/ai/provider/providers/openai/ChatCompletionsAPI.kt
@@ -32,6 +32,7 @@ import me.rerere.ai.provider.ProviderSetting
 import me.rerere.ai.provider.TextGenerationParams
 import me.rerere.ai.provider.providers.PartGroup
 import me.rerere.ai.provider.providers.groupPartsByToolBoundary
+import me.rerere.ai.provider.providers.shouldIncludeProviderReasoning
 import me.rerere.ai.registry.ModelRegistry
 import me.rerere.ai.ui.MessageChunk
 import me.rerere.ai.ui.UIMessage
@@ -254,7 +255,10 @@ class ChatCompletionsAPI(
         val host = providerSetting.baseUrl.toHttpUrl().host
         return buildJsonObject {
             put("model", params.model.modelId)
-            put("messages", buildMessages(messages, providerSetting.includeHistoryReasoning))
+            put(
+                "messages",
+                buildMessages(messages, params.model, providerSetting, providerSetting.includeHistoryReasoning)
+            )
 
             if (isModelAllowTemperature(params.model)) {
                 if (params.temperature != null) put("temperature", params.temperature)
@@ -428,12 +432,33 @@ class ChatCompletionsAPI(
         return !ModelRegistry.OPENAI_O_MODELS.match(model.modelId) && !ModelRegistry.GPT_5.match(model.modelId)
     }
 
-    private fun buildMessages(messages: List<UIMessage>, includeHistoryReasoning: Boolean = true) = buildJsonArray {
+    private fun buildMessages(
+        messages: List<UIMessage>,
+        includeHistoryReasoning: Boolean = true
+    ) = buildMessages(messages, includeHistoryReasoning) { true }
+
+    private fun buildMessages(
+        messages: List<UIMessage>,
+        currentModel: Model,
+        providerSetting: ProviderSetting.OpenAI,
+        includeHistoryReasoning: Boolean = true
+    ) = buildMessages(messages, includeHistoryReasoning) {
+        it.shouldIncludeProviderReasoning(currentModel, providerSetting)
+    }
+
+    private fun buildMessages(
+        messages: List<UIMessage>,
+        includeHistoryReasoning: Boolean,
+        shouldIncludeReasoning: (UIMessage) -> Boolean
+    ) = buildJsonArray {
         val filteredMessages = messages.filter { it.isValidToUpload() }
 
         filteredMessages.forEach { message ->
             if (message.role == MessageRole.ASSISTANT) {
-                addAssistantMessages(message, includeReasoning = includeHistoryReasoning)
+                addAssistantMessages(
+                    message,
+                    includeReasoning = includeHistoryReasoning && shouldIncludeReasoning(message)
+                )
             } else {
                 addNonAssistantMessage(message)
             }

--- a/ai/src/main/java/me/rerere/ai/provider/providers/openai/ResponseAPI.kt
+++ b/ai/src/main/java/me/rerere/ai/provider/providers/openai/ResponseAPI.kt
@@ -29,6 +29,7 @@ import me.rerere.ai.provider.ProviderSetting
 import me.rerere.ai.provider.TextGenerationParams
 import me.rerere.ai.provider.providers.PartGroup
 import me.rerere.ai.provider.providers.groupPartsByToolBoundary
+import me.rerere.ai.provider.providers.shouldIncludeProviderReasoning
 import me.rerere.ai.registry.ModelRegistry
 import me.rerere.ai.ui.MessageChunk
 import me.rerere.ai.ui.UIMessage
@@ -210,7 +211,7 @@ class ResponseAPI(
             }
 
             // messages
-            put("input", buildMessages(messages))
+            put("input", buildMessages(messages, params.model, providerSetting))
 
             // reasoning
             if (params.model.abilities.contains(ModelAbility.REASONING)) {
@@ -274,19 +275,32 @@ class ResponseAPI(
         }.mergeCustomBody(params.customBody)
     }
 
-    internal fun buildMessages(messages: List<UIMessage>) = buildJsonArray {
+    internal fun buildMessages(messages: List<UIMessage>) = buildMessages(messages) { true }
+
+    internal fun buildMessages(
+        messages: List<UIMessage>,
+        currentModel: Model,
+        providerSetting: ProviderSetting.OpenAI
+    ) = buildMessages(messages) {
+        providerSetting.includeHistoryReasoning && it.shouldIncludeProviderReasoning(currentModel, providerSetting)
+    }
+
+    private fun buildMessages(
+        messages: List<UIMessage>,
+        shouldIncludeReasoning: (UIMessage) -> Boolean
+    ) = buildJsonArray {
         messages
             .filter { it.isValidToUpload() && it.role != MessageRole.SYSTEM }
             .forEach { message ->
                 if (message.role == MessageRole.ASSISTANT) {
-                    addAssistantItems(message)
+                    addAssistantItems(message, includeReasoning = shouldIncludeReasoning(message))
                 } else {
                     addUserItems(message)
                 }
             }
     }
 
-    private fun JsonArrayBuilder.addAssistantItems(message: UIMessage) {
+    private fun JsonArrayBuilder.addAssistantItems(message: UIMessage, includeReasoning: Boolean) {
         val groups = groupPartsByToolBoundary(message.parts)
         val contentBuffer = mutableListOf<UIMessagePart>()
 
@@ -296,6 +310,9 @@ class ResponseAPI(
                     group.parts.forEach { part ->
                         when (part) {
                             is UIMessagePart.Reasoning -> {
+                                if (!includeReasoning) {
+                                    return@forEach
+                                }
                                 // 先输出累积的文本/图片内容
                                 if (contentBuffer.isNotEmpty()) {
                                     addContentItem(MessageRole.ASSISTANT, contentBuffer)
@@ -543,7 +560,30 @@ class ResponseAPI(
                 val item = jsonObject["item"]?.jsonObject ?: error("chunk item not found")
                 val type = item["type"]?.jsonPrimitive?.content ?: error("chunk type not found")
                 val id = item["id"]?.jsonPrimitive?.content ?: error("chunk id not found")
-                if (type == "reasoning") {
+                if (type == "function_call") {
+                    return MessageChunk(
+                        id = id,
+                        model = "",
+                        choices = listOf(
+                            UIMessageChoice(
+                                index = 0,
+                                message = null,
+                                delta = UIMessage(
+                                    role = MessageRole.ASSISTANT,
+                                    parts = listOf(
+                                        UIMessagePart.Tool(
+                                            toolCallId = id,
+                                            toolName = item["name"]?.jsonPrimitive?.contentOrNull ?: "",
+                                            input = item["arguments"]?.jsonPrimitive?.contentOrNull ?: "",
+                                            output = emptyList()
+                                        )
+                                    )
+                                ),
+                                finishReason = null
+                            )
+                        )
+                    )
+                } else if (type == "reasoning") {
                     val encryptedContent = item["encrypted_content"]?.jsonPrimitive?.content
                     return MessageChunk(
                         id = id,
@@ -595,6 +635,7 @@ class ResponseAPI(
             "response.function_call_arguments.done" -> {
                 val toolCallId =
                     jsonObject["item_id"]?.jsonPrimitive?.content ?: error("item_id not found")
+                val name = jsonObject["name"]?.jsonPrimitive?.contentOrNull ?: ""
                 val arguments =
                     jsonObject["arguments"]?.jsonPrimitive?.content ?: error("arguments not found")
                 return MessageChunk(
@@ -608,7 +649,7 @@ class ResponseAPI(
                                 parts = listOf(
                                     UIMessagePart.Tool(
                                         toolCallId = toolCallId,
-                                        toolName = "",
+                                        toolName = name,
                                         input = arguments,
                                         output = emptyList()
                                     )
@@ -753,4 +794,3 @@ internal fun resolveResponseProviderCapabilities(host: String): ResponseProvider
         else -> ResponseProviderCapabilities()
     }
 }
-

--- a/ai/src/main/java/me/rerere/ai/provider/providers/openai/ResponseAPI.kt
+++ b/ai/src/main/java/me/rerere/ai/provider/providers/openai/ResponseAPI.kt
@@ -58,6 +58,7 @@ import okhttp3.sse.EventSources
 import kotlin.time.Clock
 
 private const val TAG = "ResponseAPI"
+private const val RESPONSE_CALL_ID_METADATA_KEY = "response_call_id"
 
 class ResponseAPI(
     private val client: OkHttpClient,
@@ -365,15 +366,16 @@ class ResponseAPI(
 
                     // 输出 function_call + function_call_output
                     group.tools.forEach { tool ->
+                        val callId = tool.responseCallId()
                         add(buildJsonObject {
                             put("type", "function_call")
-                            put("call_id", tool.toolCallId)
+                            put("call_id", callId)
                             put("name", tool.toolName)
                             put("arguments", tool.input)
                         })
                         add(buildJsonObject {
                             put("type", "function_call_output")
-                            put("call_id", tool.toolCallId)
+                            put("call_id", callId)
                             put(
                                 "output",
                                 tool.output.filterIsInstance<UIMessagePart.Text>().joinToString("\n") { it.text })
@@ -393,6 +395,22 @@ class ResponseAPI(
         val contentParts = message.parts.filter { it is UIMessagePart.Text || it is UIMessagePart.Image }
         if (contentParts.isNotEmpty()) {
             addContentItem(message.role, contentParts)
+        }
+    }
+
+    private fun UIMessagePart.Tool.responseCallId(): String {
+        return metadata?.get(RESPONSE_CALL_ID_METADATA_KEY)
+            ?.jsonPrimitiveOrNull
+            ?.contentOrNull
+            ?.takeIf { it.isNotBlank() }
+            ?: toolCallId
+    }
+
+    private fun responseCallIdMetadata(callId: String?): JsonObject? {
+        return callId?.takeIf { it.isNotBlank() }?.let {
+            buildJsonObject {
+                put(RESPONSE_CALL_ID_METADATA_KEY, it)
+            }
         }
     }
 
@@ -487,6 +505,7 @@ class ResponseAPI(
                 val type = item["type"]?.jsonPrimitive?.content ?: error("chunk type not found")
                 val id = item["id"]?.jsonPrimitive?.content ?: error("chunk id not found")
                 if (type == "function_call") {
+                    val responseCallId = item["call_id"]?.jsonPrimitive?.contentOrNull
                     return MessageChunk(
                         id = id,
                         model = "",
@@ -502,7 +521,8 @@ class ResponseAPI(
                                             toolName = item["name"]?.jsonPrimitive?.content ?: "",
                                             input = item["arguments"]?.jsonPrimitive?.content
                                                 ?: "",
-                                            output = emptyList()
+                                            output = emptyList(),
+                                            metadata = responseCallIdMetadata(responseCallId)
                                         )
                                     )
                                 ),
@@ -561,6 +581,7 @@ class ResponseAPI(
                 val type = item["type"]?.jsonPrimitive?.content ?: error("chunk type not found")
                 val id = item["id"]?.jsonPrimitive?.content ?: error("chunk id not found")
                 if (type == "function_call") {
+                    val responseCallId = item["call_id"]?.jsonPrimitive?.contentOrNull
                     return MessageChunk(
                         id = id,
                         model = "",
@@ -575,7 +596,8 @@ class ResponseAPI(
                                             toolCallId = id,
                                             toolName = item["name"]?.jsonPrimitive?.contentOrNull ?: "",
                                             input = item["arguments"]?.jsonPrimitive?.contentOrNull ?: "",
-                                            output = emptyList()
+                                            output = emptyList(),
+                                            metadata = responseCallIdMetadata(responseCallId)
                                         )
                                     )
                                 ),

--- a/ai/src/main/java/me/rerere/ai/ui/Message.kt
+++ b/ai/src/main/java/me/rerere/ai/ui/Message.kt
@@ -463,14 +463,27 @@ sealed class UIMessagePart {
         fun merge(other: Tool): Tool {
             return Tool(
                 toolCallId = toolCallId,
-                toolName = toolName + other.toolName,
-                input = input + other.input,
+                toolName = mergeStreamingText(toolName, other.toolName),
+                input = mergeStreamingText(input, other.input),
                 output = output + other.output,
                 approvalState = approvalState,
                 metadata = if (other.metadata != null) other.metadata else metadata,
             )
         }
     }
+}
+
+private fun mergeStreamingText(current: String, delta: String): String {
+    if (delta.isEmpty()) return current
+    if (current.isEmpty()) return delta
+    if (current == delta) return current
+    if (delta.startsWith(current)) return delta
+    if (current.startsWith(delta)) return current
+
+    val overlap = (minOf(current.length, delta.length) downTo 1).firstOrNull { length ->
+        current.endsWith(delta.take(length))
+    } ?: 0
+    return current + delta.drop(overlap)
 }
 
 /**
@@ -605,6 +618,7 @@ fun List<UIMessage>.migrateToolMessages(): List<UIMessage> {
                         val matchingResult = toolResults.find { result -> result.toolCallId == part.toolCallId }
                         if (matchingResult != null) {
                             part.copy(
+                                toolName = part.toolName.ifBlank { matchingResult.toolName },
                                 output = listOf(
                                     UIMessagePart.Text(
                                         json.encodeToString(matchingResult.content)
@@ -620,7 +634,7 @@ fun List<UIMessage>.migrateToolMessages(): List<UIMessage> {
                         if (matchingResult != null) {
                             UIMessagePart.Tool(
                                 toolCallId = part.toolCallId,
-                                toolName = part.toolName,
+                                toolName = part.toolName.ifBlank { matchingResult.toolName },
                                 input = part.arguments,
                                 output = listOf(
                                     UIMessagePart.Text(
@@ -706,6 +720,7 @@ fun <T> List<T>.migrateToolNodes(
                                     val matchingResult = toolResults.find { it.toolCallId == part.toolCallId }
                                     if (matchingResult != null) {
                                         part.copy(
+                                            toolName = part.toolName.ifBlank { matchingResult.toolName },
                                             output = listOf(
                                                 UIMessagePart.Text(
                                                     json.encodeToString(matchingResult.content)
@@ -721,7 +736,7 @@ fun <T> List<T>.migrateToolNodes(
                                 if (matchingResult != null) {
                                     UIMessagePart.Tool(
                                         toolCallId = part.toolCallId,
-                                        toolName = part.toolName,
+                                        toolName = part.toolName.ifBlank { matchingResult.toolName },
                                         input = part.arguments,
                                         output = listOf(
                                             UIMessagePart.Text(

--- a/ai/src/test/java/me/rerere/ai/provider/providers/ClaudeProviderMessageTest.kt
+++ b/ai/src/test/java/me/rerere/ai/provider/providers/ClaudeProviderMessageTest.kt
@@ -5,10 +5,14 @@ import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import me.rerere.ai.core.MessageRole
+import me.rerere.ai.provider.ClaudePromptCacheTtl
+import me.rerere.ai.provider.Model
+import me.rerere.ai.provider.ProviderSetting
 import me.rerere.ai.ui.UIMessage
 import me.rerere.ai.ui.UIMessagePart
 import okhttp3.OkHttpClient
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -37,10 +41,35 @@ class ClaudeProviderMessageTest {
         val method = ClaudeProvider::class.java.getDeclaredMethod(
             "buildMessages",
             List::class.java,
-            Boolean::class.javaPrimitiveType
+            Boolean::class.javaPrimitiveType,
+            ClaudePromptCacheTtl::class.java
         )
         method.isAccessible = true
-        return method.invoke(provider, messages, false) as JsonArray
+        return method.invoke(provider, messages, false, ClaudePromptCacheTtl.FIVE_MINUTES) as JsonArray
+    }
+
+    private fun invokeBuildMessages(
+        messages: List<UIMessage>,
+        currentModel: Model,
+        providerSetting: ProviderSetting.Claude
+    ): JsonArray {
+        val method = ClaudeProvider::class.java.getDeclaredMethod(
+            "buildMessages",
+            List::class.java,
+            Model::class.java,
+            ProviderSetting.Claude::class.java,
+            Boolean::class.javaPrimitiveType,
+            ClaudePromptCacheTtl::class.java
+        )
+        method.isAccessible = true
+        return method.invoke(
+            provider,
+            messages,
+            currentModel,
+            providerSetting,
+            false,
+            ClaudePromptCacheTtl.FIVE_MINUTES
+        ) as JsonArray
     }
 
     @Test
@@ -346,6 +375,55 @@ class ClaudeProviderMessageTest {
             it.jsonObject["type"]?.jsonPrimitive?.content == "text"
         }?.jsonObject
         assertEquals("Hello, how are you?", textBlock?.get("text")?.jsonPrimitive?.content)
+    }
+
+    @Test
+    fun `foreign provider reasoning should be omitted from claude history`() {
+        val currentModel = Model(modelId = "claude-sonnet-4.6")
+        val googleModel = Model(modelId = "gemini-3-pro")
+        val providerSetting = ProviderSetting.Claude(models = listOf(currentModel))
+        val messages = listOf(
+            UIMessage.user("Question"),
+            UIMessage(
+                role = MessageRole.ASSISTANT,
+                modelId = googleModel.id,
+                parts = listOf(
+                    UIMessagePart.Reasoning(reasoning = "Gemini thought"),
+                    UIMessagePart.Text("Visible answer")
+                )
+            )
+        )
+
+        val result = invokeBuildMessages(messages, currentModel, providerSetting)
+        val content = result.single { it.jsonObject["role"]?.jsonPrimitive?.content == "assistant" }
+            .jsonObject["content"]!!.jsonArray
+
+        assertFalse(content.any { it.jsonObject["type"]?.jsonPrimitive?.content == "thinking" })
+        assertTrue(content.any { it.jsonObject["text"]?.jsonPrimitive?.content == "Visible answer" })
+    }
+
+    @Test
+    fun `same provider reasoning should be included in claude history`() {
+        val currentModel = Model(modelId = "claude-sonnet-4.6")
+        val previousModel = Model(modelId = "claude-haiku")
+        val providerSetting = ProviderSetting.Claude(models = listOf(currentModel, previousModel))
+        val messages = listOf(
+            UIMessage.user("Question"),
+            UIMessage(
+                role = MessageRole.ASSISTANT,
+                modelId = previousModel.id,
+                parts = listOf(
+                    UIMessagePart.Reasoning(reasoning = "Claude thought"),
+                    UIMessagePart.Text("Visible answer")
+                )
+            )
+        )
+
+        val result = invokeBuildMessages(messages, currentModel, providerSetting)
+        val content = result.single { it.jsonObject["role"]?.jsonPrimitive?.content == "assistant" }
+            .jsonObject["content"]!!.jsonArray
+
+        assertTrue(content.any { it.jsonObject["thinking"]?.jsonPrimitive?.content == "Claude thought" })
     }
 
     // ==================== Helper Functions ====================

--- a/ai/src/test/java/me/rerere/ai/provider/providers/GoogleProviderMessageTest.kt
+++ b/ai/src/test/java/me/rerere/ai/provider/providers/GoogleProviderMessageTest.kt
@@ -1,12 +1,14 @@
 package me.rerere.ai.provider.providers
 
 import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import me.rerere.ai.core.MessageRole
 import me.rerere.ai.ui.UIMessage
 import me.rerere.ai.ui.UIMessagePart
+import me.rerere.ai.ui.migrateToolMessages
 import okhttp3.OkHttpClient
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
@@ -435,6 +437,44 @@ class GoogleProviderMessageTest {
     }
 
     @Test
+    @Suppress("DEPRECATION")
+    fun `migrated legacy memory tool should include functionResponse name`() {
+        val messages = listOf(
+            UIMessage.user("Remember this"),
+            UIMessage(
+                role = MessageRole.ASSISTANT,
+                parts = listOf(
+                    UIMessagePart.ToolCall(
+                        toolCallId = "call_1",
+                        toolName = "",
+                        arguments = """{"action":"create"}"""
+                    )
+                )
+            ),
+            UIMessage(
+                role = MessageRole.TOOL,
+                parts = listOf(
+                    UIMessagePart.ToolResult(
+                        toolCallId = "call_1",
+                        toolName = "memory_tool",
+                        content = JsonPrimitive("created"),
+                        arguments = JsonPrimitive("""{"action":"create"}""")
+                    )
+                )
+            )
+        )
+
+        val result = invokeBuildContents(messages.migrateToolMessages())
+        val functionResponse = result
+            .flatMap { it.jsonObject["parts"]?.jsonArray ?: emptyList() }
+            .first { it.jsonObject.containsKey("functionResponse") }
+            .jsonObject["functionResponse"]!!
+            .jsonObject
+
+        assertEquals("memory_tool", functionResponse["name"]?.jsonPrimitive?.content)
+    }
+
+    @Test
     fun `blank tool name should not produce invalid function call or response`() {
         val assistantMessage = UIMessage(
             role = MessageRole.ASSISTANT,
@@ -446,15 +486,13 @@ class GoogleProviderMessageTest {
         )
 
         val result = invokeBuildContents(listOf(UIMessage.user("Remember this"), assistantMessage))
-        val toolNames = result.flatMap { message ->
-            (message.jsonObject["parts"]?.jsonArray ?: emptyList()).mapNotNull { part ->
-                val obj = part.jsonObject
-                obj["functionCall"]?.jsonObject?.get("name")?.jsonPrimitive?.content
-                    ?: obj["functionResponse"]?.jsonObject?.get("name")?.jsonPrimitive?.content
-            }
-        }
+        val parts = result.flatMap { it.jsonObject["parts"]?.jsonArray ?: emptyList() }
+        val texts = parts.mapNotNull { it.jsonObject["text"]?.jsonPrimitive?.content }
 
-        assertTrue(toolNames.none { it.isBlank() })
+        assertTrue(parts.none { it.jsonObject.containsKey("functionCall") })
+        assertTrue(parts.none { it.jsonObject.containsKey("functionResponse") })
+        assertTrue(texts.contains("Calling a tool"))
+        assertTrue(texts.contains("Done"))
     }
 
     // ==================== Helper Functions ====================

--- a/ai/src/test/java/me/rerere/ai/provider/providers/GoogleProviderMessageTest.kt
+++ b/ai/src/test/java/me/rerere/ai/provider/providers/GoogleProviderMessageTest.kt
@@ -415,6 +415,48 @@ class GoogleProviderMessageTest {
             response?.get("result")?.jsonPrimitive?.content?.contains("Expected output value") == true)
     }
 
+    @Test
+    fun `memory tool response should include functionResponse name`() {
+        val assistantMessage = UIMessage(
+            role = MessageRole.ASSISTANT,
+            parts = listOf(
+                createExecutedTool("call_1", "memory_tool", """{"action":"create"}""", "created")
+            )
+        )
+
+        val result = invokeBuildContents(listOf(UIMessage.user("Remember this"), assistantMessage))
+        val functionResponse = result
+            .flatMap { it.jsonObject["parts"]?.jsonArray ?: emptyList() }
+            .first { it.jsonObject.containsKey("functionResponse") }
+            .jsonObject["functionResponse"]!!
+            .jsonObject
+
+        assertEquals("memory_tool", functionResponse["name"]?.jsonPrimitive?.content)
+    }
+
+    @Test
+    fun `blank tool name should not produce invalid function call or response`() {
+        val assistantMessage = UIMessage(
+            role = MessageRole.ASSISTANT,
+            parts = listOf(
+                UIMessagePart.Text("Calling a tool"),
+                createExecutedTool("call_1", "", """{"action":"create"}""", "created"),
+                UIMessagePart.Text("Done")
+            )
+        )
+
+        val result = invokeBuildContents(listOf(UIMessage.user("Remember this"), assistantMessage))
+        val toolNames = result.flatMap { message ->
+            (message.jsonObject["parts"]?.jsonArray ?: emptyList()).mapNotNull { part ->
+                val obj = part.jsonObject
+                obj["functionCall"]?.jsonObject?.get("name")?.jsonPrimitive?.content
+                    ?: obj["functionResponse"]?.jsonObject?.get("name")?.jsonPrimitive?.content
+            }
+        }
+
+        assertTrue(toolNames.none { it.isBlank() })
+    }
+
     // ==================== Helper Functions ====================
 
     private fun createExecutedTool(

--- a/ai/src/test/java/me/rerere/ai/provider/providers/ProviderMessageUtilsTest.kt
+++ b/ai/src/test/java/me/rerere/ai/provider/providers/ProviderMessageUtilsTest.kt
@@ -1,12 +1,15 @@
 package me.rerere.ai.provider.providers
 
 import me.rerere.ai.core.MessageRole
+import me.rerere.ai.provider.Model
+import me.rerere.ai.provider.ProviderSetting
 import me.rerere.ai.ui.UIMessage
 import me.rerere.ai.ui.UIMessagePart
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
-import kotlin.time.Clock
+import kotlin.uuid.Uuid
 
 class ProviderMessageUtilsTest {
 
@@ -338,6 +341,46 @@ class ProviderMessageUtilsTest {
         assertEquals("Final answer", (content[1] as UIMessagePart.Text).text)
     }
 
+    // ==================== Reasoning Provider Compatibility Tests ====================
+
+    @Test
+    fun `message without model id should include provider reasoning`() {
+        val currentModel = Model(modelId = "gpt-5")
+        val providerSetting = ProviderSetting.OpenAI(models = listOf(currentModel))
+        val message = createReasoningMessage(modelId = null)
+
+        assertTrue(message.shouldIncludeProviderReasoning(currentModel, providerSetting))
+    }
+
+    @Test
+    fun `current model reasoning should be included`() {
+        val currentModel = Model(modelId = "gpt-5")
+        val providerSetting = ProviderSetting.OpenAI(models = listOf(currentModel))
+        val message = createReasoningMessage(modelId = currentModel.id)
+
+        assertTrue(message.shouldIncludeProviderReasoning(currentModel, providerSetting))
+    }
+
+    @Test
+    fun `same provider model reasoning should be included`() {
+        val currentModel = Model(modelId = "gpt-5")
+        val previousModel = Model(modelId = "gpt-4.1")
+        val providerSetting = ProviderSetting.OpenAI(models = listOf(currentModel, previousModel))
+        val message = createReasoningMessage(modelId = previousModel.id)
+
+        assertTrue(message.shouldIncludeProviderReasoning(currentModel, providerSetting))
+    }
+
+    @Test
+    fun `foreign provider model reasoning should be omitted`() {
+        val currentModel = Model(modelId = "gpt-5")
+        val googleModel = Model(modelId = "gemini-3-pro")
+        val providerSetting = ProviderSetting.OpenAI(models = listOf(currentModel))
+        val message = createReasoningMessage(modelId = googleModel.id)
+
+        assertFalse(message.shouldIncludeProviderReasoning(currentModel, providerSetting))
+    }
+
     // ==================== Helper Functions ====================
 
     private fun createExecutedTool(callId: String, name: String): UIMessagePart.Tool {
@@ -355,6 +398,17 @@ class ProviderMessageUtilsTest {
             toolName = name,
             input = "{}",
             output = emptyList()
+        )
+    }
+
+    private fun createReasoningMessage(modelId: Uuid?): UIMessage {
+        return UIMessage(
+            role = MessageRole.ASSISTANT,
+            modelId = modelId,
+            parts = listOf(
+                UIMessagePart.Reasoning(reasoning = "thinking"),
+                UIMessagePart.Text("answer")
+            )
         )
     }
 }

--- a/ai/src/test/java/me/rerere/ai/provider/providers/openai/ChatCompletionsAPIMessageTest.kt
+++ b/ai/src/test/java/me/rerere/ai/provider/providers/openai/ChatCompletionsAPIMessageTest.kt
@@ -6,11 +6,14 @@ import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import me.rerere.ai.core.MessageRole
+import me.rerere.ai.provider.Model
+import me.rerere.ai.provider.ProviderSetting
 import me.rerere.ai.ui.UIMessage
 import me.rerere.ai.ui.UIMessagePart
 import me.rerere.ai.util.KeyRoulette
 import okhttp3.OkHttpClient
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -33,10 +36,28 @@ class ChatCompletionsAPIMessageTest {
     private fun invokeBuildMessages(messages: List<UIMessage>): JsonArray {
         val method = ChatCompletionsAPI::class.java.getDeclaredMethod(
             "buildMessages",
-            List::class.java
+            List::class.java,
+            Boolean::class.javaPrimitiveType
         )
         method.isAccessible = true
-        return method.invoke(api, messages) as JsonArray
+        return method.invoke(api, messages, true) as JsonArray
+    }
+
+    private fun invokeBuildMessages(
+        messages: List<UIMessage>,
+        currentModel: Model,
+        providerSetting: ProviderSetting.OpenAI,
+        includeHistoryReasoning: Boolean = true
+    ): JsonArray {
+        val method = ChatCompletionsAPI::class.java.getDeclaredMethod(
+            "buildMessages",
+            List::class.java,
+            Model::class.java,
+            ProviderSetting.OpenAI::class.java,
+            Boolean::class.javaPrimitiveType
+        )
+        method.isAccessible = true
+        return method.invoke(api, messages, currentModel, providerSetting, includeHistoryReasoning) as JsonArray
     }
 
     @Test
@@ -163,8 +184,7 @@ class ChatCompletionsAPIMessageTest {
     }
 
     @Test
-    fun `reasoning should only be included for messages after last user message`() {
-        // First assistant message (before user's last message) - reasoning should NOT be included
+    fun `reasoning should be included for all assistant messages when enabled`() {
         val assistant1 = UIMessage(
             role = MessageRole.ASSISTANT,
             parts = listOf(
@@ -173,7 +193,6 @@ class ChatCompletionsAPIMessageTest {
             )
         )
 
-        // Second assistant message (after user's last message) - reasoning SHOULD be included
         val assistant2 = UIMessage(
             role = MessageRole.ASSISTANT,
             parts = listOf(
@@ -198,19 +217,11 @@ class ChatCompletionsAPIMessageTest {
 
         assertEquals(2, assistantMessages.size)
 
-        // First assistant should NOT have reasoning_content
         val first = assistantMessages[0].jsonObject
-        assertTrue("First assistant should not have reasoning_content",
-            !first.containsKey("reasoning_content") ||
-            first["reasoning_content"]?.jsonPrimitive?.content.isNullOrEmpty()
-        )
+        assertEquals("Initial thinking", first["reasoning_content"]?.jsonPrimitive?.content)
 
-        // Second assistant SHOULD have reasoning_content
         val second = assistantMessages[1].jsonObject
-        assertTrue("Second assistant should have reasoning_content",
-            second.containsKey("reasoning_content") &&
-            second["reasoning_content"]?.jsonPrimitive?.content?.isNotEmpty() == true
-        )
+        assertEquals("Final thinking", second["reasoning_content"]?.jsonPrimitive?.content)
     }
 
     @Test
@@ -302,7 +313,7 @@ class ChatCompletionsAPIMessageTest {
     }
 
     @Test
-    fun `assistant with only reasoning and empty text should be filtered out`() {
+    fun `assistant with only reasoning and empty text should keep reasoning content`() {
         val messages = listOf(
             UIMessage.user("Question 1"),
             UIMessage(
@@ -317,11 +328,14 @@ class ChatCompletionsAPIMessageTest {
 
         val result = invokeBuildMessages(messages)
 
-        assertEquals(2, result.size)
+        assertEquals(3, result.size)
         assertEquals("user", result[0].jsonObject["role"]?.jsonPrimitive?.content)
         assertEquals("Question 1", result[0].jsonObject["content"]?.jsonPrimitive?.content)
-        assertEquals("user", result[1].jsonObject["role"]?.jsonPrimitive?.content)
-        assertEquals("Question 2", result[1].jsonObject["content"]?.jsonPrimitive?.content)
+        assertEquals("assistant", result[1].jsonObject["role"]?.jsonPrimitive?.content)
+        assertEquals("thinking", result[1].jsonObject["reasoning_content"]?.jsonPrimitive?.content)
+        assertEquals("", result[1].jsonObject["content"]?.jsonPrimitive?.content)
+        assertEquals("user", result[2].jsonObject["role"]?.jsonPrimitive?.content)
+        assertEquals("Question 2", result[2].jsonObject["content"]?.jsonPrimitive?.content)
     }
 
     @Test
@@ -344,6 +358,53 @@ class ChatCompletionsAPIMessageTest {
         assertEquals("assistant", result[1].jsonObject["role"]?.jsonPrimitive?.content)
         assertEquals("thinking", result[1].jsonObject["reasoning_content"]?.jsonPrimitive?.content)
         assertEquals("", result[1].jsonObject["content"]?.jsonPrimitive?.content)
+    }
+
+    @Test
+    fun `foreign provider reasoning should be omitted from chat completions history`() {
+        val currentModel = Model(modelId = "gpt-5")
+        val googleModel = Model(modelId = "gemini-3-pro")
+        val providerSetting = ProviderSetting.OpenAI(models = listOf(currentModel))
+        val messages = listOf(
+            UIMessage.user("Question"),
+            UIMessage(
+                role = MessageRole.ASSISTANT,
+                modelId = googleModel.id,
+                parts = listOf(
+                    UIMessagePart.Reasoning(reasoning = "Gemini thought"),
+                    UIMessagePart.Text("Visible answer")
+                )
+            )
+        )
+
+        val result = invokeBuildMessages(messages, currentModel, providerSetting)
+        val assistant = result.single { it.jsonObject["role"]?.jsonPrimitive?.content == "assistant" }.jsonObject
+
+        assertFalse(assistant.containsKey("reasoning_content"))
+        assertEquals("Visible answer", assistant["content"]?.jsonPrimitive?.content)
+    }
+
+    @Test
+    fun `same provider reasoning should be included in chat completions history`() {
+        val currentModel = Model(modelId = "gpt-5")
+        val previousModel = Model(modelId = "gpt-4.1")
+        val providerSetting = ProviderSetting.OpenAI(models = listOf(currentModel, previousModel))
+        val messages = listOf(
+            UIMessage.user("Question"),
+            UIMessage(
+                role = MessageRole.ASSISTANT,
+                modelId = previousModel.id,
+                parts = listOf(
+                    UIMessagePart.Reasoning(reasoning = "OpenAI thought"),
+                    UIMessagePart.Text("Visible answer")
+                )
+            )
+        )
+
+        val result = invokeBuildMessages(messages, currentModel, providerSetting)
+        val assistant = result.single { it.jsonObject["role"]?.jsonPrimitive?.content == "assistant" }.jsonObject
+
+        assertEquals("OpenAI thought", assistant["reasoning_content"]?.jsonPrimitive?.content)
     }
 
     // ==================== Helper Functions ====================

--- a/ai/src/test/java/me/rerere/ai/provider/providers/openai/ResponseAPIMessageTest.kt
+++ b/ai/src/test/java/me/rerere/ai/provider/providers/openai/ResponseAPIMessageTest.kt
@@ -1,5 +1,6 @@
 package me.rerere.ai.provider.providers.openai
 
+import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.jsonArray
@@ -13,6 +14,7 @@ import me.rerere.ai.provider.ProviderSetting
 import me.rerere.ai.provider.TextGenerationParams
 import me.rerere.ai.ui.UIMessage
 import me.rerere.ai.ui.UIMessagePart
+import me.rerere.ai.ui.handleMessageChunk
 import okhttp3.OkHttpClient
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -43,12 +45,29 @@ class ResponseAPIMessageTest {
         return api.buildMessages(messages)
     }
 
+    private fun invokeBuildMessages(
+        messages: List<UIMessage>,
+        currentModel: Model,
+        providerSetting: ProviderSetting.OpenAI
+    ): JsonArray {
+        return api.buildMessages(messages, currentModel, providerSetting)
+    }
+
     private fun invokeBuildRequestBody(
         providerSetting: ProviderSetting.OpenAI,
         params: TextGenerationParams,
         stream: Boolean = false
     ): JsonObject {
         return api.buildRequestBody(providerSetting, listOf(UIMessage.user("hello")), params, stream)
+    }
+
+    private fun parseDelta(raw: String): me.rerere.ai.ui.MessageChunk? {
+        val method = ResponseAPI::class.java.getDeclaredMethod(
+            "parseResponseDelta",
+            JsonObject::class.java
+        )
+        method.isAccessible = true
+        return method.invoke(api, Json.parseToJsonElement(raw).jsonObject) as me.rerere.ai.ui.MessageChunk?
     }
 
     private fun createReasoningParams(reasoningLevel: ReasoningLevel = ReasoningLevel.OFF): TextGenerationParams {
@@ -352,6 +371,106 @@ class ResponseAPIMessageTest {
         val reasoning = requestBody["reasoning"]?.jsonObject
         assertTrue("reasoning should exist", reasoning != null)
         assertEquals("low", reasoning!!["effort"]?.jsonPrimitive?.content)
+    }
+
+    @Test
+    fun `function call done should fill tool name without duplicating arguments`() {
+        val chunks = listOf(
+            parseDelta(
+                """
+                {
+                  "type": "response.output_item.added",
+                  "item": {
+                    "id": "fc_1",
+                    "type": "function_call",
+                    "name": "",
+                    "arguments": ""
+                  }
+                }
+                """.trimIndent()
+            )!!,
+            parseDelta(
+                """
+                {
+                  "type": "response.function_call_arguments.done",
+                  "item_id": "fc_1",
+                  "name": "memory_tool",
+                  "arguments": "{\"action\":\"create\"}"
+                }
+                """.trimIndent()
+            )!!,
+            parseDelta(
+                """
+                {
+                  "type": "response.output_item.done",
+                  "item": {
+                    "id": "fc_1",
+                    "call_id": "call_1",
+                    "type": "function_call",
+                    "name": "memory_tool",
+                    "arguments": "{\"action\":\"create\"}"
+                  }
+                }
+                """.trimIndent()
+            )!!
+        )
+
+        val messages = chunks.fold(listOf(UIMessage.user("remember this"))) { acc, chunk ->
+            acc.handleMessageChunk(chunk)
+        }
+        val tool = messages.last().parts.filterIsInstance<UIMessagePart.Tool>().single()
+
+        assertEquals("memory_tool", tool.toolName)
+        assertEquals("""{"action":"create"}""", tool.input)
+    }
+
+    @Test
+    fun `foreign provider reasoning should be omitted from responses history`() {
+        val currentModel = Model(modelId = "gpt-5")
+        val googleModel = Model(modelId = "gemini-3-pro")
+        val providerSetting = ProviderSetting.OpenAI(models = listOf(currentModel))
+        val messages = listOf(
+            UIMessage.user("Question"),
+            UIMessage(
+                role = MessageRole.ASSISTANT,
+                modelId = googleModel.id,
+                parts = listOf(
+                    UIMessagePart.Reasoning(reasoning = "Gemini thought"),
+                    UIMessagePart.Text("Visible answer")
+                )
+            )
+        )
+
+        val result = invokeBuildMessages(messages, currentModel, providerSetting)
+
+        assertFalse(result.any { it.jsonObject["type"]?.jsonPrimitive?.content == "reasoning" })
+        assertTrue(result.any { it.jsonObject["content"]?.jsonPrimitive?.content == "Visible answer" })
+    }
+
+    @Test
+    fun `same provider reasoning should be included in responses history`() {
+        val currentModel = Model(modelId = "gpt-5")
+        val previousModel = Model(modelId = "gpt-4.1")
+        val providerSetting = ProviderSetting.OpenAI(models = listOf(currentModel, previousModel))
+        val messages = listOf(
+            UIMessage.user("Question"),
+            UIMessage(
+                role = MessageRole.ASSISTANT,
+                modelId = previousModel.id,
+                parts = listOf(
+                    UIMessagePart.Reasoning(reasoning = "OpenAI thought"),
+                    UIMessagePart.Text("Visible answer")
+                )
+            )
+        )
+
+        val result = invokeBuildMessages(messages, currentModel, providerSetting)
+        val reasoning = result.single { it.jsonObject["type"]?.jsonPrimitive?.content == "reasoning" }.jsonObject
+        val summary = reasoning["summary"]!!.jsonArray
+
+        assertTrue(summary.any {
+            it.jsonObject["text"]?.jsonPrimitive?.content == "OpenAI thought"
+        })
     }
 
     // ==================== Helper Functions ====================

--- a/ai/src/test/java/me/rerere/ai/provider/providers/openai/ResponseAPIMessageTest.kt
+++ b/ai/src/test/java/me/rerere/ai/provider/providers/openai/ResponseAPIMessageTest.kt
@@ -422,6 +422,19 @@ class ResponseAPIMessageTest {
 
         assertEquals("memory_tool", tool.toolName)
         assertEquals("""{"action":"create"}""", tool.input)
+
+        val executedTool = tool.copy(output = listOf(UIMessagePart.Text("created")))
+        val historyMessages = messages.dropLast(1) + messages.last().copy(parts = listOf(executedTool))
+        val history = invokeBuildMessages(historyMessages)
+        val functionCall = history.single {
+            it.jsonObject["type"]?.jsonPrimitive?.content == "function_call"
+        }.jsonObject
+        val functionOutput = history.single {
+            it.jsonObject["type"]?.jsonPrimitive?.content == "function_call_output"
+        }.jsonObject
+
+        assertEquals("call_1", functionCall["call_id"]?.jsonPrimitive?.content)
+        assertEquals("call_1", functionOutput["call_id"]?.jsonPrimitive?.content)
     }
 
     @Test

--- a/ai/src/test/java/me/rerere/ai/ui/MessageTest.kt
+++ b/ai/src/test/java/me/rerere/ai/ui/MessageTest.kt
@@ -295,6 +295,70 @@ class MessageTest {
         assertEquals(messages, result)
     }
 
+    @Test
+    fun `Tool merge should not duplicate completed streaming fields`() {
+        val tool = UIMessagePart.Tool(
+            toolCallId = "call1",
+            toolName = "memory_tool",
+            input = """{"action":"create"}"""
+        ).merge(
+            UIMessagePart.Tool(
+                toolCallId = "call1",
+                toolName = "memory_tool",
+                input = """{"action":"create"}"""
+            )
+        )
+
+        assertEquals("memory_tool", tool.toolName)
+        assertEquals("""{"action":"create"}""", tool.input)
+    }
+
+    @Test
+    fun `Tool merge should fill blank tool name from later delta`() {
+        val tool = UIMessagePart.Tool(
+            toolCallId = "call1",
+            toolName = "",
+            input = """{"action":"create"}"""
+        ).merge(
+            UIMessagePart.Tool(
+                toolCallId = "call1",
+                toolName = "memory_tool",
+                input = ""
+            )
+        )
+
+        assertEquals("memory_tool", tool.toolName)
+        assertEquals("""{"action":"create"}""", tool.input)
+    }
+
+    @Test
+    @Suppress("DEPRECATION")
+    fun `migrateToolMessages should fill blank ToolCall name from ToolResult`() {
+        val messages = listOf(
+            UIMessage(role = MessageRole.USER, parts = listOf(UIMessagePart.Text("Query"))),
+            UIMessage(
+                role = MessageRole.ASSISTANT,
+                parts = listOf(UIMessagePart.ToolCall("call1", "", """{"action":"create"}"""))
+            ),
+            UIMessage(
+                role = MessageRole.TOOL,
+                parts = listOf(
+                    UIMessagePart.ToolResult(
+                        toolCallId = "call1",
+                        toolName = "memory_tool",
+                        content = JsonPrimitive("created"),
+                        arguments = JsonPrimitive("""{"action":"create"}""")
+                    )
+                )
+            )
+        )
+
+        val result = messages.migrateToolMessages()
+        val tool = result[1].parts.filterIsInstance<UIMessagePart.Tool>().single()
+
+        assertEquals("memory_tool", tool.toolName)
+    }
+
     // ==================== migrateToolNodes Tests ====================
 
     /**


### PR DESCRIPTION
## 问题

历史工具调用结果进入 Gemini 格式时，部分工具结果会生成缺失或空的 `functionResponse.name`，导致 Gemini 直接 400。

同时，Gemini 等 provider 生成的 thinking / reasoning 历史在切换到 OpenAI、Claude、Responses API 后，可能被当作目标 provider 的原生 reasoning 字段回放，造成跨 provider 兼容问题。

Closes #1260

## 原因

工具名在几条路径上都有可能变空或丢失：

1. 流式合并工具调用时直接拼接字符串，空增量和 done 事件容易覆盖或重复已有字段。
2. 旧 `ToolCall` / `ToolResult` 迁移时，没有用结果侧的 `toolName` 补齐空调用名。
3. Responses API 的 `response.output_item.done` 没有把最终 `function_call.name` 合并回工具调用。
4. Responses API 的 `item.id` 和 `call_id` 语义不同：前者适合作为本地流式合并键，后者才是后续 `function_call_output` 需要回传的调用 id。
5. provider 序列化层没有区分 reasoning 的来源 provider，导致 provider-specific reasoning 被跨 provider 复用。

## 修复

1. 调整 `Tool.merge()` 的字符串合并策略，空增量不覆盖已有字段，完整 done 字段不重复拼接，分片字段继续合并。
2. 旧工具消息迁移时，用匹配的 `ToolResult.toolName` 补齐空的 `ToolCall` / `Tool.toolName`。
3. Responses API 补处理 `function_call` 的 done 事件：继续用 `item.id` 作为本地流式合并键，同时把真实 `call_id` 存入内部 metadata，历史序列化 `function_call` / `function_call_output` 时优先回传该 `call_id`。
4. 工具分组时只序列化已执行且 `toolName` 非空的工具，避免向 Gemini 发送非法空 `name`；新格式里仍无法恢复名称的空工具名会跳过，不猜测为 `memory_tool`。
5. 在 OpenAI Chat Completions、OpenAI Responses、Claude 序列化层隔离历史 reasoning：仅同 provider 配置或旧 `modelId == null` 消息会按当前 provider 原生 reasoning 格式回传。
6. 保持 GoogleProvider 现状：不上传历史 `UIMessagePart.Reasoning` 文本，只保留已有工具 thought signature 相关逻辑。

## 测试

- `git diff --check`
- `./gradlew :ai:testDebugUnitTest`

补充覆盖：

1. `memory_tool` 历史结果进入 Gemini 时保留 `functionResponse.name`。
2. 旧 `ToolCall(toolName = "")` + `ToolResult(toolName = "memory_tool")` 经迁移后进入 Gemini 真实链路，能生成 `functionResponse.name = "memory_tool"`。
3. 空工具名不会生成非法 Gemini `functionCall` / `functionResponse`，周围普通文本仍保留。
4. Responses API 流式 done 事件能补齐工具名且不重复参数；当 `id = "fc_1"`、`call_id = "call_1"` 时，本地只保留一个 tool，历史回传使用 `call_id = "call_1"`。
5. 旧 `ToolResult.toolName` 能补齐空调用名。
6. OpenAI Chat、Responses、Claude 会过滤外部 provider reasoning，并保留同 provider 配置内的 reasoning。
7. `ProviderMessageUtilsTest` 直接覆盖 `modelId == null`、当前模型、同 provider 配置、外部 provider 四种 reasoning 判断。
