### PR TITLE
fix: apply model custom params to background generation

### DIFF
--- a/app/src/main/java/me/rerere/rikkahub/service/ChatService.kt
+++ b/app/src/main/java/me/rerere/rikkahub/service/ChatService.kt
@@ -35,6 +35,7 @@ import kotlinx.serialization.json.jsonObject
 import me.rerere.ai.core.MessageRole
 import me.rerere.ai.core.ReasoningLevel
 import me.rerere.ai.core.Tool
+import me.rerere.ai.provider.Model
 import me.rerere.ai.provider.ModelAbility
 import me.rerere.ai.provider.ProviderManager
 import me.rerere.ai.provider.TextGenerationParams
@@ -92,6 +93,16 @@ import java.util.concurrent.ConcurrentHashMap
 import kotlin.uuid.Uuid
 
 private const val TAG = "ChatService"
+
+internal fun backgroundTextGenerationParams(
+    model: Model,
+    reasoningLevel: ReasoningLevel = ReasoningLevel.OFF,
+): TextGenerationParams = TextGenerationParams(
+    model = model,
+    reasoningLevel = reasoningLevel,
+    customHeaders = model.customHeaders,
+    customBody = model.customBodies,
+)
 
 data class ChatError(
     val id: Uuid = Uuid.random(),
@@ -721,10 +732,7 @@ class ChatService(
                                 .takeLast(4).joinToString("\n\n") { it.summaryAsText() })
                     ),
                 ),
-                params = TextGenerationParams(
-                    model = model,
-                    reasoningLevel = ReasoningLevel.OFF,
-                ),
+                params = backgroundTextGenerationParams(model),
             )
 
             // 生成完，conversation可能不是最新了，因此需要重新获取
@@ -772,10 +780,7 @@ class ChatService(
                                 .takeLast(8).joinToString("\n\n") { it.summaryAsText() }),
                     )
                 ),
-                params = TextGenerationParams(
-                    model = model,
-                    reasoningLevel = ReasoningLevel.OFF,
-                ),
+                params = backgroundTextGenerationParams(model),
             )
             val suggestions =
                 result.choices[0].message?.toText()?.split("\n")?.map { it.trim() }
@@ -855,9 +860,7 @@ class ChatService(
             val result = providerHandler.generateText(
                 providerSetting = provider,
                 messages = listOf(UIMessage.user(prompt)),
-                params = TextGenerationParams(
-                    model = model,
-                ),
+                params = backgroundTextGenerationParams(model),
             )
 
             return result.choices[0].message?.toText()?.trim()

--- a/app/src/test/java/me/rerere/rikkahub/service/ChatServiceTest.kt
+++ b/app/src/test/java/me/rerere/rikkahub/service/ChatServiceTest.kt
@@ -1,0 +1,29 @@
+package me.rerere.rikkahub.service
+
+import kotlinx.serialization.json.JsonPrimitive
+import me.rerere.ai.core.ReasoningLevel
+import me.rerere.ai.provider.CustomBody
+import me.rerere.ai.provider.CustomHeader
+import me.rerere.ai.provider.Model
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ChatServiceTest {
+    @Test
+    fun `background generation params include model custom request configuration`() {
+        val headers = listOf(CustomHeader(name = "X-Gateway-Token", value = "test-token"))
+        val bodies = listOf(CustomBody(key = "gateway_mode", value = JsonPrimitive("strict")))
+        val model = Model(
+            modelId = "custom-chat-model",
+            customHeaders = headers,
+            customBodies = bodies,
+        )
+
+        val params = backgroundTextGenerationParams(model)
+
+        assertEquals(model, params.model)
+        assertEquals(ReasoningLevel.OFF, params.reasoningLevel)
+        assertEquals(headers, params.customHeaders)
+        assertEquals(bodies, params.customBody)
+    }
+}


### PR DESCRIPTION
## Summary

- apply model-level custom headers/custom body to automatic title generation
- apply the same model request configuration to chat suggestions and compression
- add unit coverage for background text generation params

Fixes #1281.

## Test

- `./gradlew :app:testDebugUnitTest --tests 'me.rerere.rikkahub.service.ChatServiceTest'`
- `./gradlew :app:assembleDebug`
- Installed `me.rerere.rikkahub.debug` on Android 16 SM-X730 and verified against a local OpenAI-compatible mock server that returns 403 unless the model custom header is present. Both the streaming chat request and automatic title-generation request included the custom header and succeeded.

Note: `./gradlew :app:testDebugUnitTest` currently has unrelated failures on my checkout in existing `ShareSheetTest` and `TimeReminderTransformerTest` cases.
