### PR TITLE
fix: filter out MCP configs with empty name to prevent SDK crash

### DIFF
--- a/app/src/main/java/me/rerere/rikkahub/data/ai/mcp/McpManager.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/ai/mcp/McpManager.kt
@@ -89,7 +89,7 @@ class McpManager(
                 .collect { mcpServerConfigs ->
                     runCatching {
                         Log.i(TAG, "update configs: $mcpServerConfigs")
-                        val newConfigs = mcpServerConfigs.filter { it.commonOptions.enable }
+                        val newConfigs = mcpServerConfigs.filter { it.commonOptions.enable && it.commonOptions.name.isNotBlank() }
                         val currentConfigs = clients.keys.toList()
                         val (toAdd, toRemove) = currentConfigs.checkDifferent(
                             other = newConfigs,

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingMcpPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingMcpPage.kt
@@ -223,7 +223,7 @@ fun SettingMcpPage(vm: SettingVM = koinViewModel()) {
             onDismiss = { showImportDialog = false },
             onImport = { newConfigs ->
                 val existingIds = mcpConfigs.map { it.commonOptions.name }.toSet()
-                val toAdd = newConfigs.filter { it.commonOptions.name !in existingIds }
+                val toAdd = newConfigs.filter { it.commonOptions.name.isNotBlank() && it.commonOptions.name !in existingIds }
                 vm.updateSettings(settings.copy(mcpServers = mcpConfigs + toAdd))
                 showImportDialog = false
             }


### PR DESCRIPTION

## Bug Description

When adding an MCP server manually, the app occasionally throws "name is empty" error from the MCP Kotlin SDK, even though the user had entered a valid name.

## Root Cause

In McpManager, the deduplication logic uses `commonOptions.name` as a unique ID:

```kotlin
val existingIds = mcpConfigs.map { it.commonOptions.name }.toSet()
val toAdd = newConfigs.filter { it.commonOptions.name !in existingIds }
```

If a config with name = "" exists (e.g. created but not completed), "" !in existingIds is always true, causing it to be repeatedly passed to addClient(). The MCP SDK then throws "name is empty" when constructing the Implementation object.

Fix

Add a isNotBlank() guard at two points to filter out configs with empty names before they reach the SDK:

```kotlin
// Line ~92: filter before processing
val newConfigs = mcpServerConfigs.filter { 
    it.commonOptions.enable && it.commonOptions.name.isNotBlank() 
}

// Line ~225: filter during deduplication  
val toAdd = newConfigs.filter { 
    it.commonOptions.name.isNotBlank() && it.commonOptions.name !in existingIds 
}
```

Reproduction Steps

1. Manually add an MCP server (fill in name and URL)
2. Save — connection shows green dot but reports "name is empty"
3. Using JSON import with identical config works correctly

Impact

No functional change for valid configs. Prevents SDK crash caused by empty-name configs silently passing through the pipeline.

```

---
