### PR TITLE
chore: 移除模型内置工具设置页面中的 Google 搜索选项

### DIFF
--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingProviderDetailPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingProviderDetailPage.kt
@@ -1369,10 +1369,6 @@ private fun BuiltInToolsSettings(
         )
 
         val availableTools = listOf(
-            BuiltInTools.Search to Pair(
-                stringResource(R.string.setting_page_built_in_tools_search),
-                stringResource(R.string.setting_page_built_in_tools_search_desc)
-            ),
             BuiltInTools.UrlContext to Pair(
                 stringResource(R.string.setting_page_built_in_tools_url_context),
                 stringResource(R.string.setting_page_built_in_tools_url_context_desc)

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -763,7 +763,6 @@
   <string name="setting_page_built_in_tools_image_generation">画像生成</string>
   <string name="setting_page_built_in_tools_image_generation_desc">画像生成機能を有効にする</string>
   <string name="setting_page_built_in_tools_search">検索</string>
-  <string name="setting_page_built_in_tools_search_desc">Google検索連携を有効化</string>
   <string name="setting_page_built_in_tools_url_context">URLコンテキスト</string>
   <string name="setting_page_built_in_tools_url_context_desc">URLコンテンツ処理を有効化</string>
   <string name="setting_page_chat_storage">チャット保存</string>

--- a/app/src/main/res/values-ko-rKR/strings.xml
+++ b/app/src/main/res/values-ko-rKR/strings.xml
@@ -763,7 +763,6 @@
   <string name="setting_page_built_in_tools_image_generation">이미지 생성</string>
   <string name="setting_page_built_in_tools_image_generation_desc">이미지 생성 기능 활성화</string>
   <string name="setting_page_built_in_tools_search">검색</string>
-  <string name="setting_page_built_in_tools_search_desc">Google 검색 통합 활성화</string>
   <string name="setting_page_built_in_tools_url_context">URL 컨텍스트</string>
   <string name="setting_page_built_in_tools_url_context_desc">URL 콘텐츠 처리 활성화</string>
   <string name="setting_page_chat_storage">채팅 저장 공간</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -763,7 +763,6 @@
   <string name="setting_page_built_in_tools_image_generation">Генерация изображений</string>
   <string name="setting_page_built_in_tools_image_generation_desc">Включить возможность генерации изображений</string>
   <string name="setting_page_built_in_tools_search">Поиск</string>
-  <string name="setting_page_built_in_tools_search_desc">Включить интеграцию с Google Поиском</string>
   <string name="setting_page_built_in_tools_url_context">Контекст URL</string>
   <string name="setting_page_built_in_tools_url_context_desc">Включить обработку содержимого по URL</string>
   <string name="setting_page_chat_storage">Хранилище чатов</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -763,7 +763,6 @@
   <string name="setting_page_built_in_tools_image_generation">圖像生成</string>
   <string name="setting_page_built_in_tools_image_generation_desc">啟用圖片生成功能</string>
   <string name="setting_page_built_in_tools_search">搜尋</string>
-  <string name="setting_page_built_in_tools_search_desc">啟用 Google 搜尋整合</string>
   <string name="setting_page_built_in_tools_url_context">URL 上下文</string>
   <string name="setting_page_built_in_tools_url_context_desc">啟用 URL 內容處理</string>
   <string name="setting_page_chat_storage">聊天記錄儲存</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -770,7 +770,6 @@
   <string name="setting_page_built_in_tools_image_generation">图像生成</string>
   <string name="setting_page_built_in_tools_image_generation_desc">启用图像生成功能</string>
   <string name="setting_page_built_in_tools_search">搜索</string>
-  <string name="setting_page_built_in_tools_search_desc">启用 Google 搜索集成</string>
   <string name="setting_page_built_in_tools_url_context">URL 上下文</string>
   <string name="setting_page_built_in_tools_url_context_desc">启用 URL 内容处理</string>
   <string name="setting_page_chat_storage">聊天记录存储</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -773,7 +773,6 @@
   <string name="setting_page_built_in_tools_image_generation">Image Generation</string>
   <string name="setting_page_built_in_tools_image_generation_desc">Enable image generation capability</string>
   <string name="setting_page_built_in_tools_search">Search</string>
-  <string name="setting_page_built_in_tools_search_desc">Enable Google Search integration</string>
   <string name="setting_page_built_in_tools_url_context">URL Context</string>
   <string name="setting_page_built_in_tools_url_context_desc">Enable URL content processing</string>
   <string name="setting_page_chat_storage">Chat Storage</string>


### PR DESCRIPTION
移除提供商页面中的模型内置搜索启用入口，**避免用户意外对非 Gemini 官方 API 的模型启用该选项**，导致聊天框的搜索设置中的第三方搜索工具不会显示。
此外，保留了 BuiltInTools 中的 Search 对象，因为当前选中模型为 Gemini 系列时**该功能仍可在聊天框的搜索设置中启用**（提供商页面的选项和这个页面的选项本身也算是重复了，保留此处的足矣）。