### PR TITLE
feat(search): 搜索结果支持按日期排序

### DIFF
--- a/app/src/main/java/me/rerere/rikkahub/data/db/fts/MessageFtsManager.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/db/fts/MessageFtsManager.kt
@@ -19,6 +19,12 @@ data class MessageSearchResult(
     val snippet: String,
 )
 
+enum class MessageSearchSort(val orderBy: String) {
+    RELEVANCE("rank, update_at DESC"),
+    NEWEST_FIRST("update_at DESC, rank"),
+    OLDEST_FIRST("update_at ASC, rank"),
+}
+
 private const val TAG = "MessageFtsManager"
 
 class MessageFtsManager(private val database: AppDatabase) {
@@ -56,7 +62,10 @@ class MessageFtsManager(private val database: AppDatabase) {
         db.execSQL("DELETE FROM message_fts")
     }
 
-    suspend fun search(keyword: String): List<MessageSearchResult> = withContext(Dispatchers.IO) {
+    suspend fun search(
+        keyword: String,
+        sort: MessageSearchSort = MessageSearchSort.RELEVANCE,
+    ): List<MessageSearchResult> = withContext(Dispatchers.IO) {
         val results = mutableListOf<MessageSearchResult>()
         val cursor = db.query(
             """
@@ -64,7 +73,7 @@ class MessageFtsManager(private val database: AppDatabase) {
                    simple_snippet(message_fts, 0, '[', ']', '...', 30) AS snippet
             FROM message_fts
             WHERE text MATCH jieba_query(?)
-            ORDER BY rank, update_at DESC
+            ORDER BY ${sort.orderBy}
             LIMIT 50
             """.trimIndent(),
             arrayOf(keyword)

--- a/app/src/main/java/me/rerere/rikkahub/data/repository/ConversationRepository.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/repository/ConversationRepository.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.flow.map
 import me.rerere.ai.ui.UIMessage
 import me.rerere.rikkahub.data.db.AppDatabase
 import me.rerere.rikkahub.data.db.fts.MessageFtsManager
+import me.rerere.rikkahub.data.db.fts.MessageSearchSort
 import me.rerere.rikkahub.data.db.dao.ConversationDAO
 import me.rerere.rikkahub.data.db.dao.FavoriteDAO
 import me.rerere.rikkahub.data.db.dao.MessageNodeDAO
@@ -241,7 +242,10 @@ class ConversationRepository(
         filesManager.deleteChatFiles(fullConversation.files)
     }
 
-    suspend fun searchMessages(keyword: String) = messageFtsManager.search(keyword)
+    suspend fun searchMessages(
+        keyword: String,
+        sort: MessageSearchSort = MessageSearchSort.RELEVANCE,
+    ) = messageFtsManager.search(keyword, sort)
 
     suspend fun rebuildAllIndexes(onProgress: (current: Int, total: Int) -> Unit = { _, _ -> }) {
         messageFtsManager.deleteAll()

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/search/SearchPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/search/SearchPage.kt
@@ -2,6 +2,7 @@ package me.rerere.rikkahub.ui.pages.search
 
 import me.rerere.hugeicons.HugeIcons
 import me.rerere.hugeicons.stroke.Refresh01
+import me.rerere.hugeicons.stroke.Sorting01
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -23,9 +24,12 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.LargeFlexibleTopAppBar
+import androidx.compose.material3.RadioButton
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -46,6 +50,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.res.stringResource
 import me.rerere.rikkahub.R
 import me.rerere.rikkahub.data.db.fts.MessageSearchResult
+import me.rerere.rikkahub.data.db.fts.MessageSearchSort
 import me.rerere.rikkahub.ui.components.nav.BackButton
 import me.rerere.rikkahub.ui.context.LocalNavController
 import me.rerere.rikkahub.ui.theme.CustomColors
@@ -97,6 +102,10 @@ fun SearchPage(vm: SearchVM = koinViewModel()) {
                 navigationIcon = { BackButton() },
                 title = { Text(stringResource(R.string.search_page_title)) },
                 actions = {
+                    SortMenuButton(
+                        current = vm.sortOrder,
+                        onSortChange = { vm.onSortChange(it) },
+                    )
                     IconButton(
                         onClick = { showRebuildDialog = true },
                         enabled = !vm.isRebuilding,
@@ -205,6 +214,52 @@ fun SearchPage(vm: SearchVM = koinViewModel()) {
                         }
                     }
                 }
+            }
+        }
+    }
+}
+
+@Composable
+private fun SortMenuButton(
+    current: MessageSearchSort,
+    onSortChange: (MessageSearchSort) -> Unit,
+) {
+    var expanded by remember { mutableStateOf(false) }
+    Box {
+        IconButton(onClick = { expanded = true }) {
+            Icon(
+                HugeIcons.Sorting01,
+                contentDescription = stringResource(R.string.search_page_sort)
+            )
+        }
+        DropdownMenu(
+            expanded = expanded,
+            onDismissRequest = { expanded = false },
+        ) {
+            MessageSearchSort.entries.forEach { sort ->
+                DropdownMenuItem(
+                    text = {
+                        Text(
+                            stringResource(
+                                when (sort) {
+                                    MessageSearchSort.RELEVANCE -> R.string.search_page_sort_relevance
+                                    MessageSearchSort.NEWEST_FIRST -> R.string.search_page_sort_newest
+                                    MessageSearchSort.OLDEST_FIRST -> R.string.search_page_sort_oldest
+                                }
+                            )
+                        )
+                    },
+                    leadingIcon = {
+                        RadioButton(
+                            selected = sort == current,
+                            onClick = null,
+                        )
+                    },
+                    onClick = {
+                        expanded = false
+                        onSortChange(sort)
+                    },
+                )
             }
         }
     }

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/search/SearchVM.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/search/SearchVM.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.launch
 import me.rerere.rikkahub.data.db.fts.MessageSearchResult
+import me.rerere.rikkahub.data.db.fts.MessageSearchSort
 import me.rerere.rikkahub.data.repository.ConversationRepository
 
 class SearchVM(
@@ -18,6 +19,8 @@ class SearchVM(
     private val _searchQuery = MutableStateFlow("")
 
     var searchQuery by mutableStateOf("")
+        private set
+    var sortOrder by mutableStateOf(MessageSearchSort.RELEVANCE)
         private set
     var results by mutableStateOf<List<MessageSearchResult>>(emptyList())
         private set
@@ -39,6 +42,14 @@ class SearchVM(
     fun onQueryChange(query: String) {
         searchQuery = query
         _searchQuery.value = query
+    }
+
+    fun onSortChange(sort: MessageSearchSort) {
+        if (sortOrder == sort) return
+        sortOrder = sort
+        viewModelScope.launch {
+            performSearch(searchQuery)
+        }
     }
 
     fun search() {
@@ -68,7 +79,7 @@ class SearchVM(
         }
         isLoading = true
         try {
-            results = conversationRepo.searchMessages(query)
+            results = conversationRepo.searchMessages(query, sortOrder)
         } finally {
             isLoading = false
         }

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/search/SearchVM.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/search/SearchVM.kt
@@ -3,6 +3,7 @@ package me.rerere.rikkahub.ui.pages.search
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
+import android.app.Application
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -12,15 +13,26 @@ import kotlinx.coroutines.launch
 import me.rerere.rikkahub.data.db.fts.MessageSearchResult
 import me.rerere.rikkahub.data.db.fts.MessageSearchSort
 import me.rerere.rikkahub.data.repository.ConversationRepository
+import me.rerere.rikkahub.ui.hooks.readStringPreference
+import me.rerere.rikkahub.ui.hooks.writeStringPreference
+
+private const val SORT_ORDER_PREF_KEY = "search_page_sort_order"
 
 class SearchVM(
+    private val context: Application,
     private val conversationRepo: ConversationRepository,
 ) : ViewModel() {
     private val _searchQuery = MutableStateFlow("")
 
     var searchQuery by mutableStateOf("")
         private set
-    var sortOrder by mutableStateOf(MessageSearchSort.RELEVANCE)
+    var sortOrder by mutableStateOf(
+        runCatching {
+            MessageSearchSort.valueOf(
+                context.readStringPreference(SORT_ORDER_PREF_KEY, MessageSearchSort.RELEVANCE.name)!!
+            )
+        }.getOrDefault(MessageSearchSort.RELEVANCE)
+    )
         private set
     var results by mutableStateOf<List<MessageSearchResult>>(emptyList())
         private set
@@ -47,6 +59,7 @@ class SearchVM(
     fun onSortChange(sort: MessageSearchSort) {
         if (sortOrder == sort) return
         sortOrder = sort
+        context.writeStringPreference(SORT_ORDER_PREF_KEY, sort.name)
         viewModelScope.launch {
             performSearch(searchQuery)
         }

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -589,6 +589,10 @@
   <string name="search_page_rebuild_index_desc">既存のインデックスをクリアし、すべてのチャット履歴を再スキャンします。メッセージが多いほど時間がかかります。続行しますか？</string>
   <string name="search_page_rebuilding">インデックスを再構築中 (%1$d / %2$d)…</string>
   <string name="search_page_rebuilding_simple">インデックスを再構築中…</string>
+  <string name="search_page_sort">並び替え</string>
+  <string name="search_page_sort_newest">新しい順</string>
+  <string name="search_page_sort_oldest">古い順</string>
+  <string name="search_page_sort_relevance">関連度</string>
   <string name="search_page_title">メッセージを検索</string>
   <string name="search_page_untitled">無題</string>
   <string name="search_picker_title">検索設定</string>

--- a/app/src/main/res/values-ko-rKR/strings.xml
+++ b/app/src/main/res/values-ko-rKR/strings.xml
@@ -589,6 +589,10 @@
   <string name="search_page_rebuild_index_desc">기존 색인을 삭제하고 모든 채팅 기록을 다시 검색합니다. 메시지가 많을수록 시간이 오래 걸립니다. 계속하시겠습니까?</string>
   <string name="search_page_rebuilding">색인 재구성 중 (%1$d / %2$d)...</string>
   <string name="search_page_rebuilding_simple">색인 재구성 중...</string>
+  <string name="search_page_sort">정렬</string>
+  <string name="search_page_sort_newest">최신순</string>
+  <string name="search_page_sort_oldest">오래된순</string>
+  <string name="search_page_sort_relevance">관련성</string>
   <string name="search_page_title">메시지 검색</string>
   <string name="search_page_untitled">제목 없음</string>
   <string name="search_picker_title">검색 설정</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -589,6 +589,10 @@
   <string name="search_page_rebuild_index_desc">Это удалит существующий индекс и повторно просканирует всю историю чатов. Чем больше сообщений, тем дольше займет. Продолжить?</string>
   <string name="search_page_rebuilding">Пересоздание индекса (%1$d / %2$d)…</string>
   <string name="search_page_rebuilding_simple">Пересоздание индекса…</string>
+  <string name="search_page_sort">Сортировка</string>
+  <string name="search_page_sort_newest">Сначала новые</string>
+  <string name="search_page_sort_oldest">Сначала старые</string>
+  <string name="search_page_sort_relevance">По релевантности</string>
   <string name="search_page_title">Поиск сообщений</string>
   <string name="search_page_untitled">Без названия</string>
   <string name="search_picker_title">Поиск настроек</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -589,6 +589,10 @@
   <string name="search_page_rebuild_index_desc">這將清除現有索引並重新掃描所有聊天記錄。訊息越多，所需時間越長。是否繼續？</string>
   <string name="search_page_rebuilding">正在重建索引 (%1$d / %2$d)…</string>
   <string name="search_page_rebuilding_simple">正在重建索引…</string>
+  <string name="search_page_sort">排序</string>
+  <string name="search_page_sort_newest">最新優先</string>
+  <string name="search_page_sort_oldest">最舊優先</string>
+  <string name="search_page_sort_relevance">相關性</string>
   <string name="search_page_title">搜尋訊息</string>
   <string name="search_page_untitled">無標題</string>
   <string name="search_picker_title">搜尋設定</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -589,6 +589,10 @@
   <string name="search_page_rebuild_index_desc">这将清除现有索引并重新扫描所有聊天记录。消息越多，耗时越长。是否继续？</string>
   <string name="search_page_rebuilding">正在重建索引 (%1$d / %2$d)…</string>
   <string name="search_page_rebuilding_simple">正在重建索引…</string>
+  <string name="search_page_sort">排序</string>
+  <string name="search_page_sort_newest">最新优先</string>
+  <string name="search_page_sort_oldest">最旧优先</string>
+  <string name="search_page_sort_relevance">相关性</string>
   <string name="search_page_title">搜索消息</string>
   <string name="search_page_untitled">无标题</string>
   <string name="search_picker_title">搜索设置</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -589,6 +589,10 @@
   <string name="search_page_rebuild_index_desc">This will clear the existing index and re-scan all chat history. The more messages, the longer it takes. Continue?</string>
   <string name="search_page_rebuilding">Rebuilding index (%1$d / %2$d)...</string>
   <string name="search_page_rebuilding_simple">Rebuilding index...</string>
+  <string name="search_page_sort">Sort</string>
+  <string name="search_page_sort_newest">Newest first</string>
+  <string name="search_page_sort_oldest">Oldest first</string>
+  <string name="search_page_sort_relevance">Relevance</string>
   <string name="search_page_title">Search Messages</string>
   <string name="search_page_untitled">Untitled</string>
   <string name="search_picker_title">Search Settings</string>


### PR DESCRIPTION
## 功能描述

为全局消息搜索添加排序选项，解决在大量匹配结果中难以找到最近对话的问题。

Closes #1298

## 实现方式

- `MessageFtsManager` 新增 `MessageSearchSort` 枚举（相关性 / 最新优先 / 最旧优先），排序在 FTS SQL 查询层生效，保证 LIMIT 截断前就按所选顺序取结果
- `SearchVM` 新增排序状态，切换排序立即重新搜索
- **排序选择持久化**到 SharedPreferences，下次进入搜索页保持上次的排序方式
- 搜索页顶栏新增排序菜单（HugeIcons.Sorting01 图标 + DropdownMenu + RadioButton），默认仍为相关性排序，与现有 UI 风格一致
- 新增字符串资源覆盖全部 6 种语言（en/zh/zh-rTW/ja/ko/ru）

## 测试

- 本地 `:app:compileDebugKotlin` 编译通过
- 已在本地构建 APK 实测