### PR TITLE
feat(ui): 界面体验改进——沉浸模式、发送不跳转、音量键翻页恢复修复

### DIFF
--- a/app/src/main/java/me/rerere/rikkahub/RouteActivity.kt
+++ b/app/src/main/java/me/rerere/rikkahub/RouteActivity.kt
@@ -37,6 +37,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.core.net.toUri
+import androidx.core.view.WindowCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.WindowInsetsControllerCompat
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.navigation3.rememberViewModelStoreNavEntryDecorator
 import androidx.navigation3.runtime.NavKey
@@ -191,6 +194,25 @@ class RouteActivity : ComponentActivity() {
         }
     }
 
+    internal fun applyImmersiveMode(enabled: Boolean) {
+        val controller = WindowCompat.getInsetsController(window, window.decorView)
+        controller.systemBarsBehavior =
+            WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
+        if (enabled) {
+            controller.hide(WindowInsetsCompat.Type.statusBars())
+        } else {
+            controller.show(WindowInsetsCompat.Type.statusBars())
+        }
+    }
+
+    override fun onWindowFocusChanged(hasFocus: Boolean) {
+        super.onWindowFocusChanged(hasFocus)
+        // 重新获得焦点时, 系统可能恢复状态栏, 需要重新应用沉浸模式
+        if (hasFocus) {
+            applyImmersiveMode(settingsStore.settingsFlow.value.displaySetting.enableImmersiveMode)
+        }
+    }
+
     @Composable
     private fun ShareHandler(backStack: MutableList<NavKey>) {
         val shareIntent = remember {
@@ -229,6 +251,9 @@ class RouteActivity : ComponentActivity() {
     fun AppRoutes() {
         val toastState = rememberToasterState()
         val settings by settingsStore.settingsFlow.collectAsStateWithLifecycle()
+        LaunchedEffect(settings.displaySetting.enableImmersiveMode) {
+            applyImmersiveMode(settings.displaySetting.enableImmersiveMode)
+        }
         val tts = rememberCustomTtsState()
         val asr = rememberCustomAsrState()
         val eventBus = koinInject<AppEventBus>()

--- a/app/src/main/java/me/rerere/rikkahub/RouteActivity.kt
+++ b/app/src/main/java/me/rerere/rikkahub/RouteActivity.kt
@@ -5,6 +5,7 @@ import android.content.Intent
 import android.os.Build
 import android.os.Bundle
 import android.view.KeyEvent
+import android.view.WindowManager
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
@@ -199,8 +200,16 @@ class RouteActivity : ComponentActivity() {
         controller.systemBarsBehavior =
             WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
         if (enabled) {
+            // 通过主题属性使之后创建的对话框窗口继承全屏 (窗口 flag 不会被对话框继承),
+            // 避免 AlertDialog/BottomSheet 等弹窗夺焦时状态栏复现
+            theme.applyStyle(R.style.ThemeOverlay_Rikkahub_Immersive, true)
+            @Suppress("DEPRECATION")
+            window.addFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN)
             controller.hide(WindowInsetsCompat.Type.statusBars())
         } else {
+            theme.applyStyle(R.style.ThemeOverlay_Rikkahub_NonImmersive, true)
+            @Suppress("DEPRECATION")
+            window.clearFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN)
             controller.show(WindowInsetsCompat.Type.statusBars())
         }
     }

--- a/app/src/main/java/me/rerere/rikkahub/data/datastore/PreferencesStore.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/datastore/PreferencesStore.kt
@@ -591,6 +591,7 @@ data class DisplaySetting(
     val pasteLongTextThreshold: Int = 1000,
     val sendOnEnter: Boolean = false,
     val enableAutoScroll: Boolean = true,
+    val scrollToBottomOnSend: Boolean = true,
     val enableLatexRendering: Boolean = true,
     val enableBlurEffect: Boolean = false,
     val chatFontFamily: ChatFontFamily = ChatFontFamily.DEFAULT,

--- a/app/src/main/java/me/rerere/rikkahub/data/datastore/PreferencesStore.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/datastore/PreferencesStore.kt
@@ -593,6 +593,7 @@ data class DisplaySetting(
     val enableAutoScroll: Boolean = true,
     val enableLatexRendering: Boolean = true,
     val enableBlurEffect: Boolean = false,
+    val enableImmersiveMode: Boolean = false,
     val chatFontFamily: ChatFontFamily = ChatFontFamily.DEFAULT,
     val chatCustomFontPath: String = "",
     val chatCustomFontName: String = "",

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ChatList.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ChatList.kt
@@ -215,14 +215,19 @@ private fun ChatListNormal(
     val density = LocalDensity.current
     val activity = LocalContext.current as? me.rerere.rikkahub.RouteActivity
 
+    // 用 rememberUpdatedState 保证监听器读取最新值: DisposableEffect(Unit) 的 lambda
+    // 只捕获首次组合时的对象, 冷启动恢复会话时设置尚未加载完成(翻页开关为默认关闭),
+    // 否则监听器会永远返回 false, 导致音量键翻页失效, 必须切换对话才能恢复
+    val settingsUpdated by rememberUpdatedState(settings)
+    val innerPaddingUpdated by rememberUpdatedState(innerPadding)
     DisposableEffect(Unit) {
         val listener: (Boolean) -> Boolean = { isVolumeUp ->
-            if (settings.displaySetting.enableVolumeKeyScroll) {
+            if (settingsUpdated.displaySetting.enableVolumeKeyScroll) {
                 val bottomPaddingPx = with(density) {
-                    (32.dp + innerPadding.calculateBottomPadding()).toPx()
+                    (32.dp + innerPaddingUpdated.calculateBottomPadding()).toPx()
                 }
                 val scrollAmount = (state.layoutInfo.viewportSize.height - bottomPaddingPx) *
-                    settings.displaySetting.volumeKeyScrollRatio
+                    settingsUpdated.displaySetting.volumeKeyScrollRatio
                 scope.launch { state.scrollBy(if (isVolumeUp) -scrollAmount else scrollAmount) }
                 true
             } else false

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ChatPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ChatPage.kt
@@ -304,8 +304,10 @@ private fun ChatPageContent(
                             )
                         } else {
                             vm.handleMessageSend(inputState.getContents())
-                            scope.launch {
-                                chatListState.requestScrollToItem(conversation.currentMessages.size + 5)
+                            if (setting.displaySetting.scrollToBottomOnSend) {
+                                scope.launch {
+                                    chatListState.requestScrollToItem(conversation.currentMessages.size + 5)
+                                }
                             }
                         }
                         inputState.clearInput()
@@ -318,8 +320,10 @@ private fun ChatPageContent(
                             )
                         } else {
                             vm.handleMessageSend(content = inputState.getContents(), answer = false)
-                            scope.launch {
-                                chatListState.requestScrollToItem(conversation.currentMessages.size + 5)
+                            if (setting.displaySetting.scrollToBottomOnSend) {
+                                scope.launch {
+                                    chatListState.requestScrollToItem(conversation.currentMessages.size + 5)
+                                }
                             }
                         }
                         inputState.clearInput()

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingPreferencesGeneralPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingPreferencesGeneralPage.kt
@@ -135,6 +135,18 @@ fun SettingPreferencesGeneralPage(vm: SettingVM = koinViewModel()) {
                         },
                     )
                     item(
+                        headlineContent = { Text(stringResource(R.string.setting_display_page_scroll_to_bottom_on_send_title)) },
+                        supportingContent = { Text(stringResource(R.string.setting_display_page_scroll_to_bottom_on_send_desc)) },
+                        trailingContent = {
+                            Switch(
+                                checked = displaySetting.scrollToBottomOnSend,
+                                onCheckedChange = {
+                                    updateDisplaySetting(displaySetting.copy(scrollToBottomOnSend = it))
+                                }
+                            )
+                        },
+                    )
+                    item(
                         headlineContent = { Text(stringResource(R.string.setting_display_page_use_app_icon_style_loading_indicator_title)) },
                         supportingContent = {
                             Text(stringResource(R.string.setting_display_page_use_app_icon_style_loading_indicator_desc))

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingPreferencesGeneralPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingPreferencesGeneralPage.kt
@@ -161,6 +161,18 @@ fun SettingPreferencesGeneralPage(vm: SettingVM = koinViewModel()) {
                         },
                     )
                     item(
+                        headlineContent = { Text(stringResource(R.string.setting_display_page_immersive_mode_title)) },
+                        supportingContent = { Text(stringResource(R.string.setting_display_page_immersive_mode_desc)) },
+                        trailingContent = {
+                            Switch(
+                                checked = displaySetting.enableImmersiveMode,
+                                onCheckedChange = {
+                                    updateDisplaySetting(displaySetting.copy(enableImmersiveMode = it))
+                                }
+                            )
+                        },
+                    )
+                    item(
                         headlineContent = { Text(stringResource(R.string.setting_display_page_enable_message_generation_haptic_effect_title)) },
                         supportingContent = { Text(stringResource(R.string.setting_display_page_enable_message_generation_haptic_effect_desc)) },
                         trailingContent = {

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -662,6 +662,8 @@
   <string name="setting_display_page_paste_long_text_as_file_desc">テキストを貼り付けた際にしきい値を超える場合、自動的にファイル添付として保存します</string>
   <string name="setting_display_page_paste_long_text_as_file_title">長いテキストをファイルとして貼り付け</string>
   <string name="setting_display_page_paste_long_text_threshold_title">文字数しきい値</string>
+  <string name="setting_display_page_scroll_to_bottom_on_send_desc">メッセージ送信時に最新メッセージへ自動的に移動します。オフにすると現在の閲覧位置を保持します</string>
+  <string name="setting_display_page_scroll_to_bottom_on_send_title">送信時に最新メッセージへ移動</string>
   <string name="setting_display_page_send_on_enter_desc">Enterキーでメッセージを送信し、改行しない</string>
   <string name="setting_display_page_send_on_enter_title">Enterキーで送信</string>
   <string name="setting_display_page_show_assistant_bubble_desc">アシスタントメッセージのバブル背景を表示するかどうか</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -653,6 +653,8 @@
   <string name="setting_display_page_enable_message_generation_haptic_effect_title">メッセージ生成時の触覚効果</string>
   <string name="setting_display_page_font_size_preview">午前4時、海棠の花がまだ眠っていないのを見た。私はよくこうして、誰もいない夜にひとり目を覚まし、思う——もし今この瞬間、誰かが私のことを思っていてくれたなら、それだけでいい。</string>
   <string name="setting_display_page_font_size_title">チャットフォントサイズ</string>
+  <string name="setting_display_page_immersive_mode_desc">ステータスバーを非表示にして全画面表示にします。画面上端からスワイプすると一時的に表示されます</string>
+  <string name="setting_display_page_immersive_mode_title">没入モード</string>
   <string name="setting_display_page_live_update_notification">ライブアップデート通知</string>
   <string name="setting_display_page_live_update_notification_desc">メッセージ生成中のリアルタイム通知アップデートを表示（Android 15以降）</string>
   <string name="setting_display_page_message_jumper_position_desc">メッセージジャンパーを左側に移動</string>

--- a/app/src/main/res/values-ko-rKR/strings.xml
+++ b/app/src/main/res/values-ko-rKR/strings.xml
@@ -653,6 +653,8 @@
   <string name="setting_display_page_enable_message_generation_haptic_effect_title">메시지 생성 진동 효과 활성화</string>
   <string name="setting_display_page_font_size_preview">새벽 네 시, 해당화가 잠들지 않은 것을 보았다. 나는 자주 이렇게, 아무도 없는 밤에 홀로 깨어, 생각한다 — 지금 이 순간 누군가도 나를 생각하고 있다면, 그것으로 충분하다.</string>
   <string name="setting_display_page_font_size_title">채팅 글꼴 크기</string>
+  <string name="setting_display_page_immersive_mode_desc">상태 표시줄을 숨겨 전체 화면으로 표시합니다. 화면 상단에서 아래로 스와이프하면 일시적으로 표시됩니다</string>
+  <string name="setting_display_page_immersive_mode_title">몰입 모드</string>
   <string name="setting_display_page_live_update_notification">실시간 업데이트 알림</string>
   <string name="setting_display_page_live_update_notification_desc">메시지 생성 중 실시간 알림 업데이트 표시 (Android 15+)</string>
   <string name="setting_display_page_message_jumper_position_desc">메시지 점퍼를 왼쪽으로 이동</string>

--- a/app/src/main/res/values-ko-rKR/strings.xml
+++ b/app/src/main/res/values-ko-rKR/strings.xml
@@ -662,6 +662,8 @@
   <string name="setting_display_page_paste_long_text_as_file_desc">복사한 텍스트가 임계값을 초과하면 자동으로 파일 첨부로 저장</string>
   <string name="setting_display_page_paste_long_text_as_file_title">긴 텍스트를 파일로 붙여넣기</string>
   <string name="setting_display_page_paste_long_text_threshold_title">텍스트 길이 임계값</string>
+  <string name="setting_display_page_scroll_to_bottom_on_send_desc">메시지 전송 시 최신 메시지로 자동 이동합니다. 끄면 현재 읽던 위치를 유지합니다</string>
+  <string name="setting_display_page_scroll_to_bottom_on_send_title">전송 시 최신 메시지로 이동</string>
   <string name="setting_display_page_send_on_enter_desc">Enter 키를 누르면 줄 바꿈 대신 메시지를 전송합니다</string>
   <string name="setting_display_page_send_on_enter_title">Enter 키로 전송</string>
   <string name="setting_display_page_show_assistant_bubble_desc">어시스턴트 메시지에 말풍선 배경 표시 여부</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -653,6 +653,8 @@
   <string name="setting_display_page_enable_message_generation_haptic_effect_title">Тактильный эффект при генерации сообщения</string>
   <string name="setting_display_page_font_size_preview">Это **пример** текста чата</string>
   <string name="setting_display_page_font_size_title">Размер шрифта чата</string>
+  <string name="setting_display_page_immersive_mode_desc">Скрывает строку состояния для полноэкранного режима; проведите от верхнего края, чтобы временно показать её</string>
+  <string name="setting_display_page_immersive_mode_title">Режим погружения</string>
   <string name="setting_display_page_live_update_notification">Уведомление об обновлении в реальном времени</string>
   <string name="setting_display_page_live_update_notification_desc">Показывать уведомления об обновлениях в реальном времени во время генерации сообщений (Android 15+)</string>
   <string name="setting_display_page_message_jumper_position_desc">Переместить переходчик сообщений влево</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -662,6 +662,8 @@
   <string name="setting_display_page_paste_long_text_as_file_desc">При вставке текста, превышающего порог, автоматически сохранять его как файл-вложение</string>
   <string name="setting_display_page_paste_long_text_as_file_title">Вставлять длинный текст как файл</string>
   <string name="setting_display_page_paste_long_text_threshold_title">Порог длины текста</string>
+  <string name="setting_display_page_scroll_to_bottom_on_send_desc">Автоматически переходить к последнему сообщению при отправке; отключите, чтобы сохранить текущую позицию чтения</string>
+  <string name="setting_display_page_scroll_to_bottom_on_send_title">Переход к последнему при отправке</string>
   <string name="setting_display_page_send_on_enter_desc">Нажмите Enter, чтобы отправить сообщение, а не добавить новую строку</string>
   <string name="setting_display_page_send_on_enter_title">Отправлять по Enter</string>
   <string name="setting_display_page_show_assistant_bubble_desc">Показывать фоновый пузырь для сообщений ассистента</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -662,6 +662,8 @@
   <string name="setting_display_page_paste_long_text_as_file_desc">貼上文字超過上限時，自動儲存為檔案附件</string>
   <string name="setting_display_page_paste_long_text_as_file_title">貼上長文字為檔案</string>
   <string name="setting_display_page_paste_long_text_threshold_title">文字長度閾值</string>
+  <string name="setting_display_page_scroll_to_bottom_on_send_desc">發送訊息時自動跳轉到最新訊息，關閉後保持當前閱讀位置，閱讀體驗更連貫</string>
+  <string name="setting_display_page_scroll_to_bottom_on_send_title">發送時跳轉到最新訊息</string>
   <string name="setting_display_page_send_on_enter_desc">按 Enter 鍵即可傳送訊息，而非換行</string>
   <string name="setting_display_page_send_on_enter_title">按 Enter 鍵傳送</string>
   <string name="setting_display_page_show_assistant_bubble_desc">是否顯示助理訊息的泡泡背景</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -653,6 +653,8 @@
   <string name="setting_display_page_enable_message_generation_haptic_effect_title">訊息生成觸覺回饋</string>
   <string name="setting_display_page_font_size_preview">凌晨四點鐘，看到海棠花未眠。我常常這樣，在無人的夜裡獨自醒著，想，若有人此刻也在想我，那就好了。</string>
   <string name="setting_display_page_font_size_title">聊天字體大小</string>
+  <string name="setting_display_page_immersive_mode_desc">隱藏狀態列獲得全螢幕體驗，從螢幕頂部下滑可暫時呼出</string>
+  <string name="setting_display_page_immersive_mode_title">沉浸模式</string>
   <string name="setting_display_page_live_update_notification">即時更新通知</string>
   <string name="setting_display_page_live_update_notification_desc">在訊息產生期間顯示即時通知更新（Android 15+）</string>
   <string name="setting_display_page_message_jumper_position_desc">將訊息跳轉按鈕移至左側</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -660,6 +660,8 @@
   <string name="setting_display_page_enable_message_generation_haptic_effect_title">消息生成触觉反馈</string>
   <string name="setting_display_page_font_size_preview">凌晨四点钟，看到海棠花未眠。我常常这样，在无人的夜里独自醒着，想，若有人此刻也在想我，那就好了。</string>
   <string name="setting_display_page_font_size_title">聊天字体大小</string>
+  <string name="setting_display_page_immersive_mode_desc">隐藏状态栏获得全屏体验，从屏幕顶部下滑可临时呼出</string>
+  <string name="setting_display_page_immersive_mode_title">沉浸模式</string>
   <string name="setting_display_page_live_update_notification">实时更新通知</string>
   <string name="setting_display_page_live_update_notification_desc">在生成消息时显示实时通知更新（Android 15+）</string>
   <string name="setting_display_page_message_jumper_position_desc">将消息导航移到左侧</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -669,6 +669,8 @@
   <string name="setting_display_page_paste_long_text_as_file_desc">当粘贴的文本超过阈值时，自动将其保存为文件附件</string>
   <string name="setting_display_page_paste_long_text_as_file_title">粘贴长文本为文件</string>
   <string name="setting_display_page_paste_long_text_threshold_title">文本长度阈值</string>
+  <string name="setting_display_page_scroll_to_bottom_on_send_desc">发送消息时自动跳转到最新消息，关闭后保持当前阅读位置，阅读体验更连贯</string>
+  <string name="setting_display_page_scroll_to_bottom_on_send_title">发送时跳转到最新消息</string>
   <string name="setting_display_page_send_on_enter_desc">按 Enter 发送消息而非换行</string>
   <string name="setting_display_page_send_on_enter_title">按Enter发送</string>
   <string name="setting_display_page_show_assistant_bubble_desc">是否为助手消息显示气泡背景</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -669,6 +669,8 @@
   <string name="setting_display_page_paste_long_text_as_file_desc">When pasting text exceeds the threshold, automatically save it as a file attachment</string>
   <string name="setting_display_page_paste_long_text_as_file_title">Paste Long Text as File</string>
   <string name="setting_display_page_paste_long_text_threshold_title">Text Length Threshold</string>
+  <string name="setting_display_page_scroll_to_bottom_on_send_desc">Automatically jump to the latest message when sending; turn off to keep your current reading position</string>
+  <string name="setting_display_page_scroll_to_bottom_on_send_title">Jump to Latest on Send</string>
   <string name="setting_display_page_send_on_enter_desc">Press Enter to send message instead of adding a new line</string>
   <string name="setting_display_page_send_on_enter_title">Send on Enter</string>
   <string name="setting_display_page_show_assistant_bubble_desc">Whether to show bubble background for assistant messages</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -660,6 +660,8 @@
   <string name="setting_display_page_enable_message_generation_haptic_effect_title">Message Generation Haptic Effect</string>
   <string name="setting_display_page_font_size_preview">At four in the morning, I saw the begonia flowers still awake. I am often like this — lying awake alone in the quiet night, thinking: if someone is thinking of me at this moment, that would be wonderful.</string>
   <string name="setting_display_page_font_size_title">Chat Font Size</string>
+  <string name="setting_display_page_immersive_mode_desc">Hide the status bar for a fullscreen experience, swipe from the top edge to reveal it temporarily</string>
+  <string name="setting_display_page_immersive_mode_title">Immersive Mode</string>
   <string name="setting_display_page_live_update_notification">Live Update Notification</string>
   <string name="setting_display_page_live_update_notification_desc">Show real-time notification updates during message generation (Android 15+)</string>
   <string name="setting_display_page_message_jumper_position_desc">Move  Message Jumper to left side</string>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -2,4 +2,14 @@
 <resources>
 
 <style name="Theme.Rikkahub" parent="Theme.Material3.DayNight.NoActionBar" />
+
+<!-- 沉浸模式动态叠加: windowFullscreen 是主题属性, 会被之后创建的对话框窗口
+     (AlertDialog/ModalBottomSheet 等) 继承, 避免弹窗夺焦时状态栏复现 -->
+<style name="ThemeOverlay.Rikkahub.Immersive" parent="">
+    <item name="android:windowFullscreen">true</item>
+</style>
+
+<style name="ThemeOverlay.Rikkahub.NonImmersive" parent="">
+    <item name="android:windowFullscreen">false</item>
+</style>
 </resources>


### PR DESCRIPTION
## 功能描述

三项界面体验改进（前两项为设置开关，默认行为不变；第三项为 bug 修复）：

### 1. 沉浸模式

在 设置 → 偏好 → 通用 中新增「沉浸模式」开关，开启后隐藏状态栏获得全屏体验，从屏幕顶部边缘下滑可临时呼出状态栏。

- `DisplaySetting` 新增 `enableImmersiveMode`（默认关闭，序列化向后兼容）
- 使用 `WindowInsetsControllerCompat`，androidx compat 层自动适配所有受支持的 Android 版本（minSdk 26+）
- 监听 `onWindowFocusChanged` 在焦点恢复时重新应用，防止切后台后状态栏复现
- 应用已是 edge-to-edge 布局，隐藏状态栏后 Compose 通过 WindowInsets 自动回收顶部空间，无需改动任何页面布局
- **对话框兼容**：Compose 对话框（AlertDialog / ModalBottomSheet 等）是独立窗口，弹出时状态栏会复现。`android:windowFullscreen` 是主题属性，会被对话框窗口继承（窗口 flag 则不会），因此开启沉浸时动态 `theme.applyStyle` 叠加 `windowFullscreen=true`，所有后续弹窗自动保持全屏；主窗口同时设置 `FLAG_FULLSCREEN` + insets controller 双保险

### 2. 发送消息时可不跳转到最新消息

用户回看 AI 之前的回答时发送新消息，聊天列表会强制跳转到底部打断阅读。新增「发送时跳转到最新消息」开关（默认开启保持原行为），关闭后发送消息保持当前阅读位置。

- `DisplaySetting` 新增 `scrollToBottomOnSend`（默认 true）
- `ChatPage` 的 `onSendClick` / `onLongSendClick` 中的 `requestScrollToItem` 由该开关控制
- 生成过程中的自动滚动不受影响（仍由已有「自动滚动」开关控制）

### 3. 修复冷启动恢复会话后音量键翻页失效

应用从后台被杀后冷启动恢复到原对话时，音量键翻页失效（退化为调节音量），必须切换到新对话才能恢复。

根因：`ChatList` 中 `DisposableEffect(Unit)` 的音量键监听器只捕获**首次组合**时的 `settings` 对象，冷启动时设置尚未加载完成（翻页开关为默认关闭值），监听器从此永远返回 false。改用 `rememberUpdatedState` 使监听器始终读取最新设置，同时修复了在设置中切换翻页开关后旧会话不生效的问题。

## 其他

- 设置项 UI 复用现有 CardGroup + Switch 模式，与原有界面风格完全一致
- 新增字符串资源覆盖全部 6 种语言（en/zh/zh-rTW/ja/ko/ru）

## 测试

- 本地 `:app:compileDebugKotlin` 编译通过
- 已在本地构建 APK 实测