### PR TITLE
fix(ai): 修复 MCP 工具返回的图片无法被模型读取的问题

### DIFF
--- a/ai/src/main/java/me/rerere/ai/provider/providers/ClaudeProvider.kt
+++ b/ai/src/main/java/me/rerere/ai/provider/providers/ClaudeProvider.kt
@@ -37,6 +37,7 @@ import me.rerere.ai.ui.MessageChunk
 import me.rerere.ai.ui.UIMessage
 import me.rerere.ai.ui.UIMessageChoice
 import me.rerere.ai.ui.UIMessagePart
+import me.rerere.ai.ui.isVisibleToAssistant
 import me.rerere.ai.util.KeyRoulette
 import me.rerere.ai.util.configureReferHeaders
 import me.rerere.ai.util.encodeBase64
@@ -504,7 +505,9 @@ class ClaudeProvider(private val client: OkHttpClient, context: Context? = null)
         put("type", "tool_result")
         put("tool_use_id", toolCallId)
         putJsonArray("content") {
-            output.mapNotNull { it.toContentBlock() }.forEach { add(it) }
+            output.filter { it.isVisibleToAssistant() }
+                .mapNotNull { it.toContentBlock() }
+                .forEach { add(it) }
         }
     }
 

--- a/ai/src/main/java/me/rerere/ai/provider/providers/ClaudeProvider.kt
+++ b/ai/src/main/java/me/rerere/ai/provider/providers/ClaudeProvider.kt
@@ -440,6 +440,22 @@ class ClaudeProvider(private val client: OkHttpClient, context: Context? = null)
                         put("role", "user")
                         putJsonArray("content") {
                             group.tools.forEach { add(it.toToolResultBlock()) }
+                            // 图片不放入 tool_result content, 而是作为同一条 user 消息的
+                            // 普通 image block 跟随 (API 允许 tool_result 后跟其他内容块)。
+                            // 部分网关/中转会丢弃 tool_result 内嵌的 image, 导致模型看不到图片
+                            group.tools.forEach { tool ->
+                                val images = tool.output.filterIsInstance<UIMessagePart.Image>()
+                                    .filter { it.isVisibleToAssistant() }
+                                if (images.isNotEmpty()) {
+                                    add(buildJsonObject {
+                                        put("type", "text")
+                                        put("text", "[Image(s) returned by tool call ${tool.toolName} (${tool.toolCallId})]")
+                                    })
+                                    images.forEach { image ->
+                                        image.toContentBlock()?.let { add(it) }
+                                    }
+                                }
+                            }
                         }
                     })
                 }
@@ -481,7 +497,7 @@ class ClaudeProvider(private val client: OkHttpClient, context: Context? = null)
             }.onFailure {
                 Log.w(TAG, "encode image failed: $url", it)
                 put("type", "text")
-                put("text", "")
+                put("text", "[Failed to encode image: ${it.message}]")
             }
         }
 
@@ -505,9 +521,19 @@ class ClaudeProvider(private val client: OkHttpClient, context: Context? = null)
         put("type", "tool_result")
         put("tool_use_id", toolCallId)
         putJsonArray("content") {
-            output.filter { it.isVisibleToAssistant() }
-                .mapNotNull { it.toContentBlock() }
-                .forEach { add(it) }
+            // 图片以 user 消息内容块跟随在 tool_result 之后, 这里只保留非图片内容
+            val parts = output.filter { it.isVisibleToAssistant() && it !is UIMessagePart.Image }
+            parts.mapNotNull { it.toContentBlock() }.forEach { add(it) }
+            if (parts.isEmpty()) {
+                val hasImages = output.any { it is UIMessagePart.Image && it.isVisibleToAssistant() }
+                add(buildJsonObject {
+                    put("type", "text")
+                    put(
+                        "text",
+                        if (hasImages) "Tool returned image(s), attached below." else "(empty result)"
+                    )
+                })
+            }
         }
     }
 

--- a/ai/src/main/java/me/rerere/ai/provider/providers/GoogleProvider.kt
+++ b/ai/src/main/java/me/rerere/ai/provider/providers/GoogleProvider.kt
@@ -45,6 +45,7 @@ import me.rerere.ai.ui.UIMessage
 import me.rerere.ai.ui.UIMessageAnnotation
 import me.rerere.ai.ui.UIMessageChoice
 import me.rerere.ai.ui.UIMessagePart
+import me.rerere.ai.ui.isVisibleToAssistant
 import me.rerere.ai.util.KeyRoulette
 import me.rerere.ai.util.configureReferHeaders
 import me.rerere.ai.util.encodeBase64
@@ -641,7 +642,9 @@ class GoogleProvider(private val client: OkHttpClient, context: Context? = null)
                             group.tools.forEach { tool ->
                                 add(tool.toFunctionResponsePart())
                                 // functionResponse 只支持 JSON 文本, 图片结果以 inlineData parts 跟随, 否则模型无法读取
-                                tool.output.filterIsInstance<UIMessagePart.Image>().forEach { image ->
+                                tool.output.filterIsInstance<UIMessagePart.Image>()
+                                    .filter { it.isVisibleToAssistant() }
+                                    .forEach { image ->
                                     image.toGooglePart()?.let { add(it) }
                                 }
                             }
@@ -730,6 +733,7 @@ class GoogleProvider(private val client: OkHttpClient, context: Context? = null)
                 put(
                     "result",
                     output.filterIsInstance<UIMessagePart.Text>()
+                        .filter { it.isVisibleToAssistant() }
                         .joinToString("\n") { it.text }
                 )
             })

--- a/ai/src/main/java/me/rerere/ai/provider/providers/GoogleProvider.kt
+++ b/ai/src/main/java/me/rerere/ai/provider/providers/GoogleProvider.kt
@@ -638,7 +638,13 @@ class GoogleProvider(private val client: OkHttpClient, context: Context? = null)
                     add(buildJsonObject {
                         put("role", "user")
                         putJsonArray("parts") {
-                            group.tools.forEach { add(it.toFunctionResponsePart()) }
+                            group.tools.forEach { tool ->
+                                add(tool.toFunctionResponsePart())
+                                // functionResponse 只支持 JSON 文本, 图片结果以 inlineData parts 跟随, 否则模型无法读取
+                                tool.output.filterIsInstance<UIMessagePart.Image>().forEach { image ->
+                                    image.toGooglePart()?.let { add(it) }
+                                }
+                            }
                         }
                     })
                 }

--- a/ai/src/main/java/me/rerere/ai/provider/providers/openai/ChatCompletionsAPI.kt
+++ b/ai/src/main/java/me/rerere/ai/provider/providers/openai/ChatCompletionsAPI.kt
@@ -487,6 +487,33 @@ class ChatCompletionsAPI(
                                 "content",
                                 tool.output.filterIsInstance<UIMessagePart.Text>().joinToString("\n") { it.text })
                         })
+                        // tool 消息只支持文本, 图片结果以 user 消息形式跟随, 否则模型无法读取
+                        val images = tool.output.filterIsInstance<UIMessagePart.Image>()
+                        if (images.isNotEmpty()) {
+                            add(buildJsonObject {
+                                put("role", "user")
+                                putJsonArray("content") {
+                                    add(buildJsonObject {
+                                        put("type", "text")
+                                        put("text", "[Image(s) returned by tool call ${tool.toolName} (${tool.toolCallId})]")
+                                    })
+                                    images.forEach { image ->
+                                        add(buildJsonObject {
+                                            image.encodeBase64().onSuccess { encodedImage ->
+                                                put("type", "image_url")
+                                                put("image_url", buildJsonObject {
+                                                    put("url", encodedImage.base64)
+                                                })
+                                            }.onFailure {
+                                                it.printStackTrace()
+                                                put("type", "text")
+                                                put("text", "")
+                                            }
+                                        })
+                                    }
+                                }
+                            })
+                        }
                     }
                 }
             }

--- a/ai/src/main/java/me/rerere/ai/provider/providers/openai/ChatCompletionsAPI.kt
+++ b/ai/src/main/java/me/rerere/ai/provider/providers/openai/ChatCompletionsAPI.kt
@@ -38,6 +38,7 @@ import me.rerere.ai.ui.UIMessage
 import me.rerere.ai.ui.UIMessageAnnotation
 import me.rerere.ai.ui.UIMessageChoice
 import me.rerere.ai.ui.UIMessagePart
+import me.rerere.ai.ui.isVisibleToAssistant
 import me.rerere.ai.util.KeyRoulette
 import me.rerere.ai.util.configureReferHeaders
 import me.rerere.ai.util.encodeBase64
@@ -485,10 +486,13 @@ class ChatCompletionsAPI(
                             put("tool_call_id", tool.toolCallId)
                             put(
                                 "content",
-                                tool.output.filterIsInstance<UIMessagePart.Text>().joinToString("\n") { it.text })
+                                tool.output.filterIsInstance<UIMessagePart.Text>()
+                                    .filter { it.isVisibleToAssistant() }
+                                    .joinToString("\n") { it.text })
                         })
                         // tool 消息只支持文本, 图片结果以 user 消息形式跟随, 否则模型无法读取
                         val images = tool.output.filterIsInstance<UIMessagePart.Image>()
+                            .filter { it.isVisibleToAssistant() }
                         if (images.isNotEmpty()) {
                             add(buildJsonObject {
                                 put("role", "user")

--- a/ai/src/main/java/me/rerere/ai/provider/providers/openai/ResponseAPI.kt
+++ b/ai/src/main/java/me/rerere/ai/provider/providers/openai/ResponseAPI.kt
@@ -34,6 +34,7 @@ import me.rerere.ai.ui.MessageChunk
 import me.rerere.ai.ui.UIMessage
 import me.rerere.ai.ui.UIMessageChoice
 import me.rerere.ai.ui.UIMessagePart
+import me.rerere.ai.ui.isVisibleToAssistant
 import me.rerere.ai.util.KeyRoulette
 import me.rerere.ai.util.configureReferHeaders
 import me.rerere.ai.util.encodeBase64
@@ -359,8 +360,23 @@ class ResponseAPI(
                             put("call_id", tool.toolCallId)
                             put(
                                 "output",
-                                tool.output.filterIsInstance<UIMessagePart.Text>().joinToString("\n") { it.text })
+                                tool.output.filterIsInstance<UIMessagePart.Text>()
+                                    .filter { it.isVisibleToAssistant() }
+                                    .joinToString("\n") { it.text })
                         })
+                        // function_call_output 只支持文本, 图片结果以 user 消息形式跟随, 否则模型无法读取
+                        val images = tool.output.filterIsInstance<UIMessagePart.Image>()
+                            .filter { it.isVisibleToAssistant() }
+                        if (images.isNotEmpty()) {
+                            addContentItem(
+                                MessageRole.USER,
+                                listOf(
+                                    UIMessagePart.Text(
+                                        "[Image(s) returned by tool call ${tool.toolName} (${tool.toolCallId})]"
+                                    )
+                                ) + images
+                            )
+                        }
                     }
                 }
             }

--- a/ai/src/main/java/me/rerere/ai/ui/Message.kt
+++ b/ai/src/main/java/me/rerere/ai/ui/Message.kt
@@ -5,8 +5,11 @@ import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.contentOrNull
 import me.rerere.ai.core.MessageRole
 import me.rerere.ai.core.TokenUsage
 import me.rerere.ai.provider.Model
@@ -790,3 +793,12 @@ data class UIMessageChoice(
     val message: UIMessage?,
     val finishReason: String?
 )
+
+/**
+ * MCP 工具结果的 audience 注解 (存于 part.metadata["audience"], 如 ["user", "assistant"])。
+ * 未标注 audience 时默认对模型可见; 标注了 audience 但不含 "assistant" 的内容仅展示给用户, 不发送给模型。
+ */
+fun UIMessagePart.isVisibleToAssistant(): Boolean {
+    val audience = (metadata?.get("audience") as? JsonArray) ?: return true
+    return audience.any { (it as? JsonPrimitive)?.contentOrNull.equals("assistant", ignoreCase = true) }
+}

--- a/app/src/main/java/me/rerere/rikkahub/data/ai/mcp/McpManager.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/ai/mcp/McpManager.kt
@@ -15,6 +15,7 @@ import io.modelcontextprotocol.kotlin.sdk.shared.AbstractTransport
 import io.modelcontextprotocol.kotlin.sdk.shared.RequestOptions
 import io.modelcontextprotocol.kotlin.sdk.types.CallToolRequest
 import io.modelcontextprotocol.kotlin.sdk.types.CallToolRequestParams
+import io.modelcontextprotocol.kotlin.sdk.types.Annotations
 import io.modelcontextprotocol.kotlin.sdk.types.ImageContent
 import io.modelcontextprotocol.kotlin.sdk.types.Implementation
 import io.modelcontextprotocol.kotlin.sdk.types.TextContent
@@ -31,6 +32,9 @@ import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.ClassDiscriminatorMode
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.add
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.putJsonArray
 import me.rerere.ai.core.InputSchema
 import me.rerere.ai.ui.UIMessagePart
 import me.rerere.rikkahub.AppScope
@@ -150,8 +154,8 @@ class McpManager(
         )
         return result.content.map {
             when(it) {
-                is TextContent -> UIMessagePart.Text(it.text)
-                is ImageContent -> convertImageContentToFilePart(it)
+                is TextContent -> UIMessagePart.Text(it.text).withMcpAudience(it.annotations)
+                is ImageContent -> convertImageContentToFilePart(it).withMcpAudience(it.annotations)
                 else -> UIMessagePart.Text(JsonInstant.encodeToString(it))
             }
         }
@@ -169,6 +173,26 @@ class McpManager(
         val uri = filesManager.getFile(entity).toUri()
         Log.i(TAG, "convertImageContentToFilePart: saved mcp image to $uri")
         return UIMessagePart.Image(url = uri.toString())
+    }
+
+    /**
+     * 按 MCP 规范将内容的 audience 注解写入 part metadata,
+     * provider 序列化工具结果时据此决定是否发送给模型 (见 UIMessagePart.isVisibleToAssistant)
+     */
+    private fun UIMessagePart.withMcpAudience(annotations: Annotations?): UIMessagePart {
+        val audience = annotations?.audience ?: return this
+        val newMetadata = buildJsonObject {
+            metadata?.forEach { (key, value) -> put(key, value) }
+            putJsonArray("audience") {
+                audience.forEach { role -> add(role.name.lowercase()) }
+            }
+        }
+        when (this) {
+            is UIMessagePart.Text -> metadata = newMetadata
+            is UIMessagePart.Image -> metadata = newMetadata
+            else -> {}
+        }
+        return this
     }
 
     private fun getTransport(config: McpServerConfig): AbstractTransport = when (config) {


### PR DESCRIPTION
## 问题描述

MCP 工具返回图片时，用户界面可以正常显示图片，但模型完全看不到图片内容。该问题存在已久。

Closes #1138

## 根因分析

`McpManager` 已正确将 `ImageContent` 保存为 `UIMessagePart.Image` 并放入 `Tool.output`（所以 UI 能正常渲染），但发送给模型时图片被丢弃：

| Provider | 问题 |
|---|---|
| OpenAI Chat Completions | `tool` 消息 content 只取 `Text` parts，图片静默丢弃 |
| OpenAI Responses | `function_call_output` 只取 `Text` parts，图片静默丢弃 |
| Google Gemini | `functionResponse.response.result` 只取 `Text` parts，图片静默丢弃 |
| Claude | 代码上图片在 `tool_result` content 内，但实测部分网关/中转会丢弃 `tool_result` 内嵌的 image block（直接发送图片则正常），模型依然看不到 |

## 修复方式

统一策略：**工具返回的图片不放进工具结果结构内部，而是作为紧随其后的普通用户内容发送**（与用户直接发图走同一通道，模型必然可见）：

- **OpenAI (Chat Completions)**：图片以紧跟 `tool` 消息的 `user` 消息（`image_url`，带说明文字标注来源 tool call）发送
- **OpenAI (Responses)**：图片以 `input_image` user 消息跟随 `function_call_output`
- **Google (Gemini)**：图片以同一 `user` 消息 parts 中跟随 `functionResponse` 的 `inlineData` 发送
- **Claude**：图片移出 `tool_result` content，作为同一条 `user` 消息中跟随的普通 image block（[API 允许 tool_result 之后跟随其他内容块](https://platform.claude.com/docs/en/build-with-claude/tool-use)），`tool_result` 内保留文本与占位说明；图片编码失败时不再静默放入空文本，改为可诊断的错误说明

## audience 注解处理（#1138 提出）

按 [MCP 规范](https://modelcontextprotocol.io/specification/2025-11-25/server/tools#image-content)处理 `annotations.audience`：

- `McpManager` 将工具返回内容（文本/图片）的 audience 写入 part metadata
- 新增 `UIMessagePart.isVisibleToAssistant()`：未标注 audience 时默认对模型可见（向后兼容）；标注了 audience 但不含 `assistant` 的内容仅展示给用户、不发送给模型
- 四个 provider 序列化工具结果时统一应用该过滤

## 测试

- 本地 `:app:compileDebugKotlin` 编译通过
- 已在本地构建 APK 实测