### PR TITLE
feat(chat): 新增发送消息时是否跳转到最新消息的开关

### DIFF
--- a/app/src/main/java/me/rerere/rikkahub/data/datastore/PreferencesStore.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/datastore/PreferencesStore.kt
@@ -591,6 +591,7 @@ data class DisplaySetting(
     val pasteLongTextThreshold: Int = 1000,
     val sendOnEnter: Boolean = false,
     val enableAutoScroll: Boolean = true,
+    val scrollToBottomOnSend: Boolean = true,
     val enableLatexRendering: Boolean = true,
     val enableBlurEffect: Boolean = false,
     val chatFontFamily: ChatFontFamily = ChatFontFamily.DEFAULT,

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ChatPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ChatPage.kt
@@ -304,8 +304,10 @@ private fun ChatPageContent(
                             )
                         } else {
                             vm.handleMessageSend(inputState.getContents())
-                            scope.launch {
-                                chatListState.requestScrollToItem(conversation.currentMessages.size + 5)
+                            if (setting.displaySetting.scrollToBottomOnSend) {
+                                scope.launch {
+                                    chatListState.requestScrollToItem(conversation.currentMessages.size + 5)
+                                }
                             }
                         }
                         inputState.clearInput()
@@ -318,8 +320,10 @@ private fun ChatPageContent(
                             )
                         } else {
                             vm.handleMessageSend(content = inputState.getContents(), answer = false)
-                            scope.launch {
-                                chatListState.requestScrollToItem(conversation.currentMessages.size + 5)
+                            if (setting.displaySetting.scrollToBottomOnSend) {
+                                scope.launch {
+                                    chatListState.requestScrollToItem(conversation.currentMessages.size + 5)
+                                }
                             }
                         }
                         inputState.clearInput()

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingPreferencesGeneralPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingPreferencesGeneralPage.kt
@@ -135,6 +135,18 @@ fun SettingPreferencesGeneralPage(vm: SettingVM = koinViewModel()) {
                         },
                     )
                     item(
+                        headlineContent = { Text(stringResource(R.string.setting_display_page_scroll_to_bottom_on_send_title)) },
+                        supportingContent = { Text(stringResource(R.string.setting_display_page_scroll_to_bottom_on_send_desc)) },
+                        trailingContent = {
+                            Switch(
+                                checked = displaySetting.scrollToBottomOnSend,
+                                onCheckedChange = {
+                                    updateDisplaySetting(displaySetting.copy(scrollToBottomOnSend = it))
+                                }
+                            )
+                        },
+                    )
+                    item(
                         headlineContent = { Text(stringResource(R.string.setting_display_page_use_app_icon_style_loading_indicator_title)) },
                         supportingContent = {
                             Text(stringResource(R.string.setting_display_page_use_app_icon_style_loading_indicator_desc))

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -662,6 +662,8 @@
   <string name="setting_display_page_paste_long_text_as_file_desc">テキストを貼り付けた際にしきい値を超える場合、自動的にファイル添付として保存します</string>
   <string name="setting_display_page_paste_long_text_as_file_title">長いテキストをファイルとして貼り付け</string>
   <string name="setting_display_page_paste_long_text_threshold_title">文字数しきい値</string>
+  <string name="setting_display_page_scroll_to_bottom_on_send_desc">メッセージ送信時に最新メッセージへ自動的に移動します。オフにすると現在の閲覧位置を保持します</string>
+  <string name="setting_display_page_scroll_to_bottom_on_send_title">送信時に最新メッセージへ移動</string>
   <string name="setting_display_page_send_on_enter_desc">Enterキーでメッセージを送信し、改行しない</string>
   <string name="setting_display_page_send_on_enter_title">Enterキーで送信</string>
   <string name="setting_display_page_show_assistant_bubble_desc">アシスタントメッセージのバブル背景を表示するかどうか</string>

--- a/app/src/main/res/values-ko-rKR/strings.xml
+++ b/app/src/main/res/values-ko-rKR/strings.xml
@@ -662,6 +662,8 @@
   <string name="setting_display_page_paste_long_text_as_file_desc">복사한 텍스트가 임계값을 초과하면 자동으로 파일 첨부로 저장</string>
   <string name="setting_display_page_paste_long_text_as_file_title">긴 텍스트를 파일로 붙여넣기</string>
   <string name="setting_display_page_paste_long_text_threshold_title">텍스트 길이 임계값</string>
+  <string name="setting_display_page_scroll_to_bottom_on_send_desc">메시지 전송 시 최신 메시지로 자동 이동합니다. 끄면 현재 읽던 위치를 유지합니다</string>
+  <string name="setting_display_page_scroll_to_bottom_on_send_title">전송 시 최신 메시지로 이동</string>
   <string name="setting_display_page_send_on_enter_desc">Enter 키를 누르면 줄 바꿈 대신 메시지를 전송합니다</string>
   <string name="setting_display_page_send_on_enter_title">Enter 키로 전송</string>
   <string name="setting_display_page_show_assistant_bubble_desc">어시스턴트 메시지에 말풍선 배경 표시 여부</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -662,6 +662,8 @@
   <string name="setting_display_page_paste_long_text_as_file_desc">При вставке текста, превышающего порог, автоматически сохранять его как файл-вложение</string>
   <string name="setting_display_page_paste_long_text_as_file_title">Вставлять длинный текст как файл</string>
   <string name="setting_display_page_paste_long_text_threshold_title">Порог длины текста</string>
+  <string name="setting_display_page_scroll_to_bottom_on_send_desc">Автоматически переходить к последнему сообщению при отправке; отключите, чтобы сохранить текущую позицию чтения</string>
+  <string name="setting_display_page_scroll_to_bottom_on_send_title">Переход к последнему при отправке</string>
   <string name="setting_display_page_send_on_enter_desc">Нажмите Enter, чтобы отправить сообщение, а не добавить новую строку</string>
   <string name="setting_display_page_send_on_enter_title">Отправлять по Enter</string>
   <string name="setting_display_page_show_assistant_bubble_desc">Показывать фоновый пузырь для сообщений ассистента</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -662,6 +662,8 @@
   <string name="setting_display_page_paste_long_text_as_file_desc">貼上文字超過上限時，自動儲存為檔案附件</string>
   <string name="setting_display_page_paste_long_text_as_file_title">貼上長文字為檔案</string>
   <string name="setting_display_page_paste_long_text_threshold_title">文字長度閾值</string>
+  <string name="setting_display_page_scroll_to_bottom_on_send_desc">發送訊息時自動跳轉到最新訊息，關閉後保持當前閱讀位置，閱讀體驗更連貫</string>
+  <string name="setting_display_page_scroll_to_bottom_on_send_title">發送時跳轉到最新訊息</string>
   <string name="setting_display_page_send_on_enter_desc">按 Enter 鍵即可傳送訊息，而非換行</string>
   <string name="setting_display_page_send_on_enter_title">按 Enter 鍵傳送</string>
   <string name="setting_display_page_show_assistant_bubble_desc">是否顯示助理訊息的泡泡背景</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -669,6 +669,8 @@
   <string name="setting_display_page_paste_long_text_as_file_desc">当粘贴的文本超过阈值时，自动将其保存为文件附件</string>
   <string name="setting_display_page_paste_long_text_as_file_title">粘贴长文本为文件</string>
   <string name="setting_display_page_paste_long_text_threshold_title">文本长度阈值</string>
+  <string name="setting_display_page_scroll_to_bottom_on_send_desc">发送消息时自动跳转到最新消息，关闭后保持当前阅读位置，阅读体验更连贯</string>
+  <string name="setting_display_page_scroll_to_bottom_on_send_title">发送时跳转到最新消息</string>
   <string name="setting_display_page_send_on_enter_desc">按 Enter 发送消息而非换行</string>
   <string name="setting_display_page_send_on_enter_title">按Enter发送</string>
   <string name="setting_display_page_show_assistant_bubble_desc">是否为助手消息显示气泡背景</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -669,6 +669,8 @@
   <string name="setting_display_page_paste_long_text_as_file_desc">When pasting text exceeds the threshold, automatically save it as a file attachment</string>
   <string name="setting_display_page_paste_long_text_as_file_title">Paste Long Text as File</string>
   <string name="setting_display_page_paste_long_text_threshold_title">Text Length Threshold</string>
+  <string name="setting_display_page_scroll_to_bottom_on_send_desc">Automatically jump to the latest message when sending; turn off to keep your current reading position</string>
+  <string name="setting_display_page_scroll_to_bottom_on_send_title">Jump to Latest on Send</string>
   <string name="setting_display_page_send_on_enter_desc">Press Enter to send message instead of adding a new line</string>
   <string name="setting_display_page_send_on_enter_title">Send on Enter</string>
   <string name="setting_display_page_show_assistant_bubble_desc">Whether to show bubble background for assistant messages</string>


### PR DESCRIPTION
## 功能描述

用户在回看 AI 之前的回答时，如果发送新消息，聊天列表会强制跳转到最新消息，打断阅读。

本 PR 在 设置 → 偏好 → 通用 中新增「发送时跳转到最新消息」开关：
- 默认开启，保持现有行为不变
- 关闭后，发送消息时保持当前阅读位置，阅读体验更连贯

## 实现方式

- `DisplaySetting` 新增 `scrollToBottomOnSend` 字段（默认 true，序列化向后兼容）
- `ChatPage` 的 `onSendClick` / `onLongSendClick` 中的 `requestScrollToItem` 由该开关控制
- 生成过程中的自动滚动不受影响（仍由已有的「自动滚动」开关控制，且仅在已位于底部时生效）
- 设置项复用现有 CardGroup + Switch 模式，新增字符串覆盖全部 6 种语言