### PR TITLE
fix: OCR model requests now include provider advanced custom body/headers

### DIFF
--- a/app/src/main/java/me/rerere/rikkahub/data/ai/transformers/OcrTransformer.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/ai/transformers/OcrTransformer.kt
@@ -101,6 +101,8 @@ object OcrTransformer : InputMessageTransformer, KoinComponent {
             ),
             params = TextGenerationParams(
                 model = model,
+                customHeaders = model.customHeaders,
+                customBody = model.customBodies,
             ),
         )
         val content = result.choices[0].message?.toText() ?: "[ERROR, OCR failed]"


### PR DESCRIPTION
  OCR 请求构造 TextGenerationParams 时未传入 model.customHeaders
  和 model.customBodies，导致提供商高级设置中的自定义 body 在
  OCR 识别图片时被忽略（正常对话正常生效）。

  Closes #1343