### PR TITLE
feat: 支持自定义记忆工具提示词

### DIFF
--- a/app/src/main/java/me/rerere/rikkahub/data/ai/GenerationHandler.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/ai/GenerationHandler.kt
@@ -104,6 +104,7 @@ class GenerationHandler(
                     }
                     buildMemoryTools(
                         json = json,
+                        customMemoryPrompt = assistant?.memoryToolPrompt ?: "",
                         onCreation = { content ->
                             memoryRepo.addMemory(memoryAssistantId, content)
                         },

--- a/app/src/main/java/me/rerere/rikkahub/data/ai/tools/MemoryTools.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/ai/tools/MemoryTools.kt
@@ -17,32 +17,50 @@ import me.rerere.rikkahub.data.model.AssistantMemory
 import me.rerere.rikkahub.utils.toLocalString
 import java.time.LocalDate
 
+// 默认的记忆行为规则（可被用户自定义覆盖）
+internal val DEFAULT_MEMORY_TOOL_USER_PROMPT = """
+    Memories will automatically appear in the <memories> tag in later conversations.
+    Do not store sensitive information (e.g., ethnicity, religion, sexual orientation, political views, sex life, criminal records).
+    You may store: preferred name, preferences, plans, work-related notes, chat style preferences, first chat time, etc.
+    Do not show memory content directly in the conversation unless the user explicitly asks.
+    Today is {当前日期}（运行时会动态填充）.
+    Similar memories should be merged; prefer updating existing records.
+""".trimIndent()
+
 fun buildMemoryTools(
     json: Json,
+    customMemoryPrompt: String = "",
     onCreation: suspend (String) -> AssistantMemory,
     onUpdate: suspend (Int, String) -> AssistantMemory,
     onDelete: suspend (Int) -> Unit
 ): List<Tool> = listOf(
     Tool(
         name = "memory_tool",
-        description = """
-            The memory tool stores long-term information across conversations.
-            Use `action` to control the operation: `create` (add), `edit` (update), `delete` (remove).
-            - No relevant record: `create` + `content`
-            - Existing relevant record: `edit` + `id` + `content`
-            - Outdated/irrelevant record: `delete` + `id`
-            Memories will automatically appear in the <memories> tag in later conversations.
-            Do not store sensitive information (e.g., ethnicity, religion, sexual orientation, political views, sex life, criminal records).
-            You may store: preferred name, preferences, plans, work-related notes, chat style preferences, first chat time, etc.
-            Do not show memory content directly in the conversation unless the user explicitly asks.
-            Today is ${LocalDate.now().toLocalString(true)}.
-            Similar memories should be merged; prefer updating existing records.
+        description = buildString {
+            // PREFIX（固定，不可修改）
+            append("""
+                The memory tool stores long-term information across conversations.
+                Use `action` to control the operation: `create` (add), `edit` (update), `delete` (remove).
+                - No relevant record: `create` + `content`
+                - Existing relevant record: `edit` + `id` + `content`
+                - Outdated/irrelevant record: `delete` + `id`
+            """.trimIndent())
+            append("\n")
 
-            Examples:
-            {"action":"create","content":"User prefers brief replies and is more active on weekends."}
-            {"action":"edit","id":12,"content":"User’s preferred name updated to “A-Xing”, prefers Chinese replies."}
-            {"action":"delete","id":7}
-        """.trimIndent(),
+            // EDITABLE（用户自定义 或 默认）
+            val promptContent = customMemoryPrompt.ifBlank { DEFAULT_MEMORY_TOOL_USER_PROMPT }
+            // 将占位符 {当前日期} 替换为实际日期
+            append(promptContent.replace("{当前日期}", LocalDate.now().toLocalString(true)))
+            append("\n")
+
+            // SUFFIX（固定，不可修改）
+            append("""
+                Examples:
+                {"action":"create","content":"User prefers brief replies and is more active on weekends."}
+                {"action":"edit","id":12,"content":"User's preferred name updated to "A-Xing", prefers Chinese replies."}
+                {"action":"delete","id":7}
+            """.trimIndent())
+        },
         parameters = {
             InputSchema.Obj(
                 properties = buildJsonObject {

--- a/app/src/main/java/me/rerere/rikkahub/data/model/Assistant.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/model/Assistant.kt
@@ -7,6 +7,7 @@ import me.rerere.ai.provider.CustomBody
 import me.rerere.ai.provider.CustomHeader
 import me.rerere.ai.ui.UIMessage
 import me.rerere.ai.core.ReasoningLevel
+import me.rerere.rikkahub.data.ai.tools.DEFAULT_MEMORY_TOOL_USER_PROMPT
 import me.rerere.rikkahub.data.ai.tools.LocalToolOption
 import kotlin.uuid.Uuid
 
@@ -44,6 +45,7 @@ data class Assistant(
     val lorebookIds: Set<Uuid> = emptySet(),            // 关联的 Lorebook ID
     val enabledSkills: Set<String> = emptySet(),        // 启用的 skill 名称列表
     val enableTimeReminder: Boolean = false,            // 时间间隔提醒注入
+    val memoryToolPrompt: String = DEFAULT_MEMORY_TOOL_USER_PROMPT,  // 自定义记忆工具提示词（行为规则部分）
     val allowConversationSystemPrompt: Boolean = false, // 允许对话单独重写 system prompt
     val allowConversationPromptInjection: Boolean = false, // 允许对话单独绑定提示词注入
 )

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/assistant/detail/AssistantMemoryPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/assistant/detail/AssistantMemoryPage.kt
@@ -4,6 +4,7 @@ import me.rerere.hugeicons.HugeIcons
 import me.rerere.hugeicons.stroke.PencilEdit01
 import me.rerere.hugeicons.stroke.Add01
 import me.rerere.hugeicons.stroke.Delete01
+import me.rerere.hugeicons.stroke.ArrowRight01
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -12,6 +13,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.AlertDialog
@@ -21,6 +23,8 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.LargeFlexibleTopAppBar
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
@@ -44,6 +48,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import me.rerere.rikkahub.R
 import me.rerere.rikkahub.data.model.Assistant
 import me.rerere.rikkahub.data.model.AssistantMemory
+import me.rerere.rikkahub.data.ai.tools.DEFAULT_MEMORY_TOOL_USER_PROMPT
 import me.rerere.rikkahub.ui.components.nav.BackButton
 import me.rerere.rikkahub.ui.components.ui.CardGroup
 import me.rerere.rikkahub.ui.components.ui.RikkaConfirmDialog
@@ -110,6 +115,7 @@ private fun AssistantMemoryContent(
         }
     }
     var pendingDeleteMemory by remember { mutableStateOf<AssistantMemory?>(null) }
+    var showMemoryToolPromptEditor by remember { mutableStateOf(false) }
 
     // 记忆对话框
     memoryDialogState.EditStateContent { memory, update ->
@@ -246,6 +252,26 @@ private fun AssistantMemoryContent(
             )
         }
 
+        CardGroup(title = { Text(stringResource(R.string.assistant_page_memory_tool_prompt)) }) {
+            item(
+                onClick = {
+                    // 旧数据兼容迁移：如果 memoryToolPrompt 为空，自动填充默认文本
+                    if (assistant.memoryToolPrompt.isBlank()) {
+                        onUpdateAssistant(assistant.copy(memoryToolPrompt = DEFAULT_MEMORY_TOOL_USER_PROMPT))
+                    }
+                    showMemoryToolPromptEditor = true
+                },
+                headlineContent = { Text(stringResource(R.string.assistant_page_memory_tool_prompt_desc)) },
+                trailingContent = {
+                    Icon(
+                        HugeIcons.ArrowRight01,
+                        contentDescription = null,
+                        modifier = Modifier.size(16.dp),
+                    )
+                },
+            )
+        }
+
         Box(
             modifier = Modifier
                 .fillMaxWidth()
@@ -305,6 +331,18 @@ private fun AssistantMemoryContent(
             )
         }
     )
+
+    MemoryToolPromptEditor(
+        currentPrompt = assistant.memoryToolPrompt,
+        onPromptChange = { newPrompt ->
+            onUpdateAssistant(assistant.copy(memoryToolPrompt = newPrompt))
+        },
+        onResetPrompt = {
+            onUpdateAssistant(assistant.copy(memoryToolPrompt = DEFAULT_MEMORY_TOOL_USER_PROMPT))
+        },
+        show = showMemoryToolPromptEditor,
+        onDismiss = { showMemoryToolPromptEditor = false },
+    )
 }
 
 @Composable
@@ -352,6 +390,50 @@ private fun MemoryItem(
                     HugeIcons.Delete01,
                     stringResource(R.string.assistant_page_delete)
                 )
+            }
+        }
+    }
+}
+
+@Composable
+private fun MemoryToolPromptEditor(
+    currentPrompt: String,
+    onPromptChange: (String) -> Unit,
+    onResetPrompt: () -> Unit,
+    show: Boolean,
+    onDismiss: () -> Unit,
+) {
+    if (show) {
+        ModalBottomSheet(
+            onDismissRequest = onDismiss,
+        ) {
+            Column(
+                modifier = Modifier
+                    .padding(horizontal = 16.dp)
+                    .padding(bottom = 16.dp)
+                    .imePadding(),
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                Text(
+                    text = stringResource(R.string.assistant_page_memory_tool_prompt),
+                    style = MaterialTheme.typography.titleMedium,
+                )
+                Text(
+                    text = stringResource(R.string.assistant_page_memory_tool_prompt_vars),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                OutlinedTextField(
+                    value = currentPrompt,
+                    onValueChange = onPromptChange,
+                    modifier = Modifier.fillMaxWidth(),
+                    maxLines = 15,
+                )
+                TextButton(onClick = {
+                    onResetPrompt()
+                }) {
+                    Text(stringResource(R.string.setting_model_page_reset_to_default))
+                }
             }
         }
     }

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -149,6 +149,9 @@
   <string name="assistant_page_thinking_budget">思考预算</string>
   <string name="assistant_page_time_reminder">时间提醒</string>
   <string name="assistant_page_time_reminder_desc">在间隔较大的消息前自动插入时间提醒，帮助 AI 理解对话间隔</string>
+  <string name="assistant_page_memory_tool_prompt">记忆工具提示词</string>
+  <string name="assistant_page_memory_tool_prompt_desc">自定义记忆工具的行为指令</string>
+  <string name="assistant_page_memory_tool_prompt_vars">变量: {当前日期}（运行时会动态填充为当天日期）</string>
   <string name="assistant_page_title">助手设置</string>
   <string name="assistant_page_top_p">Top P</string>
   <string name="assistant_page_top_p_value">Top P: %s</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -149,6 +149,9 @@
   <string name="assistant_page_thinking_budget">Thinking Budget</string>
   <string name="assistant_page_time_reminder">Time Reminder</string>
   <string name="assistant_page_time_reminder_desc">Automatically inject time reminders before messages with large time gaps to help AI understand conversation intervals</string>
+  <string name="assistant_page_memory_tool_prompt">Memory Tool Prompt</string>
+  <string name="assistant_page_memory_tool_prompt_desc">Customize the behavioral instructions for the memory tool</string>
+  <string name="assistant_page_memory_tool_prompt_vars">Variables: {当前日期} (dynamically filled with today\'s date at runtime)</string>
   <string name="assistant_page_title">Assistant Settings</string>
   <string name="assistant_page_top_p">Top P</string>
   <string name="assistant_page_top_p_value">Top P: %s</string>


### PR DESCRIPTION
## 概述

为助手新增**记忆工具提示词自定义**功能。用户可以在助手设置 → 记忆管理页面中，编辑记忆工具发送给 AI 的行为指令，实现更加灵活的记忆管理。

## 动机：原版记忆工具提示词的两个不足

### 1. 日期硬编码导致缓存率下降，费钱

原版 `MemoryTools.kt` 中，记忆工具提示词包含 `${LocalDate.now().toLocalString(true)}`，每次构建工具时都会生成带有当天日期的字符串。对于启用了缓存的 API 调用来说，这意味着**每天第一次发消息时「记忆工具」的请求体都会变化**，缓存必然 miss，从而增加不必要的 API 费用。

**本次 PR** 将日期替换为 `{当前日期}` 占位符，在运行时通过 `replace` 动态填充。如果你**不修改**默认提示词，占位符行为与原版完全一致；但如果你使用的 API 提供商对缓存敏感，你可以在不改变语义的前提下自行移除日期变量，让缓存在跨天时依然命中。

### 2. 角色扮演等场景下提示词不够用

原版记忆工具提示词是硬编码的，用户无法修改。在很多场景下这远远不够：

- **角色扮演**：让 AI 扮演伴侣时，希望它每天自动写一份日记 → 需要在提示词中加入「请以日记形式记录今天的关键互动」
- **工作场景**：希望记忆工具按项目归类，加入「为每条记忆标注所属项目」
- **隐私定制**：对敏感信息的定义因文化/场景而异，用户可能需要更宽松或更严格的规则

**本次 PR** 将提示词拆为三段：**PREFIX（固定）** + **EDITABLE（用户可编辑）** + **SUFFIX（固定）**，只开放行为规则部分供用户自定义，工具操作说明和示例保持固定不变。

## 变更内容

### 数据/逻辑层（commit 1）

| 文件 | 变更 |
|------|------|
| `Assistant.kt` | 新增 `memoryToolPrompt` 字段，默认值为 `DEFAULT_MEMORY_TOOL_USER_PROMPT` |
| `MemoryTools.kt` | description 拆为 PREFIX + EDITABLE + SUFFIX 三段；新增 `customMemoryPrompt` 参数；日期改为 `{当前日期}` 占位符 + 运行时替换 |
| `GenerationHandler.kt` | `buildMemoryTools()` 调用处传入 `assistant?.memoryToolPrompt` |

### UI 层（commit 2）

| 文件 | 变更 |
|------|------|
| `AssistantMemoryPage.kt` | 新增 `MemoryToolPromptEditor`（ModalBottomSheet + OutlinedTextField + 重置按钮）；旧数据空白值自动迁移 |
| `values/strings.xml` | 新增 3 条英文字符串 |
| `values-zh/strings.xml` | 新增 3 条中文字符串 |

## 设计决策

- **默认值存储策略**：存储实际默认文本而非空字符串哨兵值，与现有的 `SettingModelPromptPage` 设计模式对齐
- **向后兼容**：`@Serializable` data class 带默认值，旧 JSON 反序列化不受影响
- **防御性编程**：`MemoryTools.kt` 中保留 `ifBlank` fallback，即使存储层异常也不影响工具正常运行
- **编辑范围控制**：仅开放行为规则部分（EDITABLE 段），工具操作指令（PREFIX/SUFFIX）固定不可修改，避免用户误操作导致工具失效