### PR TITLE
fix(latex): 使 LaTeX 公式渲染跟随聊天字体大小设置

### DIFF
--- a/app/src/main/java/me/rerere/rikkahub/ui/components/richtext/Markdown.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/richtext/Markdown.kt
@@ -540,7 +540,8 @@ private fun MarkdownNode(
             val enableLatexRendering = LocalSettings.current.displaySetting.enableLatexRendering
             if (enableLatexRendering) {
                 MathInline(
-                    formula, modifier = modifier.padding(horizontal = 1.dp)
+                    formula, modifier = modifier.padding(horizontal = 1.dp),
+                    fontSize = LocalTextStyle.current.fontSize
                 )
             } else {
                 Text(
@@ -558,7 +559,8 @@ private fun MarkdownNode(
                 MathBlock(
                     formula, modifier = modifier
                         .fillMaxWidth()
-                        .padding(vertical = 8.dp)
+                        .padding(vertical = 8.dp),
+                    fontSize = LocalTextStyle.current.fontSize
                 )
             } else {
                 Text(

--- a/app/src/main/java/me/rerere/rikkahub/ui/components/richtext/MarkdownNew.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/richtext/MarkdownNew.kt
@@ -975,7 +975,7 @@ private fun AnnotatedString.Builder.appendHtmlInlineElement(
                                 placeholderVerticalAlign = PlaceholderVerticalAlign.TextCenter,
                             ),
                             children = {
-                                MathInline(latex = formula, modifier = Modifier)
+                                MathInline(latex = formula, modifier = Modifier, fontSize = style.fontSize)
                             },
                         ),
                     )

--- a/app/src/main/java/me/rerere/rikkahub/ui/components/richtext/MathBlock.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/richtext/MathBlock.kt
@@ -42,7 +42,7 @@ fun MathBlock(
         LatexText(
             latex = proceededLatex,
             color = LocalContentColor.current,
-            fontSize = fontSize.takeOrElse { MaterialTheme.typography.bodyLarge.fontSize },
+            fontSize = fontSize.takeOrElse { LocalTextStyle.current.fontSize },
             modifier = Modifier
                 .align(Alignment.Center)
                 .horizontalScroll(


### PR DESCRIPTION
## 问题描述

内置的 LaTeX 渲染器不会跟随"聊天字体大小"设置(设置 → 偏好设置 → 界面偏好设置 → 字体大小)。
调整字体大小比例时,普通 Markdown 文本会相应缩放,但 LaTeX 公式(行内与块级)仍维持固定大小。

## 原因分析

`MathInline` / `MathBlock` 组件本身支持 `fontSize` 参数,但 Markdown 渲染器的调用处
未传入该参数。此外,`MathBlock` 的回退值使用了硬编码的 `MaterialTheme.typography.bodyLarge.fontSize`,
完全忽略了用户的字体缩放比例。

## 改动内容

- `MathBlock.kt`:字号回退值改用 `LocalTextStyle.current.fontSize`,不再使用硬编码主题字号
- `Markdown.kt`:在行内/块级公式调用处显式传入 `fontSize = LocalTextStyle.current.fontSize`
- `MarkdownNew.kt`:在 `InlineTextContent` 内部显式传入 `fontSize = style.fontSize`,
  避免该上下文中 `LocalTextStyle` 丢失

## 测试情况（附截图）
<img width="1080" height="1150" alt="pr1" src="https://github.com/user-attachments/assets/35f1c9a8-d8a5-4bd9-97a0-13a289f47d01" />
<img width="1080" height="1150" alt="pr2" src="https://github.com/user-attachments/assets/ac14369b-c2c8-47c9-a79d-ce0a925023a7" />

- 已在手机（vivo X200s, Android 16, Origin OS 6）/模拟器（mumu, Android 12）上成功测试
- 验证行内公式与块级公式在所有字体缩放比例下均能正确缩放
- 未发现崩溃或回归问题

Fixes #1363