### PR TITLE
fix: 修复聊天模板添加时间戳导致缓存命中率低

### DIFF
--- a/app/src/main/java/me/rerere/rikkahub/data/ai/transformers/TemplateTransformer.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/ai/transformers/TemplateTransformer.kt
@@ -2,15 +2,16 @@ package me.rerere.rikkahub.data.ai.transformers
 
 import io.pebbletemplates.pebble.PebbleEngine
 import io.pebbletemplates.pebble.loader.Loader
+import kotlinx.datetime.toJavaLocalDateTime
+import me.rerere.ai.core.MessageRole
 import me.rerere.ai.ui.UIMessage
 import me.rerere.ai.ui.UIMessagePart
 import me.rerere.rikkahub.data.datastore.SettingsStore
-import me.rerere.rikkahub.utils.toLocalDate
-import me.rerere.rikkahub.utils.toLocalTime
+import me.rerere.rikkahub.utils.toLocalDateString
+import me.rerere.rikkahub.utils.toLocalTimeString
 import java.io.Reader
 import java.io.StringReader
 import java.io.StringWriter
-import java.time.Instant
 
 class TemplateTransformer(
     private val engine: PebbleEngine,
@@ -22,6 +23,16 @@ class TemplateTransformer(
     ): List<UIMessage> {
         val template = engine.getTemplate(ctx.assistant.id.toString())
         return messages.map { message ->
+            // system / tool 等非用户/助手消息：不套用模板，原样返回。
+            // 这些消息的 createdAt 每次请求都不同，若套模板并注入时间戳会导致最前缀缓存失效；
+            // 且它们本不需要 {{ role }}/{{ message }} 等模板变量，跳过更合理。
+            if (message.role != MessageRole.USER && message.role != MessageRole.ASSISTANT) {
+                return@map message
+            }
+
+            // 用户/助手消息：使用消息自身的创建时间（历史时间戳），而非当前请求时刻。
+            // 这样历史消息渲染结果跨请求保持稳定，避免破坏各 Provider 的前缀 prompt 缓存。
+            val createdAt = message.createdAt.toJavaLocalDateTime()
             message.copy(
                 parts = message.parts.map { part ->
                     when (part) {
@@ -31,8 +42,8 @@ class TemplateTransformer(
                                 result, mapOf(
                                     "message" to part.text,
                                     "role" to message.role.name.lowercase(),
-                                    "time" to Instant.now().toLocalTime(),
-                                    "date" to Instant.now().toLocalDate(),
+                                    "time" to createdAt.toLocalTimeString(),
+                                    "date" to createdAt.toLocalDateString(),
                                 )
                             )
                             part.copy(

--- a/app/src/main/java/me/rerere/rikkahub/utils/TimeUtil.kt
+++ b/app/src/main/java/me/rerere/rikkahub/utils/TimeUtil.kt
@@ -38,6 +38,28 @@ fun Instant.toLocalTime(): String {
         .format(localDateTime)
 }
 
+/**
+ * 将本地日期时间格式化为日期字符串，与 [Instant.toLocalDate] 输出格式一致。
+ *
+ * 用于消息模板的 {{ date }} 变量：接收消息自身的创建时间（java.time.LocalDateTime），
+ * 直接格式化而不经过时区转换，使历史消息的时间戳跨请求保持稳定，避免破坏 prompt 缓存。
+ */
+fun LocalDateTime.toLocalDateString(): String =
+    DateTimeFormatter.ofLocalizedDate(FormatStyle.MEDIUM)
+        .withLocale(Locale.getDefault())
+        .format(this)
+
+/**
+ * 将本地日期时间格式化为时间字符串，与 [Instant.toLocalTime] 输出格式一致。
+ *
+ * 用于消息模板的 {{ time }} 变量：接收消息自身的创建时间（java.time.LocalDateTime），
+ * 使历史消息的时间戳跨请求保持稳定，避免破坏 prompt 缓存。
+ */
+fun LocalDateTime.toLocalTimeString(): String =
+    DateTimeFormatter.ofLocalizedTime(FormatStyle.MEDIUM)
+        .withLocale(Locale.getDefault())
+        .format(this)
+
 fun LocalDateTime.toLocalString(): String {
     val locale = Locale.getDefault()
     val formatter = DateTimeFormatter.ofLocalizedDateTime(FormatStyle.MEDIUM).withLocale(locale)


### PR DESCRIPTION
此 PR 提供了解决 #1366 的一种办法：修改了设置消息模板后的日期与时间变量逻辑，每条助手/用户消息都带有发送消息时的历史时间。

可以同时解决 **缓存命中率低** 与 **AI 对聊天中的时间没有概念** 的问题。

希望维护者可以合并或参考，谢谢！审 PR 辛苦啦 ovo

---

## 修改说明

### 问题

在助手设置的「聊天内容模板」中加入 `{{ date }}` / `{{ time }}` 变量后，`TemplateTransformer` 会把**上下文中的每一条消息**都套用模板，而这两个变量取自 `Instant.now()`（当前请求时刻）。这导致：

- 每次请求时，**所有历史消息**的时间戳都被刷新为「当前时刻」，而非各自的真实发送时间；
- 构成可缓存前缀的历史消息文本每次请求都变化，使各 Provider（Anthropic / OpenAI / Google）基于前缀匹配的 prompt cache 命中率极低。

### 根因

`TemplateTransformer` 使用 `Instant.now()` 而非消息自身的 `createdAt`：

```kotlin
"time" to Instant.now().toLocalTime(),
"date" to Instant.now().toLocalDate(),
```

而 `UIMessage` 本身就带有稳定的 `createdAt`（消息真实创建时间），项目中的 `TimeReminderTransformer` 也已正确使用它。

### 修改内容

仅改动 2 个文件：

1. **`TimeUtil.kt`**：新增 `LocalDateTime.toLocalDateString()` / `toLocalTimeString()` 两个扩展函数，格式与现有的 `Instant.toLocalDate()` / `toLocalTime()` 完全一致（均使用 `FormatStyle.MEDIUM` + `Locale.getDefault()`）。

2. **`TemplateTransformer.kt`**：
   - **user / assistant 消息**：`{{ date }}` / `{{ time }}` 改用 `message.createdAt`（消息自身的创建时间），使历史消息渲染结果跨请求保持稳定，恢复缓存命中率，同时让时间戳语义正确（昨天发的消息显示昨天的时间）。
   - **system / tool 等其他角色消息**：跳过模板渲染，原样返回。这类消息的 `createdAt` 每次请求都不同，若套模板会破坏最前缀缓存；且它们本不需要 `{{ role }}` / `{{ message }}` 等模板变量，跳过更合理。

### 影响

- 默认生效，用户无需修改既有模板设置；
- 同时解决缓存命中率低与 AI 对聊天时间无概念的问题；
- 时间戳语义更符合直觉，与 `TimeReminderTransformer` 的既有做法保持一致。

Closes #1366
