### PR TITLE
feat(workspace): support local rootfs archives + bug fixes

### DIFF
--- a/app/src/main/java/me/rerere/rikkahub/data/ai/GenerationHandler.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/ai/GenerationHandler.kt
@@ -12,8 +12,13 @@ import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.intOrNull
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.put
 import me.rerere.ai.core.MessageRole
 import me.rerere.ai.core.ReasoningLevel
@@ -473,6 +478,72 @@ class GenerationHandler(
 
         if (totalChars <= MAX_TOOL_OUTPUT_CHARS || !hasShellAccess) return output
 
+        // 尝试保留 JSON 结构（exitCode/stdout/stderr），仅截断大字段
+        val truncatedTextParts = textParts.map { part ->
+            val truncated = runCatching {
+                val obj = json.parseToJsonElement(part.text).jsonObject
+                val hasExitCode = obj.containsKey("exitCode") && obj["exitCode"]?.jsonPrimitive?.intOrNull != null
+                val hasStdoutOrStderr = obj.containsKey("stdout") || obj.containsKey("stderr")
+                if (hasExitCode && hasStdoutOrStderr) {
+                    val maxFieldLen = MAX_TOOL_OUTPUT_CHARS / 4
+                    json.encodeToString(
+                        buildJsonObject {
+                            obj.forEach { (key, value) ->
+                                if ((key == "stdout" || key == "stderr") && value is kotlinx.serialization.json.JsonPrimitive) {
+                                    val content = value.contentOrNull ?: ""
+                                    if (content.length > maxFieldLen) {
+                                        put(key, content.take(maxFieldLen))
+                                    } else {
+                                        put(key, value)
+                                    }
+                                } else {
+                                    put(key, value)
+                                }
+                            }
+                            put("truncated", JsonPrimitive(true))
+                        }
+                    )
+                } else {
+                    null
+                }
+            }.getOrNull()
+            if (truncated != null) UIMessagePart.Text(truncated) else part
+        }
+
+        val newTotal = truncatedTextParts.sumOf { it.text.length }
+        if (newTotal <= MAX_TOOL_OUTPUT_CHARS) {
+            // 写入完整输出到文件
+            val fullText = textParts.joinToString("\n") { it.text }
+            val fileName = "${toolCallId}.txt"
+            val outputDir = File(context.filesDir, FileFolders.TOOL_OUTPUTS).apply { mkdirs() }
+            File(outputDir, fileName).writeText(fullText)
+
+            // 在 JSON 中附加 systemReminder 字段
+            val withReminder = truncatedTextParts.map { part ->
+                runCatching {
+                    val obj = json.parseToJsonElement(part.text).jsonObject
+                    json.encodeToString(
+                        buildJsonObject {
+                            obj.forEach { (key, value) -> put(key, value) }
+                            put(
+                                "systemReminder",
+                                JsonPrimitive(
+                                    buildString {
+                                        appendLine("[Tool output truncated: $totalChars characters total]")
+                                        appendLine("Full output saved to: /tool_outputs/$fileName")
+                                        appendLine("Use shell to read: `cat /tool_outputs/$fileName`")
+                                        append("Use shell to search: `grep \"pattern\" /tool_outputs/$fileName`")
+                                    }
+                                ),
+                            )
+                        }
+                    )
+                }.getOrNull()?.let { UIMessagePart.Text(it) } ?: part
+            }
+            return withReminder + nonTextParts
+        }
+
+        // Fallback: 写入文件并返回摘要
         Log.i(TAG, "maybeTruncateToolOutput: truncating tool $toolCallId output ($totalChars chars)")
 
         val fullText = textParts.joinToString("\n") { it.text }

--- a/workspace/src/main/java/me/rerere/workspace/RootfsInstaller.kt
+++ b/workspace/src/main/java/me/rerere/workspace/RootfsInstaller.kt
@@ -6,6 +6,7 @@ import java.io.File
 import java.io.IOException
 import java.io.InputStream
 import java.net.HttpURLConnection
+import java.net.URI
 import java.net.URL
 import java.nio.file.Files
 import java.util.Locale
@@ -22,8 +23,29 @@ class RootfsInstaller(
         onProgress: (RootfsInstallProgress) -> Unit = {},
     ) {
         require(url.isNotBlank()) { "Rootfs download url is required" }
+        installArchive(root, ArchiveFormat.fromUrl(url), onProgress) { archive ->
+            download(url, archive, onProgress)
+        }
+    }
+
+    fun install(
+        root: String,
+        archiveName: String,
+        inputStream: InputStream,
+        onProgress: (RootfsInstallProgress) -> Unit = {},
+    ) {
+        installArchive(root, ArchiveFormat.fromUrl(archiveName), onProgress) { archive ->
+            importArchive(inputStream, archive, onProgress)
+        }
+    }
+
+    private fun installArchive(
+        root: String,
+        format: ArchiveFormat,
+        onProgress: (RootfsInstallProgress) -> Unit,
+        prepareArchive: (File) -> Unit,
+    ) {
         manager.ensureWorkspace(root)
-        val format = ArchiveFormat.fromUrl(url)
         val tempDir = manager.tempDir(root)
         val archive = File(tempDir, "rootfs.${format.extension}")
         val stagingDir = File(tempDir, "rootfs-staging")
@@ -32,7 +54,8 @@ class RootfsInstaller(
         try {
             stagingDir.deleteRecursively()
             stagingDir.mkdirs()
-            download(url, archive, onProgress)
+            prepareArchive(archive)
+            validateRootfsArchive(archive, format)
             extractTar(archive, stagingDir, format, onProgress)
             linuxDir.deleteRecursively()
             require(stagingDir.renameTo(linuxDir)) {
@@ -51,6 +74,19 @@ class RootfsInstaller(
         target: File,
         onProgress: (RootfsInstallProgress) -> Unit,
     ) {
+        if (url.startsWith("file://") || !url.contains("://")) {
+            val source = if (url.startsWith("file://")) {
+                runCatching { File(URI(url)) }.getOrElse { File(url.removePrefix("file://")) }
+            } else {
+                File(url)
+            }
+            require(source.isFile) { "Rootfs archive does not exist: $url" }
+            source.inputStream().use { input ->
+                copyArchive(input, target, source.length().takeIf { it > 0 }, RootfsInstallStage.UPLOADING, onProgress)
+            }
+            return
+        }
+
         val connection = URL(url).openConnection() as HttpURLConnection
         connection.connectTimeout = CONNECT_TIMEOUT_MS
         connection.readTimeout = READ_TIMEOUT_MS
@@ -59,42 +95,62 @@ class RootfsInstaller(
             val code = connection.responseCode
             require(code in 200..299) { "Rootfs download failed: HTTP $code" }
             val totalBytes = connection.contentLengthLong.takeIf { it > 0 }
-            target.parentFile?.mkdirs()
             connection.inputStream.use { input ->
-                target.outputStream().use { output ->
-                    val buffer = ByteArray(BUFFER_SIZE)
-                    var bytesRead = 0L
-                    var lastReportBytes = 0L
-                    while (true) {
-                        checkInterrupted()
-                        val read = input.read(buffer)
-                        if (read < 0) break
-                        output.write(buffer, 0, read)
-                        bytesRead += read
-                        if (bytesRead - lastReportBytes >= PROGRESS_STEP_BYTES || bytesRead == totalBytes) {
-                            lastReportBytes = bytesRead
-                            onProgress(
-                                RootfsInstallProgress(
-                                    stage = RootfsInstallStage.DOWNLOADING,
-                                    bytesRead = bytesRead,
-                                    totalBytes = totalBytes,
-                                )
-                            )
-                        }
-                    }
-                    if (bytesRead == 0L) {
-                        onProgress(
-                            RootfsInstallProgress(
-                                stage = RootfsInstallStage.DOWNLOADING,
-                                bytesRead = 0,
-                                totalBytes = totalBytes,
-                            )
-                        )
-                    }
-                }
+                copyArchive(input, target, totalBytes, RootfsInstallStage.DOWNLOADING, onProgress)
             }
         } finally {
             connection.disconnect()
+        }
+    }
+
+    private fun importArchive(
+        inputStream: InputStream,
+        target: File,
+        onProgress: (RootfsInstallProgress) -> Unit,
+    ) {
+        inputStream.use { input ->
+            copyArchive(input, target, null, RootfsInstallStage.UPLOADING, onProgress)
+        }
+    }
+
+    private fun copyArchive(
+        inputStream: InputStream,
+        target: File,
+        totalBytes: Long?,
+        stage: RootfsInstallStage,
+        onProgress: (RootfsInstallProgress) -> Unit,
+    ) {
+        target.parentFile?.mkdirs()
+        target.outputStream().use { output ->
+            val buffer = ByteArray(BUFFER_SIZE)
+            var bytesRead = 0L
+            var lastReportBytes = 0L
+            while (true) {
+                checkInterrupted()
+                val read = inputStream.read(buffer)
+                if (read < 0) break
+                output.write(buffer, 0, read)
+                bytesRead += read
+                if (bytesRead - lastReportBytes >= PROGRESS_STEP_BYTES || bytesRead == totalBytes) {
+                    lastReportBytes = bytesRead
+                    onProgress(
+                        RootfsInstallProgress(
+                            stage = stage,
+                            bytesRead = bytesRead,
+                            totalBytes = totalBytes,
+                        )
+                    )
+                }
+            }
+            if (bytesRead == 0L) {
+                onProgress(
+                    RootfsInstallProgress(
+                        stage = RootfsInstallStage.DOWNLOADING,
+                        bytesRead = 0,
+                        totalBytes = totalBytes,
+                    )
+                )
+            }
         }
     }
 
@@ -263,6 +319,40 @@ class RootfsInstaller(
         return result
     }
 
+    private fun validateRootfsArchive(
+        archive: File,
+        format: ArchiveFormat,
+    ) {
+        format.wrapStream(BufferedInputStream(archive.inputStream())).use { input ->
+            while (true) {
+                checkInterrupted()
+                val rawHeader = input.readTarHeader() ?: break
+                when (rawHeader.type) {
+                    TarEntryType.LONG_NAME -> {
+                        val longName = input.readExactly(rawHeader.size)
+                            .toString(Charsets.UTF_8)
+                            .trimEnd('\u0000', '\n')
+                        input.skipFully(rawHeader.size.paddingSize())
+                        if (longName in ROOTFS_SHELLS) return
+                    }
+
+                    TarEntryType.PAX -> {
+                        input.skipFully(rawHeader.size.paddedTarSize())
+                    }
+
+                    else -> {
+                        if (rawHeader.name in ROOTFS_SHELLS) return
+                        if (rawHeader.type != TarEntryType.FILE) {
+                            input.skipFully(rawHeader.size)
+                        }
+                        input.skipFully(rawHeader.size.paddingSize())
+                    }
+                }
+            }
+        }
+        throw IllegalArgumentException("not a valid rootfs archive file")
+    }
+
     // 协程取消时调用方通过 runInterruptible 将取消转成线程中断, 这里在阻塞循环中检测并尽早退出,
     // 避免离开页面后仍继续下载/解压并向已清空的 StateFlow 推送进度
     private fun checkInterrupted() {
@@ -318,6 +408,7 @@ class RootfsInstaller(
 
     private fun File.safeResolve(path: String): File {
         val normalized = normalizeTarPath(path)
+        require(normalized.isNotBlank()) { "Rootfs entry path is blank" }
         val root = canonicalFile
         val target = File(root, normalized).canonicalFile
         require(target.path == root.path || target.path.startsWith(root.path + File.separator)) {
@@ -338,7 +429,6 @@ class RootfsInstaller(
             .trim()
             .trimStart('/')
             .removePrefix("./")
-        require(normalized.isNotBlank()) { "Rootfs entry path is blank" }
         require(!normalized.contains('\u0000')) { "Rootfs entry path contains invalid character" }
         require(normalized.split('/').none { it == ".." }) { "Rootfs entry escapes target directory: $path" }
         return normalized
@@ -414,5 +504,13 @@ class RootfsInstaller(
         private const val PROGRESS_STEP_BYTES = 512 * 1024
         private const val CONNECT_TIMEOUT_MS = 30_000
         private const val READ_TIMEOUT_MS = 60_000
+        private val ROOTFS_SHELLS = setOf(
+            "bin/bash",
+            "usr/bin/bash",
+            "bin/ash",
+            "bin/dash",
+            "bin/sh",
+            "usr/bin/sh",
+        )
     }
 }

--- a/workspace/src/test/java/me/rerere/workspace/ExampleUnitTest.kt
+++ b/workspace/src/test/java/me/rerere/workspace/ExampleUnitTest.kt
@@ -64,6 +64,7 @@ class ExampleUnitTest {
         val installer = RootfsInstaller(manager)
         val archive = tarGz(
             TarTestEntry("bin/", type = '5'),
+            TarTestEntry("bin/sh", content = "#!/bin/sh\n".toByteArray(), mode = 493),
             TarTestEntry("bin/hello", content = "echo hello\n".toByteArray(), mode = 493),
             TarTestEntry("usr/bin/hello-link", type = '2', linkName = "../../bin/hello"),
         )

--- a/workspace/src/test/java/me/rerere/workspace/RootfsInstallerTest.kt
+++ b/workspace/src/test/java/me/rerere/workspace/RootfsInstallerTest.kt
@@ -2,6 +2,7 @@ package me.rerere.workspace
 
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
@@ -47,6 +48,40 @@ class RootfsInstallerTest {
 
         assertEquals(true, File(target, "dir").isDirectory)
         assertEquals("content", File(target, "dir/file.txt").readText())
+    }
+
+    @Test
+    fun `validate rootfs archive passes for archive with shell`() {
+        val archive = tmp.newFile("rootfs.tar.gz")
+        GZIPOutputStream(archive.outputStream()).use { out ->
+            out.writeTarEntry("bin/", '5', ByteArray(0))
+            out.writeTarEntry("bin/sh", '0', "#!/bin/sh\n".toByteArray())
+            out.write(ByteArray(TAR_BLOCK * 2))
+        }
+
+        val manager = WorkspaceManager(tmp.newFolder())
+        val installer = RootfsInstaller(manager)
+        installer.install("test", "rootfs.tar.gz", archive.inputStream()) {}
+
+        assertTrue(manager.hasRootfs("test"))
+    }
+
+    @Test
+    fun `validate rootfs archive rejects archive without shell`() {
+        val archive = tmp.newFile("rootfs.tar.gz")
+        GZIPOutputStream(archive.outputStream()).use { out ->
+            out.writeTarEntry("etc/passwd", '0', "root:x:0:0:root:/root:\n".toByteArray())
+            out.write(ByteArray(TAR_BLOCK * 2))
+        }
+
+        val manager = WorkspaceManager(tmp.newFolder())
+        val installer = RootfsInstaller(manager)
+        try {
+            installer.install("test", "rootfs.tar.gz", archive.inputStream()) {}
+            throw AssertionError("Expected IllegalArgumentException")
+        } catch (e: IllegalArgumentException) {
+            assertEquals("not a valid rootfs archive file", e.message)
+        }
     }
 
     private fun createInstaller() = RootfsInstaller(WorkspaceManager(tmp.newFolder()))


### PR DESCRIPTION
Support installing workspace rootfs from a local archive file (`.tar.gz`, `.tar.xz`, `.txz`) — accepts both `file://` URLs and plain local paths. Shows "Uploading" progress for local files, "Downloading" for URLs.

Before extracting, the archive is validated to contain a known shell binary (`/bin/bash`, `/usr/bin/bash`, `/bin/ash`, `/bin/dash`, `/bin/sh`, `/usr/bin/sh`). Non-rootfs archives are rejected with `"not a valid rootfs archive file"`. Also fixes shell availability checks for rootfs images that use absolute symlinks, and handles tar entries like `./` that previously caused extraction to fail.

Fixes tool output truncation: when shell output exceeds 32 KB, the old code flattened the structured JSON (exitCode/stdout/stderr) into plain text. The UI (`WorkspaceToolUIs.kt`) couldn't find `exitCode` and fell back to displaying "exit ?" with no output content at all — making tools look broken even though the LLM side technically received the data. Now it preserves the JSON structure, truncating only the oversized stdout/stderr fields, and attaches a `systemReminder` field with the full output file path for the LLM.