### PR TITLE
fix(avatar): crop selected assistant avatar images

### DIFF
--- a/app/src/main/java/me/rerere/rikkahub/ui/components/ai/CropLauncher.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/ai/CropLauncher.kt
@@ -20,7 +20,10 @@ import java.io.File
 
 @Composable
 internal fun useCropLauncher(
-    onCroppedImageReady: (Uri) -> Unit, onCleanup: (() -> Unit)? = null
+    onCroppedImageReady: (Uri) -> Unit,
+    onCleanup: (() -> Unit)? = null,
+    aspectRatio: Pair<Float, Float>? = null,
+    freeStyleCropEnabled: Boolean = true
 ): Pair<ActivityResultLauncher<Intent>, (Uri) -> Unit> {
     val context = LocalContext.current
     var cropOutputUri by remember { mutableStateOf<Uri?>(null) }
@@ -42,13 +45,17 @@ internal fun useCropLauncher(
         val outputFile = File(context.appTempFolder, "crop_output_${System.currentTimeMillis()}.jpg")
         cropOutputUri = Uri.fromFile(outputFile)
 
-        val cropIntent = UCrop.of(sourceUri, cropOutputUri!!).withOptions(UCrop.Options().apply {
-            setFreeStyleCropEnabled(true)
+        var crop = UCrop.of(sourceUri, cropOutputUri!!).withOptions(UCrop.Options().apply {
+            setFreeStyleCropEnabled(freeStyleCropEnabled)
             setAllowedGestures(
                 UCropActivity.SCALE, UCropActivity.ROTATE, UCropActivity.NONE
             )
             setCompressionFormat(Bitmap.CompressFormat.PNG)
-        }).withMaxResultSize(4096, 4096).getIntent(context)
+        }).withMaxResultSize(4096, 4096)
+        aspectRatio?.let { (x, y) ->
+            crop = crop.withAspectRatio(x, y)
+        }
+        val cropIntent = crop.getIntent(context)
 
         cropActivityLauncher.launch(cropIntent)
     }

--- a/app/src/main/java/me/rerere/rikkahub/ui/components/ui/UIAvatar.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/ui/UIAvatar.kt
@@ -3,6 +3,7 @@ package me.rerere.rikkahub.ui.components.ui
 import android.net.Uri
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
 import androidx.compose.foundation.text.TextAutoSize
@@ -47,14 +48,18 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.em
 import androidx.compose.ui.unit.sp
+import androidx.core.net.toUri
 import coil3.compose.AsyncImage
+import me.rerere.common.android.appTempFolder
 import me.rerere.hugeicons.HugeIcons
 import me.rerere.hugeicons.stroke.Edit03
 import me.rerere.rikkahub.R
 import me.rerere.rikkahub.data.files.FilesManager
 import me.rerere.rikkahub.data.model.Avatar
+import me.rerere.rikkahub.ui.components.ai.useCropLauncher
 import me.rerere.rikkahub.ui.hooks.rememberAvatarShape
 import org.koin.compose.koinInject
+import java.io.File
 
 @Composable
 fun TextAvatar(
@@ -95,18 +100,47 @@ fun UIAvatar(
     onClick: (() -> Unit)? = null
 ) {
     val filesManager: FilesManager = koinInject()
+    val context = LocalContext.current
     var showPickOption by remember { mutableStateOf(false) }
     var showEmojiPicker by remember { mutableStateOf(false) }
     var showUrlInput by remember { mutableStateOf(false) }
     var urlInput by remember { mutableStateOf("") }
+    var preCropTempFile by remember { mutableStateOf<File?>(null) }
+
+    fun saveAvatarImage(uri: Uri) {
+        val localUris = filesManager.createChatFilesByContents(listOf(uri))
+        localUris.firstOrNull()?.let { localUri ->
+            onUpdate?.invoke(Avatar.Image(localUri.toString()))
+        }
+    }
+
+    val (_, launchImageCrop) = useCropLauncher(
+        onCroppedImageReady = { croppedUri ->
+            saveAvatarImage(croppedUri)
+        },
+        onCleanup = {
+            preCropTempFile?.delete()
+            preCropTempFile = null
+        },
+        aspectRatio = 1f to 1f,
+        freeStyleCropEnabled = false
+    )
 
     val imagePickerLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.GetContent()
     ) { uri: Uri? ->
-        uri?.let {
-            val localUris = filesManager.createChatFilesByContents(listOf(it))
-            localUris.firstOrNull()?.let { localUri ->
-                onUpdate?.invoke(Avatar.Image(localUri.toString()))
+        uri?.let { selectedUri ->
+            val tempFile = File(context.appTempFolder, "avatar_pick_${System.currentTimeMillis()}.jpg")
+            runCatching {
+                context.contentResolver.openInputStream(selectedUri)?.use { input ->
+                    tempFile.outputStream().use { output -> input.copyTo(output) }
+                } ?: error("Failed to open input stream for $selectedUri")
+                preCropTempFile?.delete()
+                preCropTempFile = tempFile
+                launchImageCrop(tempFile.toUri())
+            }.onFailure {
+                tempFile.delete()
+                launchImageCrop(selectedUri)
             }
         }
     }


### PR DESCRIPTION
选择助手头像图片时进入图片裁剪，并固定为 1:1
- 为 useCropLauncher 增加可选比例和自由裁剪开关
- 助手头像选择图片后进入 1:1 裁剪
- 保持聊天图片裁剪默认行为不变