### PR TITLE
feat(mcp): spec-compliant OAuth for Streamable HTTP servers

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -207,6 +207,8 @@ dependencies {
     implementation(libs.ktor.client.okhttp)
     implementation(libs.ktor.client.content.negotiation)
     implementation(libs.ktor.serialization.kotlinx.json)
+    implementation(libs.ktor.server.core)
+    implementation(libs.ktor.server.cio)
 
     // ucrop
     implementation(libs.ucrop)

--- a/app/src/main/java/me/rerere/rikkahub/data/ai/mcp/McpConfig.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/ai/mcp/McpConfig.kt
@@ -23,6 +23,11 @@ data class McpTool(
 )
 
 @Serializable
+data class McpOAuthConfig(
+    val enabled: Boolean = true,
+)
+
+@Serializable
 sealed class McpServerConfig {
     abstract val id: Uuid
     abstract val commonOptions: McpCommonOptions
@@ -50,6 +55,7 @@ sealed class McpServerConfig {
         override val id: Uuid = Uuid.random(),
         override val commonOptions: McpCommonOptions = McpCommonOptions(),
         val url: String = "",
+        val oauth: McpOAuthConfig? = null,
     ) : McpServerConfig() {
         override fun clone(id: Uuid, commonOptions: McpCommonOptions): McpServerConfig {
             return copy(id = id, commonOptions = commonOptions)

--- a/app/src/main/java/me/rerere/rikkahub/data/ai/mcp/McpManager.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/ai/mcp/McpManager.kt
@@ -7,6 +7,7 @@ import io.ktor.client.engine.okhttp.OkHttp
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.client.plugins.sse.SSE
 import io.ktor.serialization.kotlinx.json.json
+import io.ktor.http.HttpHeaders
 import io.ktor.util.StringValues
 import io.modelcontextprotocol.kotlin.sdk.client.Client
 import io.modelcontextprotocol.kotlin.sdk.client.SseClientTransport
@@ -55,6 +56,7 @@ class McpManager(
     private val settingsStore: SettingsStore,
     private val appScope: AppScope,
     private val filesManager: FilesManager,
+    private val oAuthManager: McpOAuthManager,
 ) {
     private val okHttpClient: OkHttpClient = OkHttpClient.Builder()
         .connectTimeout(20, TimeUnit.SECONDS)
@@ -100,14 +102,16 @@ class McpManager(
                         toAdd.forEach { cfg ->
                             appScope.launch {
                                 runCatching { addClient(cfg) }
-                                    .onFailure { it.printStackTrace() }
+                                    .onFailure {
+                                        Log.w(TAG, "Failed to add MCP client ${cfg.commonOptions.name}: ${it.safeLogMessage()}")
+                                    }
                             }
                         }
                         toRemove.forEach { cfg ->
                             appScope.launch { removeClient(cfg) }
                         }
                     }.onFailure {
-                        it.printStackTrace()
+                        Log.w(TAG, "Failed to update MCP configs: ${it.safeLogMessage()}")
                     }
                 }
         }
@@ -138,16 +142,37 @@ class McpManager(
         val config = entry.key
         Log.i(TAG, "callTool: $toolName / $args (server: ${config.commonOptions.name})")
 
+        if (!ensureOAuthTokenForConnect(config)) {
+            return listOf(UIMessagePart.Text("MCP server needs OAuth authorization. Please authorize it in settings."))
+        }
         if (client.transport == null) client.connect(getTransport(config))
-        val result = client.callTool(
-            request = CallToolRequest(
-                params = CallToolRequestParams(
-                    name = toolName,
-                    arguments = args,
+        val result = runCatching {
+            client.callTool(
+                request = CallToolRequest(
+                    params = CallToolRequestParams(
+                        name = toolName,
+                        arguments = args,
+                    ),
                 ),
-            ),
-            options = RequestOptions(timeout = 120.seconds),
-        )
+                options = RequestOptions(timeout = 120.seconds),
+            )
+        }.getOrElse { error ->
+            if (handleOAuthFailure(config, error)) {
+                client.callTool(
+                    request = CallToolRequest(
+                        params = CallToolRequestParams(
+                            name = toolName,
+                            arguments = args,
+                        ),
+                    ),
+                    options = RequestOptions(timeout = 120.seconds),
+                )
+            } else if (error.isOAuthAuthorizationError(config)) {
+                return listOf(UIMessagePart.Text("MCP OAuth authorization is required or needs more permissions. Please authorize this server in MCP settings."))
+            } else {
+                throw error
+            }
+        }
         return result.content.map {
             when(it) {
                 is TextContent -> UIMessagePart.Text(it.text)
@@ -178,9 +203,7 @@ class McpManager(
                 client = client,
                 requestBuilder = {
                     headers.appendAll(StringValues.build {
-                        config.commonOptions.headers.forEach {
-                            append(it.first, it.second)
-                        }
+                        config.commonOptions.headers.forEach { append(it.first, it.second) }
                     })
                 },
             )
@@ -192,8 +215,14 @@ class McpManager(
                 client = client,
                 requestBuilder = {
                     headers.appendAll(StringValues.build {
-                        config.commonOptions.headers.forEach {
-                            append(it.first, it.second)
+                        if (config.oauth?.enabled == true) {
+                            oAuthManager.getCachedAccessToken(config.id)?.let {
+                                append(HttpHeaders.Authorization, "Bearer $it")
+                            }
+                        } else {
+                            config.commonOptions.headers.forEach {
+                                append(it.first, it.second)
+                            }
                         }
                     })
                 }
@@ -205,6 +234,8 @@ class McpManager(
         removeClient(config) // Remove first
         cancelReconnect(config.id)
         reconnectAttempts[config.id] = 0
+
+        if (!ensureOAuthTokenForConnect(config)) return@withContext
 
         val transport = getTransport(config)
         val client = Client(
@@ -225,7 +256,7 @@ class McpManager(
         }
 
         transport.onError { error ->
-            Log.e(TAG, "Transport error for ${config.commonOptions.name}: ${error.message}")
+            Log.e(TAG, "Transport error for ${config.commonOptions.name}: ${error.safeLogMessage()}")
             val currentStatus = syncingStatus.value[config.id]
             // 只有在已连接状态下才触发重连
             if (currentStatus == McpStatus.Connected) {
@@ -242,8 +273,32 @@ class McpManager(
             reconnectAttempts[config.id] = 0 // 重置重连计数
             Log.i(TAG, "addClient: connected ${config.commonOptions.name}")
         }.onFailure {
-            it.printStackTrace()
-            setStatus(config = config, status = McpStatus.Error(it.message ?: it.javaClass.name))
+            Log.w(TAG, "Failed to connect MCP client ${config.commonOptions.name}: ${it.safeLogMessage()}")
+            if (handleOAuthFailure(config, it)) {
+                if (!retryConnectAfterOAuth(config)) {
+                    setStatus(config = config, status = McpStatus.Error(it.message ?: it.javaClass.name))
+                }
+            } else if (!it.isOAuthAuthorizationError(config)) {
+                setStatus(config = config, status = McpStatus.Error(it.message ?: it.javaClass.name))
+            }
+        }
+    }
+
+    fun authorize(config: McpServerConfig.StreamableHTTPServer): Job {
+        return appScope.launch(Dispatchers.IO) {
+            setStatus(config, McpStatus.Authorizing)
+            when (val result = oAuthManager.authorize(config.id, config.url)) {
+                is OAuthResult.Success -> addClient(config)
+                is OAuthResult.Error -> setStatus(config, McpStatus.Error(result.message))
+            }
+        }
+    }
+
+    fun revokeAuthorization(config: McpServerConfig.StreamableHTTPServer): Job {
+        return appScope.launch(Dispatchers.IO) {
+            oAuthManager.revoke(config.id)
+            removeClient(config)
+            setStatus(config, McpStatus.Idle)
         }
     }
 
@@ -251,6 +306,7 @@ class McpManager(
         val client = clients[config] ?: return
 
         setStatus(config = config, status = McpStatus.Connecting)
+        if (!ensureOAuthTokenForConnect(config)) return
 
         // Update tools
         if (client.transport == null) {
@@ -317,7 +373,7 @@ class McpManager(
             runCatching {
                 sync(config)
             }.onFailure {
-                it.printStackTrace()
+                Log.w(TAG, "Failed to sync MCP client ${config.commonOptions.name}: ${it.safeLogMessage()}")
                 setStatus(config, McpStatus.Error(it.message ?: it.javaClass.name))
             }
         }
@@ -330,7 +386,7 @@ class McpManager(
             runCatching {
                 entry.value.close()
             }.onFailure {
-                it.printStackTrace()
+                Log.w(TAG, "Failed to close MCP client ${entry.key.commonOptions.name}: ${it.safeLogMessage()}")
             }
             clients.remove(entry.key)
             syncingStatus.emit(syncingStatus.value.toMutableMap().apply { remove(entry.key.id) })
@@ -380,7 +436,7 @@ class McpManager(
                 Log.i(TAG, "Reconnect cancelled for ${config.commonOptions.name}")
                 throw e
             } catch (e: Exception) {
-                Log.e(TAG, "Reconnect failed for ${config.commonOptions.name}", e)
+                Log.e(TAG, "Reconnect failed for ${config.commonOptions.name}: ${e.safeLogMessage()}")
                 // 继续尝试重连
                 scheduleReconnect(config)
             }
@@ -399,10 +455,15 @@ class McpManager(
     }
 
     private suspend fun reconnectClient(config: McpServerConfig) = withContext(Dispatchers.IO) {
+        if (!ensureOAuthTokenForConnect(config)) return@withContext
+
         // 先关闭旧客户端
         val oldEntry = clients.entries.find { it.key.id == config.id }
         if (oldEntry != null) {
-            runCatching { oldEntry.value.close() }.onFailure { it.printStackTrace() }
+            runCatching { oldEntry.value.close() }
+                .onFailure {
+                    Log.w(TAG, "Failed to close old MCP client ${config.commonOptions.name}: ${it.safeLogMessage()}")
+                }
             clients.remove(oldEntry.key)
         }
 
@@ -424,7 +485,7 @@ class McpManager(
         }
 
         transport.onError { error ->
-            Log.e(TAG, "Transport error for ${config.commonOptions.name}: ${error.message}")
+            Log.e(TAG, "Transport error for ${config.commonOptions.name}: ${error.safeLogMessage()}")
             val currentStatus = syncingStatus.value[config.id]
             if (currentStatus == McpStatus.Connected) {
                 scheduleReconnect(config)
@@ -433,11 +494,53 @@ class McpManager(
 
         clients[config] = client
         setStatus(config, McpStatus.Connecting)
-        client.connect(transport)
-        sync(config)
-        setStatus(config, McpStatus.Connected)
-        reconnectAttempts[config.id] = 0 // 重置重连计数
-        Log.i(TAG, "Reconnected successfully: ${config.commonOptions.name}")
+        runCatching {
+            client.connect(transport)
+            sync(config)
+            setStatus(config, McpStatus.Connected)
+            reconnectAttempts[config.id] = 0 // 重置重连计数
+            Log.i(TAG, "Reconnected successfully: ${config.commonOptions.name}")
+        }.onFailure {
+            if (!handleOAuthFailure(config, it) && !it.isOAuthAuthorizationError(config)) throw it
+        }
+    }
+
+    private suspend fun ensureOAuthTokenForConnect(config: McpServerConfig): Boolean {
+        if (config !is McpServerConfig.StreamableHTTPServer || config.oauth?.enabled != true) return true
+        val token = oAuthManager.ensureValidToken(config.id)
+        return if (token == null) {
+            setStatus(config, McpStatus.Error("This MCP server requires OAuth authorization. Please tap Authorize."))
+            false
+        } else {
+            true
+        }
+    }
+
+    private suspend fun handleOAuthFailure(config: McpServerConfig, error: Throwable): Boolean {
+        if (config !is McpServerConfig.StreamableHTTPServer || config.oauth?.enabled != true) return false
+        val statusCode = error.httpStatusCode() ?: return false
+        return oAuthManager.handleAuthFailure(config.id, statusCode, error.wwwAuthenticate())
+    }
+
+    private suspend fun retryConnectAfterOAuth(config: McpServerConfig): Boolean {
+        if (config !is McpServerConfig.StreamableHTTPServer || config.oauth?.enabled != true) return false
+        val transport = getTransport(config)
+        val client = Client(
+            clientInfo = Implementation(
+                name = config.commonOptions.name,
+                version = "1.0",
+            )
+        )
+        clients[config] = client
+        return runCatching {
+            setStatus(config = config, status = McpStatus.Connecting)
+            client.connect(transport)
+            sync(config)
+            setStatus(config = config, status = McpStatus.Connected)
+            true
+        }.getOrElse {
+            false
+        }
     }
 
     private suspend fun setStatus(config: McpServerConfig, status: McpStatus) {
@@ -463,4 +566,45 @@ internal val McpJson: Json by lazy {
 
 private fun ToolSchema.toSchema(): InputSchema {
     return InputSchema.Obj(properties = this.properties ?: JsonObject(emptyMap()), required = this.required)
+}
+
+private fun Throwable.httpStatusCode(): Int? {
+    val response = runCatching {
+        this::class.java.methods.firstOrNull { it.name == "getResponse" }?.invoke(this)
+    }.getOrNull()
+    val status = runCatching {
+        response?.javaClass?.methods?.firstOrNull { it.name == "getStatus" }?.invoke(response)
+    }.getOrNull()
+    val value = runCatching {
+        status?.javaClass?.methods?.firstOrNull { it.name == "getValue" }?.invoke(status) as? Int
+    }.getOrNull()
+    if (value != null) return value
+    val code = runCatching {
+        this::class.java.methods.firstOrNull { it.name == "getCode" }?.invoke(this) as? Int
+    }.getOrNull()
+    if (code != null) return code
+    return Regex("""\b(401|403)\b""").find(message.orEmpty())?.value?.toIntOrNull()
+}
+
+private fun Throwable.wwwAuthenticate(): String? {
+    val response = runCatching {
+        this::class.java.methods.firstOrNull { it.name == "getResponse" }?.invoke(this)
+    }.getOrNull()
+    val headers = runCatching {
+        response?.javaClass?.methods?.firstOrNull { it.name == "getHeaders" }?.invoke(response)
+    }.getOrNull()
+    return runCatching {
+        headers?.javaClass?.methods
+            ?.firstOrNull { it.name == "get" && it.parameterTypes.size == 1 }
+            ?.invoke(headers, "WWW-Authenticate") as? String
+    }.getOrNull()
+}
+
+private fun Throwable.isOAuthAuthorizationError(config: McpServerConfig): Boolean {
+    if (config !is McpServerConfig.StreamableHTTPServer || config.oauth?.enabled != true) return false
+    return httpStatusCode() == 401 || httpStatusCode() == 403
+}
+
+private fun Throwable.safeLogMessage(): String {
+    return "${this::class.java.simpleName}: ${message?.take(160).orEmpty()}"
 }

--- a/app/src/main/java/me/rerere/rikkahub/data/ai/mcp/McpOAuthManager.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/ai/mcp/McpOAuthManager.kt
@@ -1,0 +1,713 @@
+package me.rerere.rikkahub.data.ai.mcp
+
+import android.content.Context
+import android.content.Intent
+import android.net.ConnectivityManager
+import android.net.Network
+import android.net.Uri
+import android.os.Build
+import android.util.Log
+import io.ktor.http.ContentType
+import io.ktor.server.application.call
+import io.ktor.server.cio.CIO
+import io.ktor.server.cio.CIOApplicationEngine
+import io.ktor.server.engine.EmbeddedServer
+import io.ktor.server.engine.embeddedServer
+import io.ktor.server.response.respondText
+import io.ktor.server.routing.get
+import io.ktor.server.routing.routing
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withTimeout
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+import kotlinx.serialization.json.putJsonArray
+import me.rerere.common.http.await
+import okhttp3.FormBody
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import java.security.MessageDigest
+import java.security.SecureRandom
+import java.util.Base64
+import java.util.concurrent.ConcurrentHashMap
+import kotlin.coroutines.resume
+import kotlin.uuid.Uuid
+
+private const val MCP_OAUTH_TAG = "McpOAuthManager"
+
+class McpOAuthManager(
+    private val context: Context,
+    private val scope: CoroutineScope,
+    private val client: OkHttpClient,
+    private val store: McpOAuthTokenStore,
+    private val json: Json,
+) {
+    private var server: EmbeddedServer<CIOApplicationEngine, CIOApplicationEngine.Configuration>? = null
+    private var callbackPort: Int? = null
+    private val sessions = ConcurrentHashMap<String, OAuthSession>()
+    private val refreshLocks = ConcurrentHashMap<Uuid, Mutex>()
+    private val pendingScopes = ConcurrentHashMap<Uuid, List<String>>()
+    private val mutex = Mutex()
+    private val _status = MutableStateFlow<Map<Uuid, McpOAuthStatus>>(emptyMap())
+    val status: StateFlow<Map<Uuid, McpOAuthStatus>> = _status.asStateFlow()
+
+    init {
+        restoreStoredAuthorizationStatuses()
+    }
+
+    fun getCachedAccessToken(serverId: Uuid): String? {
+        val credential = store.read().credentials.firstOrNull { it.serverId == serverId } ?: return null
+        if (credential.expiresAt != null && credential.expiresAt <= System.currentTimeMillis() + REFRESH_MARGIN_MS) {
+            return null
+        }
+        return credential.accessToken
+    }
+
+    suspend fun ensureValidToken(serverId: Uuid): String? {
+        val credential = mutex.withLock {
+            store.read().credentials.firstOrNull { it.serverId == serverId }
+        } ?: return null
+        if (credential.expiresAt == null || credential.expiresAt > System.currentTimeMillis() + REFRESH_MARGIN_MS) {
+            return credential.accessToken
+        }
+        return refreshToken(serverId)
+    }
+
+    suspend fun authorize(serverId: Uuid, serverUrl: String): OAuthResult {
+        setStatus(serverId, McpOAuthStatus.Authorizing)
+        var state: String? = null
+        return runCatching {
+            val challenge = fetchInitialChallenge(serverUrl)
+            val discovered = discover(serverUrl, challenge)
+            val requestedScopes = pendingScopes[serverId] ?: discovered.scopes
+            val verifier = randomUrlSafe(64)
+            val codeChallenge = Base64.getUrlEncoder().withoutPadding().encodeToString(
+                MessageDigest.getInstance("SHA-256").digest(verifier.encodeToByteArray())
+            )
+            val port = ensureCallbackServer()
+            val redirectUri = "http://localhost:$port/auth/callback"
+            val clientRegistration = ensureClient(serverId, discovered, redirectUri, requestedScopes)
+            val oauthState = randomUrlSafe(32)
+            state = oauthState
+            val deferred = CompletableDeferred<StoredMcpOAuthCredential>()
+            sessions[oauthState] = OAuthSession(
+                serverId = serverId,
+                verifier = verifier,
+                redirectUri = redirectUri,
+                discovered = discovered,
+                client = clientRegistration,
+                scopes = requestedScopes,
+                deferred = deferred,
+            )
+
+            val authUrl = Uri.parse(discovered.asMetadata.authorizationEndpoint).buildUpon()
+                .appendQueryParameter("response_type", "code")
+                .appendQueryParameter("client_id", clientRegistration.clientId)
+                .appendQueryParameter("redirect_uri", redirectUri)
+                .appendQueryParameter("state", oauthState)
+                .appendQueryParameter("code_challenge", codeChallenge)
+                .appendQueryParameter("code_challenge_method", "S256")
+                .appendQueryParameter("resource", discovered.resource)
+                .apply {
+                    if (requestedScopes.isNotEmpty()) {
+                        appendQueryParameter("scope", requestedScopes.joinToString(" "))
+                    }
+                }
+                .build()
+
+            context.startActivity(
+                Intent(Intent.ACTION_VIEW, authUrl).apply {
+                    addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                }
+            )
+
+            val credential = withTimeout(AUTH_TIMEOUT_MS) { deferred.await() }
+            pendingScopes.remove(serverId)
+            setStatus(serverId, McpOAuthStatus.Authorized)
+            OAuthResult.Success(credential.accessToken)
+        }.getOrElse { error ->
+            state?.let { sessions.remove(it)?.deferred?.cancel() }
+                ?: sessions.entries.removeIf { it.value.serverId == serverId }
+            Log.e(MCP_OAUTH_TAG, "OAuth authorization failed: ${error.safeLogMessage()}")
+            val message = when (error) {
+                is TimeoutCancellationException -> "MCP OAuth authorization timed out. Please try again."
+                else -> error.message ?: "MCP OAuth authorization failed"
+            }
+            setStatus(serverId, McpOAuthStatus.Error(message))
+            OAuthResult.Error(message)
+        }.also {
+            stopCallbackServerIfIdle()
+        }
+    }
+
+    suspend fun handleAuthFailure(serverId: Uuid, statusCode: Int, wwwAuthenticate: String?): Boolean {
+        return when (statusCode) {
+            401 -> {
+                val refreshed = refreshToken(serverId) != null
+                if (!refreshed) {
+                    clearCredential(serverId)
+                    setStatus(serverId, McpOAuthStatus.Error("MCP OAuth authorization expired. Please authorize again."))
+                }
+                refreshed
+            }
+            403 -> {
+                val scope = parseWwwAuthenticate(wwwAuthenticate).scope.orEmpty()
+                val scopes = scope.split(" ").filter { it.isNotBlank() }
+                if (scopes.isNotEmpty()) {
+                    pendingScopes[serverId] = scopes
+                }
+                val message = if (scope.isBlank()) {
+                    "MCP OAuth permission is insufficient. Please authorize again."
+                } else {
+                    "MCP OAuth permission is insufficient. Please authorize again for: $scope"
+                }
+                setStatus(serverId, McpOAuthStatus.Error(message))
+                false
+            }
+            else -> false
+        }
+    }
+
+    suspend fun revoke(serverId: Uuid) {
+        mutex.withLock {
+            val state = store.read()
+            store.write(
+                state.copy(
+                    credentials = state.credentials.filterNot { it.serverId == serverId },
+                    clients = state.clients.filterNot { it.serverId == serverId },
+                )
+            )
+        }
+        sessions.entries.removeIf { it.value.serverId == serverId }
+        stopCallbackServerIfIdle()
+        setStatus(serverId, McpOAuthStatus.Idle)
+    }
+
+    private suspend fun clearCredential(serverId: Uuid) {
+        mutex.withLock {
+            val state = store.read()
+            store.write(
+                state.copy(
+                    credentials = state.credentials.filterNot { it.serverId == serverId },
+                )
+            )
+        }
+    }
+
+    private suspend fun refreshToken(serverId: Uuid): String? {
+        val lock = refreshLocks.getOrPut(serverId) { Mutex() }
+        return lock.withLock {
+            val existing = mutex.withLock {
+                store.read().credentials.firstOrNull { it.serverId == serverId }
+            } ?: return@withLock null
+            val refreshToken = existing.refreshToken ?: return@withLock null
+            runCatching {
+                val form = FormBody.Builder()
+                    .add("grant_type", "refresh_token")
+                    .add("refresh_token", refreshToken)
+                    .add("client_id", existing.clientId)
+                    .add("resource", existing.resource)
+                    .apply {
+                        existing.clientSecret?.let { add("client_secret", it) }
+                        if (existing.scopes.isNotEmpty()) add("scope", existing.scopes.joinToString(" "))
+                    }
+                    .build()
+                val response = client.newCall(
+                    Request.Builder()
+                        .url(existing.tokenEndpoint)
+                        .post(form)
+                        .build()
+                ).await()
+                val body = response.body.string()
+                if (!response.isSuccessful) {
+                    throw OAuthHttpException(response.code, "MCP OAuth token refresh failed: ${response.code}")
+                }
+                val token = json.parseToJsonElement(body).jsonObject
+                val updated = existing.copy(
+                    accessToken = token.string("access_token") ?: error("Missing refreshed access token"),
+                    refreshToken = token.string("refresh_token") ?: existing.refreshToken,
+                    expiresAt = token.long("expires_in")?.let { System.currentTimeMillis() + it * 1000L },
+                    tokenType = token.string("token_type") ?: existing.tokenType,
+                )
+                saveCredential(updated)
+                setStatus(serverId, McpOAuthStatus.Authorized)
+                updated.accessToken
+            }.getOrElse {
+                Log.e(MCP_OAUTH_TAG, "MCP OAuth token refresh failed: ${it.safeLogMessage()}")
+                val statusCode = (it as? OAuthHttpException)?.statusCode
+                if (statusCode == 400 || statusCode == 401 || statusCode == 403) {
+                    clearCredential(serverId)
+                }
+                setStatus(serverId, McpOAuthStatus.Error("MCP OAuth token expired. Please authorize again."))
+                null
+            }
+        }
+    }
+
+    private suspend fun exchangeCode(code: String, session: OAuthSession): StoredMcpOAuthCredential {
+        awaitNetworkUnblocked()
+        val form = FormBody.Builder()
+            .add("grant_type", "authorization_code")
+            .add("client_id", session.client.clientId)
+            .add("code", code)
+            .add("redirect_uri", session.redirectUri)
+            .add("code_verifier", session.verifier)
+            .add("resource", session.discovered.resource)
+            .apply {
+                session.client.clientSecret?.let { add("client_secret", it) }
+            }
+            .build()
+        val response = client.newCall(
+            Request.Builder()
+                .url(session.discovered.asMetadata.tokenEndpoint)
+                .post(form)
+                .build()
+        ).await()
+        val body = response.body.string()
+        if (!response.isSuccessful) {
+            error("MCP OAuth token exchange failed: ${response.code}")
+        }
+        val token = json.parseToJsonElement(body).jsonObject
+        val credential = StoredMcpOAuthCredential(
+            serverId = session.serverId,
+            resource = session.discovered.resource,
+            authorizationServerIssuer = session.discovered.asMetadata.issuer,
+            tokenEndpoint = session.discovered.asMetadata.tokenEndpoint,
+            clientId = session.client.clientId,
+            clientSecret = session.client.clientSecret,
+            scopes = session.scopes,
+            accessToken = token.string("access_token") ?: error("Missing access token"),
+            refreshToken = token.string("refresh_token"),
+            expiresAt = token.long("expires_in")?.let { System.currentTimeMillis() + it * 1000L },
+            tokenType = token.string("token_type") ?: "Bearer",
+        )
+        if (!session.deferred.isActive) {
+            error("OAuth session is no longer active.")
+        }
+        saveCredential(credential)
+        return credential
+    }
+
+    private suspend fun saveCredential(credential: StoredMcpOAuthCredential) = mutex.withLock {
+        val state = store.read()
+        store.write(
+            state.copy(
+                credentials = state.credentials.filterNot { it.serverId == credential.serverId } + credential
+            )
+        )
+    }
+
+    private suspend fun ensureClient(
+        serverId: Uuid,
+        discovered: DiscoveredMetadata,
+        redirectUri: String,
+        scopes: List<String>,
+    ): StoredMcpOAuthClient {
+        val existing = mutex.withLock {
+            store.read().clients.firstOrNull {
+                it.serverId == serverId && it.authorizationServerIssuer == discovered.asMetadata.issuer
+            }
+        }
+        if (existing != null) return existing
+        val registrationEndpoint = discovered.asMetadata.registrationEndpoint
+            ?: error("This MCP server does not support automatic OAuth client registration. Manual client ID setup is not available in this build yet.")
+        val body = buildJsonObject {
+            put("client_name", "RikkaHub")
+            putJsonArray("redirect_uris") { add(JsonPrimitive(redirectUri)) }
+            putJsonArray("grant_types") {
+                add(JsonPrimitive("authorization_code"))
+                add(JsonPrimitive("refresh_token"))
+            }
+            putJsonArray("response_types") { add(JsonPrimitive("code")) }
+            put("token_endpoint_auth_method", "none")
+            if (scopes.isNotEmpty()) {
+                put("scope", scopes.joinToString(" "))
+            }
+        }
+        val response = client.newCall(
+            Request.Builder()
+                .url(registrationEndpoint)
+                .post(body.toString().toRequestBody("application/json".toMediaType()))
+                .build()
+        ).await()
+        val responseBody = response.body.string()
+        if (!response.isSuccessful) {
+            error("MCP OAuth client registration failed: ${response.code}")
+        }
+        val registered = json.parseToJsonElement(responseBody).jsonObject
+        val stored = StoredMcpOAuthClient(
+            serverId = serverId,
+            authorizationServerIssuer = discovered.asMetadata.issuer,
+            clientId = registered.string("client_id") ?: error("Missing registered client_id"),
+            clientSecret = registered.string("client_secret"),
+        )
+        mutex.withLock {
+            val state = store.read()
+            store.write(
+                state.copy(
+                    clients = state.clients.filterNot {
+                        it.serverId == serverId && it.authorizationServerIssuer == discovered.asMetadata.issuer
+                    } + stored
+                )
+            )
+        }
+        return stored
+    }
+
+    private suspend fun discover(serverUrl: String, challenge: AuthChallenge): DiscoveredMetadata {
+        val protectedResource = discoverProtectedResource(serverUrl, challenge.resourceMetadata)
+        val scopes = when {
+            challenge.scope.isNotBlank() -> challenge.scope.split(" ").filter { it.isNotBlank() }
+            protectedResource.scopesSupported.isNotEmpty() -> protectedResource.scopesSupported
+            else -> emptyList()
+        }
+        for (issuer in protectedResource.authorizationServers) {
+            val asMetadata = discoverAuthorizationServer(issuer)
+            if (asMetadata != null) {
+                if (!asMetadata.codeChallengeMethodsSupported.contains("S256")) {
+                    error("Authorization server does not support required PKCE S256.")
+                }
+                return DiscoveredMetadata(
+                    resource = protectedResource.resource,
+                    scopes = scopes,
+                    asMetadata = asMetadata,
+                )
+            }
+        }
+        error("Unable to discover MCP OAuth authorization server metadata.")
+    }
+
+    private suspend fun discoverProtectedResource(serverUrl: String, resourceMetadataUrl: String?): ProtectedResourceMetadata {
+        val candidates = buildList {
+            resourceMetadataUrl?.takeIf { it.isNotBlank() }?.let(::add)
+            val uri = Uri.parse(serverUrl)
+            val origin = "${uri.scheme}://${uri.encodedAuthority}"
+            val path = uri.encodedPath.orEmpty()
+            if (path.isNotBlank() && path != "/") add("$origin/.well-known/oauth-protected-resource$path")
+            add("$origin/.well-known/oauth-protected-resource")
+        }.distinct()
+        for (url in candidates) {
+            val metadata = runCatching { getJson(url) }.getOrNull() ?: continue
+            val resource = metadata.string("resource") ?: continue
+            val authorizationServers = metadata.arrayStrings("authorization_servers")
+            if (authorizationServers.isEmpty()) continue
+            return ProtectedResourceMetadata(
+                resource = resource,
+                authorizationServers = authorizationServers,
+                scopesSupported = metadata.arrayStrings("scopes_supported"),
+            )
+        }
+        error("Unable to discover MCP protected-resource metadata.")
+    }
+
+    private suspend fun discoverAuthorizationServer(issuer: String): AsMetadata? {
+        val candidates = authorizationServerMetadataCandidates(issuer)
+        for (url in candidates) {
+            val metadata = runCatching { getJson(url) }.getOrNull() ?: continue
+            val authorizationEndpoint = metadata.string("authorization_endpoint") ?: continue
+            val tokenEndpoint = metadata.string("token_endpoint") ?: continue
+            requireHttpsOrLocalhost(authorizationEndpoint, "authorization_endpoint")
+            requireHttpsOrLocalhost(tokenEndpoint, "token_endpoint")
+            metadata.string("registration_endpoint")?.let {
+                requireHttpsOrLocalhost(it, "registration_endpoint")
+            }
+            return AsMetadata(
+                issuer = metadata.string("issuer") ?: issuer,
+                authorizationEndpoint = authorizationEndpoint,
+                tokenEndpoint = tokenEndpoint,
+                registrationEndpoint = metadata.string("registration_endpoint"),
+                codeChallengeMethodsSupported = metadata.arrayStrings("code_challenge_methods_supported"),
+            )
+        }
+        return null
+    }
+
+    private fun authorizationServerMetadataCandidates(issuer: String): List<String> {
+        val uri = Uri.parse(issuer)
+        val origin = "${uri.scheme}://${uri.encodedAuthority}"
+        val path = uri.encodedPath.orEmpty().trim('/')
+        return if (path.isBlank()) {
+            listOf(
+                "$origin/.well-known/oauth-authorization-server",
+                "$origin/.well-known/openid-configuration",
+            )
+        } else {
+            listOf(
+                "$origin/.well-known/oauth-authorization-server/$path",
+                "$origin/.well-known/openid-configuration/$path",
+                "${issuer.trimEnd('/')}/.well-known/openid-configuration",
+            )
+        }
+    }
+
+    private suspend fun getJson(url: String): JsonObject {
+        val response = client.newCall(Request.Builder().url(url).get().build()).await()
+        val body = response.body.string()
+        if (!response.isSuccessful) {
+            error("GET $url failed: ${response.code}")
+        }
+        return json.parseToJsonElement(body).jsonObject
+    }
+
+    private suspend fun fetchInitialChallenge(serverUrl: String): AuthChallenge {
+        val response = runCatching {
+            client.newCall(Request.Builder().url(serverUrl).get().build()).await()
+        }.getOrNull()
+        return parseWwwAuthenticate(response?.header("WWW-Authenticate"))
+    }
+
+    @Synchronized
+    private fun ensureCallbackServer(): Int {
+        callbackPort?.let { return it }
+        var lastError: Throwable? = null
+        for (port in CALLBACK_PORTS) {
+            try {
+                server = embeddedServer(CIO, host = "127.0.0.1", port = port) {
+                    routing {
+                        get("/auth/callback") {
+                            val callbackState = call.request.queryParameters["state"]
+                            val code = call.request.queryParameters["code"]
+                            val error = call.request.queryParameters["error"]
+                            val session = callbackState?.let(sessions::remove)
+                            when {
+                                session == null -> {
+                                    call.respondText(callbackPage(false), ContentType.Text.Html)
+                                    stopCallbackServerIfIdle()
+                                }
+
+                                !error.isNullOrBlank() -> {
+                                    session.deferred.completeExceptionally(IllegalStateException(error))
+                                    call.respondText(callbackPage(false), ContentType.Text.Html)
+                                    stopCallbackServerIfIdle()
+                                }
+
+                                code.isNullOrBlank() -> {
+                                    session.deferred.completeExceptionally(IllegalStateException("Missing authorization code"))
+                                    call.respondText(callbackPage(false), ContentType.Text.Html)
+                                    stopCallbackServerIfIdle()
+                                }
+
+                                else -> {
+                                    call.respondText(callbackPage(true), ContentType.Text.Html)
+                                    scope.launch {
+                                        runCatching {
+                                            withTimeout(TOKEN_EXCHANGE_TIMEOUT_MS) {
+                                                exchangeCode(code, session)
+                                            }
+                                        }
+                                            .onSuccess { session.deferred.complete(it) }
+                                            .onFailure { session.deferred.completeExceptionally(it) }
+                                        stopCallbackServerIfIdle()
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }.start(wait = false)
+                callbackPort = port
+                return port
+            } catch (error: Throwable) {
+                lastError = error
+            }
+        }
+        throw IllegalStateException("MCP OAuth callback ports are unavailable", lastError)
+    }
+
+    @Synchronized
+    private fun stopCallbackServerIfIdle() {
+        if (sessions.isNotEmpty()) return
+        val currentServer = server ?: return
+        server = null
+        callbackPort = null
+        runCatching {
+            currentServer.stop(gracePeriodMillis = 500, timeoutMillis = 1_000)
+        }.onFailure {
+            Log.w(MCP_OAUTH_TAG, "Failed to stop OAuth callback server: ${it.safeLogMessage()}")
+        }
+    }
+
+    private suspend fun awaitNetworkUnblocked() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) return
+        val connectivityManager = context.getSystemService(ConnectivityManager::class.java)
+        runCatching {
+            withTimeout(NETWORK_UNBLOCK_TIMEOUT_MS) {
+                suspendCancellableCoroutine { continuation ->
+                    lateinit var callback: ConnectivityManager.NetworkCallback
+                    callback = object : ConnectivityManager.NetworkCallback() {
+                        override fun onBlockedStatusChanged(network: Network, blocked: Boolean) {
+                            if (!blocked && continuation.isActive) {
+                                runCatching { connectivityManager.unregisterNetworkCallback(callback) }
+                                continuation.resume(Unit)
+                            }
+                        }
+                    }
+                    continuation.invokeOnCancellation {
+                        runCatching { connectivityManager.unregisterNetworkCallback(callback) }
+                    }
+                    connectivityManager.registerDefaultNetworkCallback(callback)
+                    val capabilities = connectivityManager.getNetworkCapabilities(connectivityManager.activeNetwork)
+                    if (
+                        continuation.isActive &&
+                        (capabilities == null ||
+                            capabilities.hasCapability(android.net.NetworkCapabilities.NET_CAPABILITY_NOT_RESTRICTED))
+                    ) {
+                        runCatching { connectivityManager.unregisterNetworkCallback(callback) }
+                        continuation.resume(Unit)
+                    }
+                }
+            }
+        }.onFailure {
+            Log.w(MCP_OAUTH_TAG, "Network unblock check skipped: ${it.safeLogMessage()}")
+        }
+    }
+
+    private fun callbackPage(success: Boolean): String {
+        return """
+            <!doctype html>
+            <html>
+              <head><meta name="viewport" content="width=device-width, initial-scale=1"></head>
+              <body style="font-family: sans-serif; padding: 24px;">
+                <h3>${if (success) "RikkaHub authorization complete" else "RikkaHub authorization failed"}</h3>
+                <p>${if (success) "You can close this tab and return to RikkaHub." else "Please return to RikkaHub and try again."}</p>
+              </body>
+            </html>
+        """.trimIndent()
+    }
+
+    private fun setStatus(serverId: Uuid, status: McpOAuthStatus) {
+        _status.value = _status.value.toMutableMap().apply { put(serverId, status) }
+    }
+
+    private fun restoreStoredAuthorizationStatuses() {
+        runCatching {
+            val now = System.currentTimeMillis()
+            _status.value = store.read().credentials
+                .filter { it.isUsable(now) }
+                .associate { it.serverId to McpOAuthStatus.Authorized }
+        }.onFailure {
+            Log.w(MCP_OAUTH_TAG, "Failed to restore MCP OAuth authorization status: ${it.safeLogMessage()}")
+        }
+    }
+
+    private fun randomUrlSafe(size: Int): String {
+        val bytes = ByteArray(size)
+        SecureRandom().nextBytes(bytes)
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes)
+    }
+
+    private companion object {
+        const val REFRESH_MARGIN_MS = 30_000L
+        const val AUTH_TIMEOUT_MS = 5 * 60 * 1000L
+        const val TOKEN_EXCHANGE_TIMEOUT_MS = 60 * 1000L
+        const val NETWORK_UNBLOCK_TIMEOUT_MS = 10 * 1000L
+        val CALLBACK_PORTS = listOf(1455, 1457, 1459)
+    }
+}
+
+sealed interface OAuthResult {
+    data class Success(val accessToken: String) : OAuthResult
+    data class Error(val message: String) : OAuthResult
+}
+
+sealed interface McpOAuthStatus {
+    data object Idle : McpOAuthStatus
+    data object Authorizing : McpOAuthStatus
+    data object Authorized : McpOAuthStatus
+    data class Error(val message: String) : McpOAuthStatus
+}
+
+private data class OAuthSession(
+    val serverId: Uuid,
+    val verifier: String,
+    val redirectUri: String,
+    val discovered: DiscoveredMetadata,
+    val client: StoredMcpOAuthClient,
+    val scopes: List<String>,
+    val deferred: CompletableDeferred<StoredMcpOAuthCredential>,
+)
+
+private class OAuthHttpException(
+    val statusCode: Int,
+    message: String,
+) : IllegalStateException(message)
+
+private data class AuthChallenge(
+    val resourceMetadata: String? = null,
+    val scope: String = "",
+)
+
+private data class ProtectedResourceMetadata(
+    val resource: String,
+    val authorizationServers: List<String>,
+    val scopesSupported: List<String>,
+)
+
+private data class DiscoveredMetadata(
+    val resource: String,
+    val scopes: List<String>,
+    val asMetadata: AsMetadata,
+)
+
+private data class AsMetadata(
+    val issuer: String,
+    val authorizationEndpoint: String,
+    val tokenEndpoint: String,
+    val registrationEndpoint: String?,
+    val codeChallengeMethodsSupported: List<String>,
+)
+
+private fun parseWwwAuthenticate(header: String?): AuthChallenge {
+    if (header.isNullOrBlank()) return AuthChallenge()
+    fun find(name: String): String? {
+        val quoted = Regex("""$name\s*=\s*"([^"]*)"""").find(header)?.groupValues?.getOrNull(1)
+        if (quoted != null) return quoted
+        return Regex("""$name\s*=\s*([^,\s]+)""").find(header)?.groupValues?.getOrNull(1)
+    }
+    return AuthChallenge(
+        resourceMetadata = find("resource_metadata"),
+        scope = find("scope").orEmpty(),
+    )
+}
+
+private fun requireHttpsOrLocalhost(url: String, field: String) {
+    val uri = Uri.parse(url)
+    val scheme = uri.scheme.orEmpty().lowercase()
+    val host = uri.host.orEmpty().lowercase()
+    if (scheme == "https") return
+    if (scheme == "http" && (host == "localhost" || host == "127.0.0.1" || host == "::1")) return
+    error("OAuth $field must use HTTPS.")
+}
+
+private fun Throwable.safeLogMessage(): String {
+    return "${this::class.java.simpleName}: ${message?.take(160).orEmpty()}"
+}
+
+private fun StoredMcpOAuthCredential.isUsable(nowMillis: Long): Boolean {
+    return expiresAt == null || expiresAt > nowMillis + 30_000L || refreshToken != null
+}
+
+private fun JsonObject.string(name: String): String? = this[name]?.jsonPrimitive?.contentOrNull
+
+private fun JsonObject.long(name: String): Long? = string(name)?.toLongOrNull()
+
+private fun JsonObject.arrayStrings(name: String): List<String> {
+    return (this[name] as? JsonArray)?.jsonArray?.mapNotNull { it.jsonPrimitive.contentOrNull }.orEmpty()
+}

--- a/app/src/main/java/me/rerere/rikkahub/data/ai/mcp/McpOAuthTokenStore.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/ai/mcp/McpOAuthTokenStore.kt
@@ -1,0 +1,126 @@
+package me.rerere.rikkahub.data.ai.mcp
+
+import android.content.Context
+import android.security.keystore.KeyGenParameterSpec
+import android.security.keystore.KeyProperties
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import java.io.File
+import java.io.FileOutputStream
+import java.nio.file.Files
+import java.nio.file.StandardCopyOption
+import java.security.KeyStore
+import javax.crypto.Cipher
+import javax.crypto.KeyGenerator
+import javax.crypto.SecretKey
+import javax.crypto.spec.GCMParameterSpec
+import kotlin.uuid.Uuid
+
+class McpOAuthTokenStore(
+    context: Context,
+    private val json: Json,
+) {
+    private val file = File(context.noBackupFilesDir, FILE_NAME)
+    private var cachedKey: SecretKey? = null
+
+    @Synchronized
+    internal fun read(): McpOAuthStoreState {
+        if (!file.exists()) return McpOAuthStoreState()
+        return runCatching {
+            val bytes = file.readBytes()
+            require(bytes.size > IV_SIZE)
+            val iv = bytes.copyOfRange(0, IV_SIZE)
+            val encrypted = bytes.copyOfRange(IV_SIZE, bytes.size)
+            val cipher = Cipher.getInstance(TRANSFORMATION)
+            cipher.init(Cipher.DECRYPT_MODE, getOrCreateKey(), GCMParameterSpec(TAG_LENGTH, iv))
+            json.decodeFromString<McpOAuthStoreState>(cipher.doFinal(encrypted).decodeToString())
+        }.getOrElse {
+            throw IllegalStateException("Failed to read MCP OAuth credentials", it)
+        }
+    }
+
+    @Synchronized
+    internal fun write(state: McpOAuthStoreState) {
+        file.parentFile?.mkdirs()
+        val cipher = Cipher.getInstance(TRANSFORMATION)
+        cipher.init(Cipher.ENCRYPT_MODE, getOrCreateKey())
+        val encrypted = cipher.doFinal(json.encodeToString(state).encodeToByteArray())
+        val temporary = File(file.parentFile, "$FILE_NAME.tmp")
+        try {
+            FileOutputStream(temporary).use { output ->
+                output.write(cipher.iv + encrypted)
+                output.fd.sync()
+            }
+            Files.move(
+                temporary.toPath(),
+                file.toPath(),
+                StandardCopyOption.REPLACE_EXISTING,
+                StandardCopyOption.ATOMIC_MOVE,
+            )
+        } catch (error: Throwable) {
+            temporary.delete()
+            throw IllegalStateException("Failed to atomically write MCP OAuth credentials", error)
+        }
+    }
+
+    @Synchronized
+    private fun getOrCreateKey(): SecretKey {
+        cachedKey?.let { return it }
+        val keyStore = KeyStore.getInstance(KEYSTORE).apply { load(null) }
+        (keyStore.getKey(KEY_ALIAS, null) as? SecretKey)?.let {
+            cachedKey = it
+            return it
+        }
+        return KeyGenerator.getInstance(KeyProperties.KEY_ALGORITHM_AES, KEYSTORE).run {
+            init(
+                KeyGenParameterSpec.Builder(
+                    KEY_ALIAS,
+                    KeyProperties.PURPOSE_ENCRYPT or KeyProperties.PURPOSE_DECRYPT,
+                )
+                    .setBlockModes(KeyProperties.BLOCK_MODE_GCM)
+                    .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
+                    .build()
+            )
+            generateKey()
+        }.also { cachedKey = it }
+    }
+
+    private companion object {
+        const val FILE_NAME = "mcp_oauth_credentials.enc"
+        const val KEYSTORE = "AndroidKeyStore"
+        const val KEY_ALIAS = "rikkahub_mcp_oauth_credentials"
+        const val TRANSFORMATION = "AES/GCM/NoPadding"
+        const val IV_SIZE = 12
+        const val TAG_LENGTH = 128
+    }
+}
+
+@Serializable
+internal data class McpOAuthStoreState(
+    val credentials: List<StoredMcpOAuthCredential> = emptyList(),
+    val clients: List<StoredMcpOAuthClient> = emptyList(),
+)
+
+@Serializable
+internal data class StoredMcpOAuthCredential(
+    val serverId: Uuid,
+    val resource: String,
+    val authorizationServerIssuer: String,
+    val tokenEndpoint: String,
+    val clientId: String,
+    val clientSecret: String? = null,
+    val scopes: List<String> = emptyList(),
+    val accessToken: String,
+    val refreshToken: String? = null,
+    val expiresAt: Long? = null,
+    val tokenType: String = "Bearer",
+)
+
+@Serializable
+internal data class StoredMcpOAuthClient(
+    val serverId: Uuid,
+    val authorizationServerIssuer: String,
+    val clientId: String,
+    val clientSecret: String? = null,
+)

--- a/app/src/main/java/me/rerere/rikkahub/data/ai/mcp/McpStatus.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/ai/mcp/McpStatus.kt
@@ -2,6 +2,7 @@ package me.rerere.rikkahub.data.ai.mcp
 
 sealed class McpStatus {
     data object Idle : McpStatus()
+    data object Authorizing : McpStatus()
     data object Connecting : McpStatus()
     data object Connected : McpStatus()
     data class Reconnecting(val attempt: Int, val maxAttempts: Int) : McpStatus()

--- a/app/src/main/java/me/rerere/rikkahub/di/DataSourceModule.kt
+++ b/app/src/main/java/me/rerere/rikkahub/di/DataSourceModule.kt
@@ -13,6 +13,7 @@ import io.requery.android.database.sqlite.SQLiteCustomExtension
 import kotlinx.serialization.json.Json
 import me.rerere.ai.provider.ProviderManager
 import me.rerere.common.http.AcceptLanguageBuilder
+import me.rerere.rikkahub.AppScope
 import me.rerere.rikkahub.BuildConfig
 import me.rerere.rikkahub.data.ai.AIRequestInterceptor
 import me.rerere.rikkahub.data.ai.RequestLoggingInterceptor
@@ -31,12 +32,15 @@ import me.rerere.rikkahub.data.db.migrations.Migration_13_14
 import me.rerere.rikkahub.data.db.migrations.Migration_14_15
 import me.rerere.rikkahub.data.db.migrations.Migration_15_16
 import me.rerere.rikkahub.data.ai.mcp.McpManager
+import me.rerere.rikkahub.data.ai.mcp.McpOAuthManager
+import me.rerere.rikkahub.data.ai.mcp.McpOAuthTokenStore
 import me.rerere.rikkahub.data.sync.webdav.WebDavSync
 import me.rerere.search.SearchService
 import me.rerere.rikkahub.data.sync.S3Sync
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
+import org.koin.core.qualifier.named
 import org.koin.dsl.module
 import retrofit2.Retrofit
 import retrofit2.converter.kotlinx.serialization.asConverterFactory
@@ -146,7 +150,43 @@ val dataSourceModule = module {
         MessageFtsManager(get())
     }
 
-    single { McpManager(settingsStore = get(), appScope = get(), filesManager = get()) }
+    single { McpOAuthTokenStore(context = get(), json = get()) }
+
+    single<OkHttpClient>(named("mcpOAuth")) {
+        val acceptLang = AcceptLanguageBuilder.fromAndroid(get())
+            .build()
+        OkHttpClient.Builder()
+            .connectTimeout(20, TimeUnit.SECONDS)
+            .readTimeout(120, TimeUnit.SECONDS)
+            .writeTimeout(120, TimeUnit.SECONDS)
+            .followSslRedirects(true)
+            .followRedirects(true)
+            .retryOnConnectionFailure(true)
+            .addInterceptor { chain ->
+                val originalRequest = chain.request()
+                val requestBuilder = originalRequest.newBuilder()
+                    .addHeader(HttpHeaders.AcceptLanguage, acceptLang)
+
+                if (originalRequest.header(HttpHeaders.UserAgent) == null) {
+                    requestBuilder.addHeader(HttpHeaders.UserAgent, "RikkaHub-Android/${BuildConfig.VERSION_NAME}")
+                }
+
+                chain.proceed(requestBuilder.build())
+            }
+            .build()
+    }
+
+    single {
+        McpOAuthManager(
+            context = get(),
+            scope = get<AppScope>(),
+            client = get<OkHttpClient>(named("mcpOAuth")),
+            store = get(),
+            json = get(),
+        )
+    }
+
+    single { McpManager(settingsStore = get(), appScope = get(), filesManager = get(), oAuthManager = get()) }
 
     single {
         GenerationHandler(

--- a/app/src/main/java/me/rerere/rikkahub/ui/components/ai/McpPicker.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/ai/McpPicker.kt
@@ -65,7 +65,7 @@ fun McpPickerButton(
 ) {
     var showMcpPicker by remember { mutableStateOf(false) }
     val status by mcpManager.syncingStatus.collectAsStateWithLifecycle()
-    val loading = status.values.any { it == McpStatus.Connecting }
+    val loading = status.values.any { it == McpStatus.Connecting || it == McpStatus.Authorizing }
     val enabledServers = servers.fastFilter {
         it.commonOptions.enable && assistant.mcpServers.contains(it.id)
     }
@@ -169,7 +169,7 @@ fun McpPickerListItem(
 ) {
     var showMcpPicker by remember { mutableStateOf(false) }
     val status by mcpManager.syncingStatus.collectAsStateWithLifecycle()
-    val loading = status.values.any { it == McpStatus.Connecting }
+    val loading = status.values.any { it == McpStatus.Connecting || it == McpStatus.Authorizing }
     val enabledServers = servers.fastFilter {
         it.commonOptions.enable && assistant.mcpServers.contains(it.id)
     }
@@ -295,6 +295,10 @@ fun McpPicker(
                 ) {
                     when (status) {
                         McpStatus.Idle -> Icon(HugeIcons.Icon1stBracket, null)
+                        McpStatus.Authorizing -> CircularProgressIndicator(
+                            modifier = Modifier.size(20.dp),
+                            strokeWidth = 2.dp
+                        )
                         McpStatus.Connecting -> CircularProgressIndicator(
                             modifier = Modifier.size(
                                 24.dp
@@ -318,6 +322,7 @@ fun McpPicker(
                         Text(
                             text = when (val s = status) {
                                 is McpStatus.Idle -> "Idle"
+                                is McpStatus.Authorizing -> "Authorizing"
                                 is McpStatus.Connecting -> "Connecting"
                                 is McpStatus.Connected -> "Connected"
                                 is McpStatus.Reconnecting -> "Reconnecting (${s.attempt}/${s.maxAttempts})"

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingMcpPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingMcpPage.kt
@@ -89,6 +89,9 @@ import me.rerere.ai.core.InputSchema
 import me.rerere.hugeicons.stroke.McpServer
 import me.rerere.rikkahub.R
 import me.rerere.rikkahub.data.ai.mcp.McpManager
+import me.rerere.rikkahub.data.ai.mcp.McpOAuthConfig
+import me.rerere.rikkahub.data.ai.mcp.McpOAuthManager
+import me.rerere.rikkahub.data.ai.mcp.McpOAuthStatus
 import me.rerere.rikkahub.data.ai.mcp.McpServerConfig
 import me.rerere.rikkahub.data.ai.mcp.McpCommonOptions
 import me.rerere.rikkahub.data.ai.mcp.McpStatus
@@ -166,7 +169,7 @@ fun SettingMcpPage(vm: SettingVM = koinViewModel()) {
         val status by mcpManager.syncingStatus.collectAsStateWithLifecycle()
         val scope = rememberCoroutineScope()
         val state = rememberPullToRefreshState()
-        val loading = status.values.any { it == McpStatus.Connecting || it is McpStatus.Reconnecting }
+        val loading = status.values.any { it == McpStatus.Connecting || it == McpStatus.Authorizing || it is McpStatus.Reconnecting }
         PullToRefreshBox(
             isRefreshing = loading,
             onRefresh = {
@@ -284,6 +287,10 @@ private fun McpServerItem(
             ) {
                 when (status) {
                     McpStatus.Idle -> Icon(HugeIcons.MessageBlocked, null)
+                    McpStatus.Authorizing -> CircularProgressIndicator(
+                        modifier = Modifier.size(24.dp),
+                        strokeWidth = 2.dp
+                    )
                     McpStatus.Connecting -> CircularProgressIndicator(
                         modifier = Modifier.size(
                             24.dp
@@ -446,6 +453,9 @@ private fun McpCommonOptionsConfigure(
     config: McpServerConfig,
     update: (McpServerConfig) -> Unit
 ) {
+    val mcpManager = koinInject<McpManager>()
+    val oAuthManager = koinInject<McpOAuthManager>()
+    val oAuthStatusMap by oAuthManager.status.collectAsStateWithLifecycle()
     Column(
         modifier = Modifier
             .fillMaxSize()
@@ -630,79 +640,205 @@ private fun McpCommonOptionsConfigure(
 
         HorizontalDivider()
 
-        // 请求头配置
-        FormItem(
-            label = {
-                Text(stringResource(R.string.setting_mcp_page_custom_headers))
-            },
-            description = {
-                Text(stringResource(R.string.setting_mcp_page_custom_headers_desc))
-            }
-        ) {
-            Column(
-                verticalArrangement = Arrangement.spacedBy(8.dp)
+        if (config is McpServerConfig.StreamableHTTPServer) {
+            FormItem(
+                label = {
+                    Text("Authentication")
+                },
+                description = {
+                    Text("Choose how this MCP server signs in.")
+                }
             ) {
-                config.commonOptions.headers.forEachIndexed { index, header ->
-                    var headerName by remember(header.first) { mutableStateOf(header.first) }
-                    var headerValue by remember(header.second) { mutableStateOf(header.second) }
-
-                    Row(
-                        verticalAlignment = Alignment.CenterVertically,
-                        horizontalArrangement = Arrangement.spacedBy(8.dp)
-                    ) {
-                        Column(modifier = Modifier.weight(1f)) {
-                            OutlinedTextField(
-                                value = headerName,
-                                onValueChange = {
-                                    headerName = it
-                                    val updatedHeaders =
-                                        config.commonOptions.headers.toMutableList()
-                                    updatedHeaders[index] =
-                                        it.trim() to updatedHeaders[index].second
+                val authTypes = listOf("None", "Headers", "OAuth")
+                val oauthStatus = oAuthStatusMap[config.id] ?: McpOAuthStatus.Idle
+                val currentAuthIndex = when {
+                    config.oauth?.enabled == true -> 2
+                    config.commonOptions.headers.isNotEmpty() -> 1
+                    else -> 0
+                }
+                Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                    SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {
+                        authTypes.forEachIndexed { index, type ->
+                            SegmentedButton(
+                                shape = SegmentedButtonDefaults.itemShape(index, authTypes.size),
+                                onClick = {
                                     update(
-                                        when (config) {
-                                            is McpServerConfig.SseTransportServer -> config.copy(
-                                                commonOptions = config.commonOptions.copy(headers = updatedHeaders)
+                                        when (index) {
+                                            0 -> config.copy(
+                                                oauth = null,
+                                                commonOptions = config.commonOptions.copy(headers = emptyList())
                                             )
 
-                                            is McpServerConfig.StreamableHTTPServer -> config.copy(
-                                                commonOptions = config.commonOptions.copy(headers = updatedHeaders)
+                                            1 -> config.copy(oauth = null)
+                                            2 -> config.copy(
+                                                oauth = McpOAuthConfig(),
+                                                commonOptions = config.commonOptions.copy(headers = emptyList())
                                             )
+                                            else -> config
                                         }
                                     )
                                 },
-                                label = { Text(stringResource(R.string.setting_mcp_page_header_name)) },
-                                modifier = Modifier.fillMaxWidth(),
-                                placeholder = { Text(stringResource(R.string.setting_mcp_page_header_name_placeholder)) }
-                            )
-                            Spacer(Modifier.height(8.dp))
-                            OutlinedTextField(
-                                value = headerValue,
-                                onValueChange = {
-                                    headerValue = it
-                                    val updatedHeaders =
-                                        config.commonOptions.headers.toMutableList()
-                                    updatedHeaders[index] = updatedHeaders[index].first to it.trim()
-                                    update(
-                                        when (config) {
-                                            is McpServerConfig.SseTransportServer -> config.copy(
-                                                commonOptions = config.commonOptions.copy(headers = updatedHeaders)
-                                            )
-
-                                            is McpServerConfig.StreamableHTTPServer -> config.copy(
-                                                commonOptions = config.commonOptions.copy(headers = updatedHeaders)
-                                            )
-                                        }
-                                    )
-                                },
-                                label = { Text(stringResource(R.string.setting_mcp_page_header_value)) },
-                                modifier = Modifier.fillMaxWidth(),
-                                placeholder = { Text(stringResource(R.string.setting_mcp_page_header_value_placeholder)) }
-                            )
+                                selected = index == currentAuthIndex
+                            ) {
+                                Text(type, maxLines = 1)
+                            }
                         }
-                        IconButton(onClick = {
+                    }
+                    if (config.oauth?.enabled == true) {
+                        Text(
+                            text = "Authorize in your browser, then return to RikkaHub.",
+                            modifier = Modifier.fillMaxWidth(),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                        Text(
+                            text = when (val status = oauthStatus) {
+                                McpOAuthStatus.Idle -> "Not authorized yet."
+                                McpOAuthStatus.Authorizing -> "Authorizing..."
+                                McpOAuthStatus.Authorized -> "Authorized."
+                                is McpOAuthStatus.Error -> status.message
+                            },
+                            modifier = Modifier.fillMaxWidth(),
+                            style = MaterialTheme.typography.labelSmall,
+                            color = when (oauthStatus) {
+                                is McpOAuthStatus.Error -> MaterialTheme.colorScheme.error
+                                else -> MaterialTheme.colorScheme.onSurfaceVariant
+                            },
+                        )
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.End),
+                            verticalAlignment = Alignment.CenterVertically,
+                        ) {
+                            TextButton(
+                                onClick = {
+                                    mcpManager.revokeAuthorization(config)
+                                },
+                                enabled = oauthStatus != McpOAuthStatus.Authorizing,
+                            ) {
+                                Text("Cancel authorization")
+                            }
+                            Button(
+                                onClick = {
+                                    mcpManager.authorize(config)
+                                },
+                                enabled = config.url.isNotBlank() && oauthStatus != McpOAuthStatus.Authorizing,
+                            ) {
+                                if (oauthStatus == McpOAuthStatus.Authorizing) {
+                                    CircularProgressIndicator(
+                                        modifier = Modifier.size(18.dp),
+                                        strokeWidth = 2.dp,
+                                    )
+                                } else {
+                                    Text("Authorize")
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            HorizontalDivider()
+        }
+
+        // 请求头配置
+        if (config !is McpServerConfig.StreamableHTTPServer || config.oauth?.enabled != true) {
+            FormItem(
+                label = {
+                    Text(stringResource(R.string.setting_mcp_page_custom_headers))
+                },
+                description = {
+                    Text(stringResource(R.string.setting_mcp_page_custom_headers_desc))
+                }
+            ) {
+                Column(
+                    verticalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    config.commonOptions.headers.forEachIndexed { index, header ->
+                        var headerName by remember(header.first) { mutableStateOf(header.first) }
+                        var headerValue by remember(header.second) { mutableStateOf(header.second) }
+
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.spacedBy(8.dp)
+                        ) {
+                            Column(modifier = Modifier.weight(1f)) {
+                                OutlinedTextField(
+                                    value = headerName,
+                                    onValueChange = {
+                                        headerName = it
+                                        val updatedHeaders =
+                                            config.commonOptions.headers.toMutableList()
+                                        updatedHeaders[index] =
+                                            it.trim() to updatedHeaders[index].second
+                                        update(
+                                            when (config) {
+                                                is McpServerConfig.SseTransportServer -> config.copy(
+                                                    commonOptions = config.commonOptions.copy(headers = updatedHeaders)
+                                                )
+
+                                                is McpServerConfig.StreamableHTTPServer -> config.copy(
+                                                    commonOptions = config.commonOptions.copy(headers = updatedHeaders)
+                                                )
+                                            }
+                                        )
+                                    },
+                                    label = { Text(stringResource(R.string.setting_mcp_page_header_name)) },
+                                    modifier = Modifier.fillMaxWidth(),
+                                    placeholder = { Text(stringResource(R.string.setting_mcp_page_header_name_placeholder)) }
+                                )
+                                Spacer(Modifier.height(8.dp))
+                                OutlinedTextField(
+                                    value = headerValue,
+                                    onValueChange = {
+                                        headerValue = it
+                                        val updatedHeaders =
+                                            config.commonOptions.headers.toMutableList()
+                                        updatedHeaders[index] = updatedHeaders[index].first to it.trim()
+                                        update(
+                                            when (config) {
+                                                is McpServerConfig.SseTransportServer -> config.copy(
+                                                    commonOptions = config.commonOptions.copy(headers = updatedHeaders)
+                                                )
+
+                                                is McpServerConfig.StreamableHTTPServer -> config.copy(
+                                                    commonOptions = config.commonOptions.copy(headers = updatedHeaders)
+                                                )
+                                            }
+                                        )
+                                    },
+                                    label = { Text(stringResource(R.string.setting_mcp_page_header_value)) },
+                                    modifier = Modifier.fillMaxWidth(),
+                                    placeholder = { Text(stringResource(R.string.setting_mcp_page_header_value_placeholder)) }
+                                )
+                            }
+                            IconButton(onClick = {
+                                val updatedHeaders = config.commonOptions.headers.toMutableList()
+                                updatedHeaders.removeAt(index)
+                                update(
+                                    when (config) {
+                                        is McpServerConfig.SseTransportServer -> config.copy(
+                                            commonOptions = config.commonOptions.copy(headers = updatedHeaders)
+                                        )
+
+                                        is McpServerConfig.StreamableHTTPServer -> config.copy(
+                                            commonOptions = config.commonOptions.copy(headers = updatedHeaders)
+                                        )
+                                    }
+                                )
+                            }) {
+                                Icon(
+                                    HugeIcons.Delete01,
+                                    contentDescription = stringResource(R.string.setting_mcp_page_delete_header)
+                                )
+                            }
+                        }
+                    }
+
+                    Button(
+                        onClick = {
                             val updatedHeaders = config.commonOptions.headers.toMutableList()
-                            updatedHeaders.removeAt(index)
+                            updatedHeaders.add("" to "")
                             update(
                                 when (config) {
                                     is McpServerConfig.SseTransportServer -> config.copy(
@@ -714,39 +850,16 @@ private fun McpCommonOptionsConfigure(
                                     )
                                 }
                             )
-                        }) {
-                            Icon(
-                                HugeIcons.Delete01,
-                                contentDescription = stringResource(R.string.setting_mcp_page_delete_header)
-                            )
-                        }
-                    }
-                }
-
-                Button(
-                    onClick = {
-                        val updatedHeaders = config.commonOptions.headers.toMutableList()
-                        updatedHeaders.add("" to "")
-                        update(
-                            when (config) {
-                                is McpServerConfig.SseTransportServer -> config.copy(
-                                    commonOptions = config.commonOptions.copy(headers = updatedHeaders)
-                                )
-
-                                is McpServerConfig.StreamableHTTPServer -> config.copy(
-                                    commonOptions = config.commonOptions.copy(headers = updatedHeaders)
-                                )
-                            }
+                        },
+                        modifier = Modifier.fillMaxWidth()
+                    ) {
+                        Icon(
+                            HugeIcons.Add01,
+                            contentDescription = stringResource(R.string.setting_mcp_page_add_header)
                         )
-                    },
-                    modifier = Modifier.fillMaxWidth()
-                ) {
-                    Icon(
-                        HugeIcons.Add01,
-                        contentDescription = stringResource(R.string.setting_mcp_page_add_header)
-                    )
-                    Spacer(Modifier.width(4.dp))
-                    Text(stringResource(R.string.setting_mcp_page_add_header))
+                        Spacer(Modifier.width(4.dp))
+                        Text(stringResource(R.string.setting_mcp_page_add_header))
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary

Adds minimal, spec-compliant OAuth support for remote MCP Streamable HTTP servers.

Addresses #1123 (and the earlier #308).

This PR is intentionally scoped to MCP OAuth only and is based on current `rikkahub/rikkahub:master`; it does not include the Codex/OpenAI OAuth changes from #1313.

## What changed

- Adds optional OAuth config for `StreamableHTTPServer` while keeping existing header-based configs compatible (old `commonOptions.headers` configs still deserialize and work).
- Adds `McpOAuthManager` covering the full MCP Authorization flow:
  - **Discovery**: parses `401 WWW-Authenticate: resource_metadata`, fetches protected-resource metadata (path + root well-known fallback), then discovers authorization-server metadata (OAuth AS Metadata + OIDC fallback, with path insertion/append forms).
  - **PKCE**: requires `S256` support in AS metadata before starting authorization; refuses if absent.
  - **Resource Indicators**: sends the `resource` parameter in authorization, token, and refresh requests (RFC 8707).
  - **Client registration**: uses Dynamic Client Registration when `registration_endpoint` is available; persists `client_id` per server+issuer for reuse.
  - **Token storage**: Android Keystore + AES/GCM under `noBackupFilesDir`, with refresh-token rotation (new refresh token replaces the old; absent refresh token keeps the old one).
  - **Callback**: localhost callback server bound to `127.0.0.1`, stopped after authorization completes (success/failure/timeout).
- Connects OAuth MCP servers with `Authorization: Bearer <token>`; custom headers are only sent in non-OAuth mode.
- Adds UI auth mode selection: None / Custom Headers / OAuth, plus Authorize / Cancel authorization actions and visible OAuth status (Idle/Authorizing/Authorized/Error) in the MCP settings screen.
- Handles expired tokens by refreshing first (singleflight per server); if refresh fails, clears local credentials and asks the user to authorize again.
- Handles insufficient scope by recording requested scopes for the next authorization.

## Validation

- `:app:compileDebugKotlin` ✅
- `:app:assembleDebug` ✅ (debug APK builds)
- DevSpace OAuth flow validated end-to-end in a debug build: authorize in browser → return to RikkaHub → MCP session created → `tools/list` returned → `open_workspace` + `bash` tool calls succeeded against a local project directory.

`./gradlew.bat --no-daemon --no-configuration-cache :app:testDebugUnitTest -x :web:buildWebUi` currently has 9 failures in `TimeReminderTransformerTest`, `ChatServiceTest`, and `ShareSheetTest`. These failures also reproduce on `master` (this PR touches no test files), so they are pre-existing and unrelated to MCP OAuth.

## Known limitations

- First version supports OAuth servers that expose a `registration_endpoint` (Dynamic Client Registration). Manual `client_id` / `client_secret` setup is not included yet.
- SSE OAuth and custom-scheme callback are deferred.
- 401/403 flows clear credentials and prompt the user to re-authorize instead of automatically opening the browser, to avoid surprise browser launches and authorization loops.
- OAuth status is in-memory; it restores on the next successful connection rather than persisting across app restart.
- HTTPS enforcement on discovered endpoints is pending.
