### PR TITLE
fix(sync): 修复 S3/COS 下载丢数据及腾讯云COS endpoint兼容问题

### DIFF
--- a/app/src/main/java/me/rerere/rikkahub/data/sync/s3/AwsSignatureV4.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/sync/s3/AwsSignatureV4.kt
@@ -45,8 +45,14 @@ internal object AwsSignatureV4 {
             path
         }.let { if (it.isEmpty()) "/" else it }
 
+        val hostAlreadyContainsBucket = host.startsWith("${config.bucket}.")
+
         val allHeaders = mutableMapOf(
-            "host" to (if (config.pathStyle) host else "${config.bucket}.$host"),
+            "host" to when {
+                config.pathStyle -> host
+                hostAlreadyContainsBucket -> host
+                else -> "${config.bucket}.$host"
+            },
             "x-amz-content-sha256" to resolvedPayloadHash,
             "x-amz-date" to amzDate,
         )
@@ -102,7 +108,13 @@ internal object AwsSignatureV4 {
 
         val url = buildString {
             append(if (config.isHttps) "https://" else "http://")
-            append(if (config.pathStyle) host else "${config.bucket}.$host")
+            append(
+                when {
+                    config.pathStyle -> host
+                    hostAlreadyContainsBucket -> host
+                    else -> "${config.bucket}.$host"
+                }
+            )
             append(canonicalUri)
             if (canonicalQueryString.isNotEmpty()) {
                 append("?$canonicalQueryString")

--- a/app/src/main/java/me/rerere/rikkahub/data/sync/s3/S3Client.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/sync/s3/S3Client.kt
@@ -177,14 +177,9 @@ class S3Client(
                     throw S3Exception("Failed to download object: ${response.status}", errorBody)
                 }
 
-                val channel = response.bodyAsChannel()
-                targetFile.outputStream().use { outputStream ->
-                    val buffer = ByteArray(8192)
-                    while (!channel.isClosedForRead) {
-                        val bytesRead = channel.readAvailable(buffer)
-                        if (bytesRead > 0) {
-                            outputStream.write(buffer, 0, bytesRead)
-                        }
+                response.bodyAsChannel().toInputStream().use { input ->
+                    targetFile.outputStream().use { output ->
+                        input.copyTo(output)
                     }
                 }
                 Log.d(TAG, "downloadObjectToFile success: downloaded ${targetFile.length()} bytes")


### PR DESCRIPTION
## 问题描述

两个 S3/COS 同步相关 bug：

### 1. downloadObjectToFile 下载丢数据

`readAvailable()` + `isClosedForRead` 手动循环存在竞态：最后一个数据块到达和 channel 关闭之间存在窗口，导致文件末尾字节丢失。

### 2. 腾讯云 COS endpoint 兼容

腾讯云 COS 的标准 endpoint 格式为 `bucket.cos.region.myqcloud.com`（bucket 已包含在 host 中），但现有逻辑会在签名和 URL 构造时再拼接一次 `bucket.host`，导致请求失败。

## 修复方案

- **S3Client.downloadObjectToFile**: 改用 `toInputStream().copyTo()` 替代手动 `readAvailable()` 循环，与 `getObject()` 保持一致
- **AwsSignatureV4.sign**: 检测 host 是否已包含 bucket 名，若已包含则不再重复拼接