### PR TITLE
fix(ui): 修复附件菜单按钮未居中

### DIFF
--- a/app/src/main/java/me/rerere/rikkahub/ui/components/ai/FilesPicker.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/ai/FilesPicker.kt
@@ -119,8 +119,8 @@ internal fun FilesPicker(
             .padding(16.dp), verticalArrangement = Arrangement.spacedBy(16.dp)
     ) {
         FlowRow(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.spacedBy(16.dp),
+            modifier = Modifier.fillMaxWidth().wrapContentWidth(Alignment.CenterHorizontally),
+            horizontalArrangement = Arrangement.spacedBy(16.dp, Alignment.Start),
             verticalArrangement = Arrangement.spacedBy(4.dp),
         ) {
             TakePicButton(onLaunchCamera = onTakePic)


### PR DESCRIPTION
修复附件菜单按钮整体未居中问题

Close #1398 