### PR TITLE
Add Requesty as a built-in provider

### DIFF
--- a/ai/src/main/java/me/rerere/ai/provider/providers/openai/ChatCompletionsAPI.kt
+++ b/ai/src/main/java/me/rerere/ai/provider/providers/openai/ChatCompletionsAPI.kt
@@ -280,7 +280,7 @@ class ChatCompletionsAPI(
             }
 
             // open router适配
-            if(host == "openrouter.ai") {
+            if(host == "openrouter.ai" || host == "router.requesty.ai") {
                 if(params.model.outputModalities.contains(Modality.IMAGE)) {
                     put("modalities", buildJsonArray {
                         add("image")
@@ -292,7 +292,7 @@ class ChatCompletionsAPI(
             if (params.model.abilities.contains(ModelAbility.REASONING)) {
                 val level = params.reasoningLevel
                 when (host) {
-                    "openrouter.ai" -> {
+                    "openrouter.ai", "router.requesty.ai" -> {
                         // https://openrouter.ai/docs/use-cases/reasoning-tokens
                         put("reasoning", buildJsonObject {
                             when (level) {

--- a/ai/src/main/java/me/rerere/ai/util/Request.kt
+++ b/ai/src/main/java/me/rerere/ai/util/Request.kt
@@ -34,6 +34,12 @@ fun Request.Builder.configureReferHeaders(url: String): Request.Builder {
                 .addHeader("HTTP-Referer", "https://rikka-ai.com")
         }
 
+        "router.requesty.ai" -> {
+            this
+                .addHeader("X-Title", "RikkaHub")
+                .addHeader("HTTP-Referer", "https://rikka-ai.com")
+        }
+
         else -> this
     }
 }

--- a/app/src/main/java/me/rerere/rikkahub/data/datastore/DefaultProviders.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/datastore/DefaultProviders.kt
@@ -134,6 +134,22 @@ val DEFAULT_PROVIDERS = listOf(
         )
     ),
     ProviderSetting.OpenAI(
+        id = Uuid.parse("c3f8a1e2-6b4d-4e7a-9c05-2f1d8a3b6e90"),
+        name = "Requesty",
+        baseUrl = "https://router.requesty.ai/v1",
+        apiKey = "",
+        builtIn = true,
+        description = {
+            MarkdownBlock(
+                content = """
+                    OpenAI-compatible LLM router providing access to hundreds of models through a single API (model naming: provider/model).
+                    官网: [requesty.ai](https://requesty.ai)
+                    API Keys: [app.requesty.ai/api-keys](https://app.requesty.ai/api-keys)
+                """.trimIndent()
+            )
+        },
+    ),
+    ProviderSetting.OpenAI(
         id = Uuid.parse("386e0f29-8228-4512-affe-8fd8add82d88"),
         name = "Vercel AI Gateway",
         baseUrl = "https://ai-gateway.vercel.sh/v1",


### PR DESCRIPTION
Adds Requesty (https://requesty.ai) as a built-in OpenAI-compatible provider, mirroring the existing OpenRouter entry.

- `DefaultProviders.kt`: new built-in `ProviderSetting.OpenAI` entry (fresh unique id, `name = "Requesty"`, `baseUrl = "https://router.requesty.ai/v1"`, `builtIn = true`) with a short MarkdownBlock description matching the other providers. OpenRouter's `balanceOption` points at an OpenRouter-specific credits endpoint, so it's omitted for Requesty (same as OpenAI/Gemini entries).
- `Request.kt`: added a `router.requesty.ai` branch to `configureReferHeaders` alongside the existing `openrouter.ai` one (Requesty supports `HTTP-Referer`/`X-Title`).
- `ChatCompletionsAPI.kt`: extended the two host-keyed branches (image modalities, reasoning tokens) to also match `router.requesty.ai`, since Requesty passes those OpenRouter-style params through.

Requesty is OpenAI-compatible (`Authorization: Bearer`, `provider/model` naming), so it reuses the OpenAI provider type. API keys: https://app.requesty.ai/api-keys

I work at Requesty. This mirrors the existing OpenRouter provider as closely as possible. Happy to adjust or close it if it's not a fit.