### PR TITLE
fix(UI): 修复页面系统指示条沉浸问题

### DIFF
--- a/app/src/main/assets/html/mark.html
+++ b/app/src/main/assets/html/mark.html
@@ -174,7 +174,7 @@
     <script type="module">
         // Import markdown-it and plugins using esm.sh
         import MarkdownIt from 'https://esm.sh/markdown-it@14.0.0';
-        import vscodemarkdownItKatex from 'https://esm.sh/@vscode/markdown-it-katex'
+        import vscodemarkdownItKatex from 'https://esm.sh/@vscode/markdown-it-katex?deps=katex@0.16.8'
         import markdownItTaskLists from 'https://esm.sh/markdown-it-task-lists@2.1.1';
 
         import katex from 'https://esm.sh/katex@0.16.8';

--- a/app/src/main/assets/html/mark.html
+++ b/app/src/main/assets/html/mark.html
@@ -174,7 +174,7 @@
     <script type="module">
         // Import markdown-it and plugins using esm.sh
         import MarkdownIt from 'https://esm.sh/markdown-it@14.0.0';
-        import vscodemarkdownItKatex from 'https://esm.sh/@vscode/markdown-it-katex?deps=katex@0.16.8'
+        import vscodemarkdownItKatex from 'https://esm.sh/@vscode/markdown-it-katex'
         import markdownItTaskLists from 'https://esm.sh/markdown-it-task-lists@2.1.1';
 
         import katex from 'https://esm.sh/katex@0.16.8';

--- a/app/src/main/java/me/rerere/rikkahub/ui/components/ai/McpPicker.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/ai/McpPicker.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
@@ -276,11 +277,13 @@ fun McpPicker(
     assistant: Assistant,
     servers: List<McpServerConfig>,
     modifier: Modifier = Modifier,
+    contentPadding: PaddingValues = PaddingValues(0.dp),
     onUpdateAssistant: (Assistant) -> Unit
 ) {
     val mcpManager = koinInject<McpManager>()
     LazyColumn(
         modifier = modifier.fillMaxSize(),
+        contentPadding = contentPadding,
         verticalArrangement = Arrangement.spacedBy(4.dp),
     ) {
         items(servers.fastFilter { it.commonOptions.enable }) { server ->

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/assistant/AssistantPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/assistant/AssistantPage.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.imePadding
@@ -77,6 +76,7 @@ import me.rerere.rikkahub.ui.hooks.useEditState
 import me.rerere.rikkahub.ui.modifier.onClick
 import me.rerere.rikkahub.ui.pages.assistant.detail.AssistantImporter
 import me.rerere.rikkahub.ui.theme.CustomColors
+import me.rerere.rikkahub.utils.plus
 import org.koin.androidx.compose.koinViewModel
 import sh.calvin.reorderable.ReorderableItem
 import sh.calvin.reorderable.rememberReorderableLazyListState
@@ -133,13 +133,11 @@ fun AssistantPage(vm: AssistantVM = koinViewModel()) {
         },
         modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
         containerColor = CustomColors.topBarColors.containerColor,
-    ) {
+    ) { innerPadding ->
         Column(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(it)
-                .padding(top = 16.dp)
-                .consumeWindowInsets(it),
+                .padding(PaddingValues(top = innerPadding.calculateTopPadding()) + PaddingValues(top = 16.dp)),
             verticalArrangement = Arrangement.spacedBy(8.dp),
         ) {
             val lazyListState = rememberLazyListState()
@@ -190,7 +188,7 @@ fun AssistantPage(vm: AssistantVM = koinViewModel()) {
                 modifier = Modifier
                     .fillMaxSize()
                     .imePadding(),
-                contentPadding = PaddingValues(horizontal = 16.dp),
+                contentPadding = PaddingValues(horizontal = 16.dp) + PaddingValues(bottom = innerPadding.calculateBottomPadding()),
                 verticalArrangement = Arrangement.spacedBy(8.dp),
                 state = lazyListState,
             ) {

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/assistant/detail/AssistantBasicPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/assistant/detail/AssistantBasicPage.kt
@@ -2,6 +2,7 @@ package me.rerere.rikkahub.ui.pages.assistant.detail
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.imePadding
@@ -47,6 +48,7 @@ import me.rerere.rikkahub.ui.components.ui.TagsInput
 import me.rerere.rikkahub.ui.components.ui.UIAvatar
 import me.rerere.rikkahub.ui.hooks.heroAnimation
 import me.rerere.rikkahub.ui.theme.CustomColors
+import me.rerere.rikkahub.utils.plus
 import me.rerere.rikkahub.utils.toFixed
 import org.koin.androidx.compose.koinViewModel
 import org.koin.core.parameter.parametersOf
@@ -84,7 +86,7 @@ fun AssistantBasicPage(id: String) {
         containerColor = CustomColors.topBarColors.containerColor,
     ) { innerPadding ->
         AssistantBasicContent(
-            modifier = Modifier.padding(innerPadding),
+            contentPadding = innerPadding,
             assistant = assistant,
             providers = providers,
             tags = tags,
@@ -98,6 +100,7 @@ fun AssistantBasicPage(id: String) {
 @Composable
 internal fun AssistantBasicContent(
     modifier: Modifier = Modifier,
+    contentPadding: PaddingValues = PaddingValues(),
     assistant: Assistant,
     providers: List<me.rerere.ai.provider.ProviderSetting>,
     tags: List<DataTag>,
@@ -108,8 +111,8 @@ internal fun AssistantBasicContent(
     Column(
         modifier = modifier
             .fillMaxSize()
-            .padding(16.dp)
             .verticalScroll(rememberScrollState())
+            .padding(contentPadding + PaddingValues(16.dp))
             .imePadding(),
         verticalArrangement = Arrangement.spacedBy(16.dp)
     ) {

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/assistant/detail/AssistantLocalToolPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/assistant/detail/AssistantLocalToolPage.kt
@@ -3,6 +3,7 @@ package me.rerere.rikkahub.ui.pages.assistant.detail
 import android.Manifest
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
@@ -34,6 +35,7 @@ import me.rerere.rikkahub.ui.context.LocalToaster
 import me.rerere.rikkahub.ui.theme.CustomColors
 import me.rerere.rikkahub.utils.hasUsageStatsPermission
 import me.rerere.rikkahub.utils.openUsageAccessSettings
+import me.rerere.rikkahub.utils.plus
 import org.koin.androidx.compose.koinViewModel
 import org.koin.core.parameter.parametersOf
 
@@ -64,7 +66,7 @@ fun AssistantLocalToolPage(id: String) {
         containerColor = CustomColors.topBarColors.containerColor,
     ) { innerPadding ->
         AssistantLocalToolContent(
-            modifier = Modifier.padding(innerPadding),
+            contentPadding = innerPadding,
             assistant = assistant,
             onUpdate = { vm.update(it) }
         )
@@ -74,6 +76,7 @@ fun AssistantLocalToolPage(id: String) {
 @Composable
 private fun AssistantLocalToolContent(
     modifier: Modifier = Modifier,
+    contentPadding: PaddingValues = PaddingValues(),
     assistant: Assistant,
     onUpdate: (Assistant) -> Unit
 ) {
@@ -120,8 +123,8 @@ private fun AssistantLocalToolContent(
     Column(
         modifier = modifier
             .fillMaxSize()
-            .padding(16.dp)
             .verticalScroll(rememberScrollState())
+            .padding(contentPadding + PaddingValues(16.dp))
             .imePadding(),
         verticalArrangement = Arrangement.spacedBy(12.dp)
     ) {

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/assistant/detail/AssistantMcpPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/assistant/detail/AssistantMcpPage.kt
@@ -1,7 +1,7 @@
 package me.rerere.rikkahub.ui.pages.assistant.detail
 
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
@@ -14,6 +14,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import me.rerere.rikkahub.R
 import me.rerere.rikkahub.ui.components.ai.McpPicker
 import me.rerere.rikkahub.ui.components.nav.BackButton
+import me.rerere.rikkahub.utils.plus
 import org.koin.androidx.compose.koinViewModel
 import org.koin.core.parameter.parametersOf
 
@@ -40,10 +41,8 @@ fun AssistantMcpPage(id: String) {
         }
     ) { innerPadding ->
         McpPicker(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(innerPadding)
-                .padding(16.dp),
+            modifier = Modifier.fillMaxSize(),
+            contentPadding = innerPadding + PaddingValues(16.dp), 
             assistant = assistant,
             servers = mcpServerConfigs,
             onUpdateAssistant = { vm.update(it) }

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/assistant/detail/AssistantMemoryPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/assistant/detail/AssistantMemoryPage.kt
@@ -7,6 +7,7 @@ import me.rerere.hugeicons.stroke.Delete01
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -16,7 +17,6 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Card
-import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.LargeFlexibleTopAppBar
@@ -50,6 +50,7 @@ import me.rerere.rikkahub.ui.components.ui.RikkaConfirmDialog
 import me.rerere.rikkahub.ui.hooks.EditStateContent
 import me.rerere.rikkahub.ui.hooks.useEditState
 import me.rerere.rikkahub.ui.theme.CustomColors
+import me.rerere.rikkahub.utils.plus
 import org.koin.androidx.compose.koinViewModel
 import org.koin.core.parameter.parametersOf
 
@@ -81,7 +82,8 @@ fun AssistantMemoryPage(id: String) {
         containerColor = CustomColors.topBarColors.containerColor,
     ) { innerPadding ->
         AssistantMemoryContent(
-            modifier = Modifier.padding(innerPadding),
+            modifier = Modifier.fillMaxSize(),
+            contentPadding = innerPadding + PaddingValues(16.dp),
             assistant = assistant,
             memories = memories,
             onUpdateAssistant = { vm.update(it) },
@@ -95,6 +97,7 @@ fun AssistantMemoryPage(id: String) {
 @Composable
 private fun AssistantMemoryContent(
     modifier: Modifier = Modifier,
+    contentPadding: PaddingValues = PaddingValues(0.dp),
     assistant: Assistant,
     memories: List<AssistantMemory>,
     onUpdateAssistant: (Assistant) -> Unit,
@@ -156,9 +159,8 @@ private fun AssistantMemoryContent(
 
     Column(
         modifier = modifier
-            .fillMaxSize()
-            .padding(16.dp)
             .verticalScroll(rememberScrollState())
+            .padding(contentPadding)
             .imePadding(),
         verticalArrangement = Arrangement.spacedBy(12.dp)
     ) {

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/assistant/detail/AssistantPromptPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/assistant/detail/AssistantPromptPage.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -90,6 +91,7 @@ import me.rerere.rikkahub.utils.UiState
 import me.rerere.rikkahub.utils.insertAtCursor
 import me.rerere.rikkahub.utils.onError
 import me.rerere.rikkahub.utils.onSuccess
+import me.rerere.rikkahub.utils.plus
 import org.koin.androidx.compose.koinViewModel
 import org.koin.compose.koinInject
 import org.koin.core.parameter.parametersOf
@@ -123,7 +125,7 @@ fun AssistantPromptPage(id: String) {
         containerColor = CustomColors.topBarColors.containerColor,
     ) { innerPadding ->
         AssistantPromptContent(
-            modifier = Modifier.padding(innerPadding),
+            innerPadding = innerPadding,
             assistant = assistant,
             settings = settings,
             onUpdate = { vm.update(it) }
@@ -134,6 +136,7 @@ fun AssistantPromptPage(id: String) {
 @Composable
 private fun AssistantPromptContent(
     modifier: Modifier = Modifier,
+    innerPadding: PaddingValues,
     assistant: Assistant,
     settings: Settings,
     onUpdate: (Assistant) -> Unit
@@ -144,9 +147,9 @@ private fun AssistantPromptContent(
     Column(
         modifier = modifier
             .fillMaxSize()
-            .padding(16.dp)
             .imePadding()
-            .verticalScroll(rememberScrollState()),
+            .verticalScroll(rememberScrollState())
+            .padding(innerPadding + PaddingValues(16.dp)),
         verticalArrangement = Arrangement.spacedBy(12.dp)
     ) {
         Card(

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/assistant/detail/AssistantRequestPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/assistant/detail/AssistantRequestPage.kt
@@ -2,6 +2,7 @@ package me.rerere.rikkahub.ui.pages.assistant.detail
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
@@ -23,6 +24,7 @@ import me.rerere.rikkahub.R
 import me.rerere.rikkahub.data.model.Assistant
 import me.rerere.rikkahub.ui.components.nav.BackButton
 import me.rerere.rikkahub.ui.theme.CustomColors
+import me.rerere.rikkahub.utils.plus
 import org.koin.androidx.compose.koinViewModel
 import org.koin.core.parameter.parametersOf
 
@@ -53,7 +55,7 @@ fun AssistantRequestPage(id: String) {
         containerColor = CustomColors.topBarColors.containerColor,
     ) { innerPadding ->
         AssistantRequestContent(
-            modifier = Modifier.padding(innerPadding),
+            contentPadding = innerPadding,
             assistant = assistant,
             onUpdate = { vm.update(it) }
         )
@@ -63,6 +65,7 @@ fun AssistantRequestPage(id: String) {
 @Composable
 internal fun AssistantRequestContent(
     modifier: Modifier = Modifier,
+    contentPadding: PaddingValues = PaddingValues(),
     assistant: Assistant,
     onUpdate: (Assistant) -> Unit
 ) {
@@ -70,7 +73,7 @@ internal fun AssistantRequestContent(
         modifier = modifier
             .fillMaxSize()
             .verticalScroll(rememberScrollState())
-            .padding(16.dp)
+            .padding(contentPadding + PaddingValues(16.dp))
             .imePadding(),
         verticalArrangement = Arrangement.spacedBy(12.dp)
     ) {

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/log/LogPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/log/LogPage.kt
@@ -46,6 +46,7 @@ import me.rerere.rikkahub.ui.components.ui.JsonTree
 import me.rerere.rikkahub.ui.theme.CustomColors
 import me.rerere.rikkahub.ui.theme.JetbrainsMono
 import me.rerere.rikkahub.utils.JsonInstantPretty
+import me.rerere.rikkahub.utils.plus
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
@@ -85,9 +86,8 @@ fun LogPage() {
                 requestLoggingEnabled = it
                 Logging.setRequestLoggingEnabled(it)
             },
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(contentPadding)
+            modifier = Modifier.fillMaxSize(),
+            contentPadding = contentPadding + PaddingValues(16.dp)
         )
     }
 }
@@ -97,7 +97,8 @@ private fun UnifiedLogList(
     logs: List<LogEntry>,
     requestLoggingEnabled: Boolean,
     onRequestLoggingChange: (Boolean) -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    contentPadding: PaddingValues = PaddingValues(16.dp)
 ) {
     var selectedLog by remember { mutableStateOf<LogEntry.RequestLog?>(null) }
     val sheetState = rememberBottomSheetState(initialValue = SheetValue.Hidden, enabledValues = setOf(SheetValue.Hidden, SheetValue.Expanded))
@@ -107,7 +108,7 @@ private fun UnifiedLogList(
     LazyColumn(
         modifier = modifier,
         verticalArrangement = Arrangement.spacedBy(8.dp),
-        contentPadding = PaddingValues(16.dp)
+        contentPadding = contentPadding
     ) {
         item {
             RequestLoggingSwitchCard(

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingFilesPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingFilesPage.kt
@@ -53,6 +53,7 @@ import me.rerere.rikkahub.data.files.FilesManager
 import me.rerere.rikkahub.ui.components.nav.BackButton
 import me.rerere.rikkahub.ui.context.LocalToaster
 import me.rerere.rikkahub.ui.theme.CustomColors
+import me.rerere.rikkahub.utils.plus
 import org.koin.compose.koinInject
 import java.io.File
 
@@ -120,7 +121,7 @@ fun SettingFilesPage(
         Column(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(innerPadding)
+                .padding(top = innerPadding.calculateTopPadding())
         ) {
             FolderRow(
                 folders = folders,
@@ -134,12 +135,15 @@ fun SettingFilesPage(
                         .fillMaxSize(),
                     contentAlignment = Alignment.Center
                 ) {
-                    Text(stringResource(R.string.setting_files_page_no_files))
+                    Text(
+                        text = stringResource(R.string.setting_files_page_no_files),
+                        modifier = Modifier.padding(bottom = innerPadding.calculateBottomPadding())
+                    )
                 }
             } else {
                 LazyVerticalStaggeredGrid(
                     modifier = Modifier.fillMaxSize(),
-                    contentPadding = PaddingValues(16.dp),
+                    contentPadding = PaddingValues(16.dp) + PaddingValues(bottom = innerPadding.calculateBottomPadding()),
                     verticalItemSpacing = 8.dp,
                     horizontalArrangement = Arrangement.spacedBy(8.dp),
                     state = gridState,

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingMcpPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingMcpPage.kt
@@ -99,6 +99,7 @@ import me.rerere.rikkahub.ui.hooks.EditStateContent
 import me.rerere.rikkahub.ui.hooks.useEditState
 import me.rerere.rikkahub.ui.theme.CustomColors
 import me.rerere.rikkahub.ui.theme.extendColors
+import me.rerere.rikkahub.utils.plus
 import org.koin.androidx.compose.koinViewModel
 import org.koin.compose.koinInject
 
@@ -172,13 +173,13 @@ fun SettingMcpPage(vm: SettingVM = koinViewModel()) {
                 }
             },
             state = state,
-            modifier = Modifier.padding(innerPadding)
+            modifier = Modifier.fillMaxSize()
         ) {
             LazyColumn(
                 modifier = Modifier
                     .fillMaxSize(),
                 verticalArrangement = Arrangement.spacedBy(8.dp),
-                contentPadding = PaddingValues(16.dp)
+                contentPadding = innerPadding + PaddingValues(16.dp)
             ) {
                 items(mcpConfigs, key = { it.id }) { mcpConfig ->
                     McpServerItem(

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/webview/WebViewPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/webview/WebViewPage.kt
@@ -7,6 +7,7 @@ import me.rerere.hugeicons.stroke.Earth
 import me.rerere.hugeicons.stroke.Refresh01
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -40,6 +41,7 @@ import me.rerere.rikkahub.ui.components.webview.WebView
 import me.rerere.rikkahub.ui.components.webview.rememberWebViewState
 import me.rerere.rikkahub.ui.theme.JetbrainsMono
 import me.rerere.rikkahub.utils.base64Decode
+import me.rerere.rikkahub.utils.plus
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -136,12 +138,12 @@ fun WebViewPage(url: String, content: String) {
                 }
             )
         }
-    ) {
+    ) { innerPadding ->
         WebView(
             state = state,
             modifier = Modifier
                 .fillMaxSize()
-                .padding(it),
+                .padding(PaddingValues(top = innerPadding.calculateTopPadding()) + PaddingValues()),
         )
     }
 


### PR DESCRIPTION
Close #1348 

## 修复如下页面系统指示条沉浸问题：

- `assistant: AssistantPage`，设置 -> 助手

---

- `assistant/detail: AssistantBasicPage`，设置 -> 助手 -> 助手详情 -> 基础设定
- `assistant/detail: AssistantPromptPage`，设置 -> 助手 -> 助手详情 -> 提示词
- `assistant/detail: AssistantMemoryPage`，设置 -> 助手 -> 助手详情 -> 记忆
- `assistant/detail: AssistantRequestPage`，设置 -> 助手 -> 助手详情 -> 自定义请求
- `assistant/detail: AssistantMcpPage`，设置 -> 助手 -> 助手详情 -> MCP
- `assistant/detail: AssistantLocalToolPage`，设置 -> 助手 -> 助手详情 -> 本地工具

---

- `setting: SettingMcpPage`，设置 -> MCP
- `setting: SettingFilesPage`，设置 -> 聊天记录存储
- `log: LogPage`，设置 -> 请求日志

---

- `webview: WebViewPage`，聊天/代码块/Mermaid 预览 -> 网页视图渲染

---

| 修复前 | 修复后 |
|--------|--------|
| <img width="500" height="500" alt="a28318af7b7fb30a7aaaa3b0b5efdf0d" src="https://github.com/user-attachments/assets/3b22fe17-85e6-43ba-8660-2cb5e3b2b4e4" /> | <img width="500" height="500" alt="da9c6e013d675e28a82af829bf5c4e5f" src="https://github.com/user-attachments/assets/b21ba495-93f0-48cf-89f9-d4618ce906b7" /> |
| <img width="500" height="500" alt="74c07bb54126414cd04d0eef2fe1ecf3" src="https://github.com/user-attachments/assets/07688e64-e3c6-43d1-9237-cad1a7e5e6af" /> | <img width="500" height="500" alt="8620a5e78455c4db4f25e3770c60f087" src="https://github.com/user-attachments/assets/ff92d284-f9c4-4d56-b219-804c48b8b9a4" /> |

---

以及修复WebView markdown版本冲突