### PR TITLE
feat: 增加TTS朗读设置中引号所包含的标点符号

### DIFF
--- a/app/src/main/java/me/rerere/rikkahub/utils/StringUtils.kt
+++ b/app/src/main/java/me/rerere/rikkahub/utils/StringUtils.kt
@@ -93,17 +93,17 @@ fun Double.toFixed(digits: Int = 0) = "%.${digits}f".format(this)
 
 /**
  * 提取字符串中所有引号内的内容
- * 支持多种引号类型：英文双引号 "..."、英文单引号 '...'、中文双引号 "..."、中文单引号 '...'
+ * 支持多种引号类型：英文双引号 "..."、英文单引号 '...'、直角引号「…」、白直角引号『…』
  * @return 所有引号内内容的列表
  */
 fun String.extractQuotedContent(): List<String> {
     val result = mutableListOf<String>()
     // 匹配多种引号类型
     val patterns = listOf(
-        """"([^"]*?)"""",  // 中文双引号
-        """'([^']*?)'""",  // 中文单引号
-        """"([^"]*?)"""",  // 英文双引号
-        """'([^']*?)'""",  // 英文单引号
+        """"([^"]*?)"""",             // 英文双引号
+        """'([^']*?)'""",             // 英文单引号
+        """「([^」]*?)」""",           // 直角引号
+        """『([^』]*?)』""",           // 白直角引号
     )
     for (pattern in patterns) {
         val regex = Regex(pattern)

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -719,7 +719,7 @@
   <string name="setting_display_page_skip_crop_image_desc">导入图片或拍照后跳过裁剪界面</string>
   <string name="setting_display_page_skip_crop_image_title">跳过图片编辑</string>
   <string name="setting_display_page_title">显示设置</string>
-  <string name="setting_display_page_tts_only_read_quoted_desc">启用后，TTS 仅朗读引号内的内容</string>
+  <string name="setting_display_page_tts_only_read_quoted_desc">启用后，TTS 仅朗读引号（包括 ""、''、「」、『』）内的内容</string>
   <string name="setting_display_page_tts_only_read_quoted_title">TTS仅朗读引用内容</string>
   <string name="setting_display_page_use_app_icon_style_loading_indicator_desc">使用应用图标动画替代默认的圆形加载指示器</string>
   <string name="setting_display_page_use_app_icon_style_loading_indicator_title">使用APP图标风格的加载指示器</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -725,7 +725,7 @@
   <string name="setting_display_page_skip_crop_image_desc">Skip crop interface after importing images or taking photos</string>
   <string name="setting_display_page_skip_crop_image_title">Skip Image Editing</string>
   <string name="setting_display_page_title">Display Settings</string>
-  <string name="setting_display_page_tts_only_read_quoted_desc">When enabled, TTS will only read content within quotation marks</string>
+  <string name="setting_display_page_tts_only_read_quoted_desc">When enabled, TTS will only read content within quotation marks (including "", '', 「」, 『』)</string>
   <string name="setting_display_page_tts_only_read_quoted_title">TTS Read Quoted Content Only</string>
   <string name="setting_display_page_use_app_icon_style_loading_indicator_desc">Use the animated app icon instead of the default circular loading indicator</string>
   <string name="setting_display_page_use_app_icon_style_loading_indicator_title">Use App Icon-Style Loading Indicator</string>


### PR DESCRIPTION
## 变更内容

在 TTS "仅朗读引用内容" 功能中新增支持的引号类型：

- 直角引号「」（U+300C / U+300D）
- 白直角引号『』（U+300E / U+300F）

### 修改文件
1. `StringUtils.kt` - 新增直角引号、白直角引号正则
2. `values-zh/strings.xml` - 中文描述更新
3. `values/strings.xml` - 英文描述更新
