### PR TITLE
fix: 修复TTS朗读设置中中文弯引号无法正确匹配的问题

### DIFF
--- a/app/src/main/java/me/rerere/rikkahub/utils/StringUtils.kt
+++ b/app/src/main/java/me/rerere/rikkahub/utils/StringUtils.kt
@@ -100,8 +100,8 @@ fun String.extractQuotedContent(): List<String> {
     val result = mutableListOf<String>()
     // 匹配多种引号类型
     val patterns = listOf(
-        """"([^"]*?)"""",  // 中文双引号
-        """'([^']*?)'""",  // 中文单引号
+        "\u201C([^\u201D]*?)\u201D",  // 中文双引号
+        "\u2018([^\u2019]*?)\u2019",  // 中文单引号
         """"([^"]*?)"""",  // 英文双引号
         """'([^']*?)'""",  // 英文单引号
     )


### PR DESCRIPTION
## 变更内容

修复 `extractQuotedContent()` 中中文弯引号无法正确匹配的问题。

### 背景
原始代码中第103-104行虽注释为"中文双引号"/"中文单引号"，但因使用 Kotlin 原始字符串 `"""..."""` 且写的是 ASCII 双引号 `"`，实际匹配的是 ASCII 引号而非中文弯引号（U+201C/U+201D、U+2018/U+2019），导致中文弯引号从未被匹配过。

### 修复
- 将前两行正则替换为使用 Unicode 转义的正确表达式
- 保留英文引号部分不变

### 修改文件
1. `StringUtils.kt` - 修正中文弯引号正则表达式
