### PR TITLE
feat: 新增TTS正则设置TTS仅朗读括号外的内容

### DIFF
--- a/app/src/main/java/me/rerere/rikkahub/data/datastore/PreferencesStore.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/datastore/PreferencesStore.kt
@@ -587,6 +587,7 @@ data class DisplaySetting(
     val codeBlockAutoCollapse: Boolean = false,
     val showLineNumbers: Boolean = false,
     val ttsOnlyReadQuoted: Boolean = false,
+    val ttsOnlyReadOutsideBrackets: Boolean = false,
     val autoPlayTTSAfterGeneration: Boolean = false,
     val pasteLongTextAsFile: Boolean = false,
     val pasteLongTextThreshold: Int = 1000,

--- a/app/src/main/java/me/rerere/rikkahub/ui/components/message/ChatMessageActions.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/message/ChatMessageActions.kt
@@ -61,6 +61,7 @@ import me.rerere.rikkahub.ui.context.LocalSettings
 import me.rerere.rikkahub.ui.context.LocalTTSState
 import me.rerere.rikkahub.utils.copyMessageToClipboard
 import me.rerere.rikkahub.utils.extractQuotedContentAsText
+import me.rerere.rikkahub.utils.removeBracketedContent
 import me.rerere.rikkahub.utils.toLocalString
 import me.rerere.rikkahub.utils.toMessageTimeString
 import java.util.Locale
@@ -140,6 +141,8 @@ fun ColumnScope.ChatMessageActionButtons(
                                 val text = message.toText()
                                 val textToSpeak = if (settings.displaySetting.ttsOnlyReadQuoted) {
                                     text.extractQuotedContentAsText() ?: text
+                                } else if (settings.displaySetting.ttsOnlyReadOutsideBrackets) {
+                                    text.removeBracketedContent() ?: text
                                 } else {
                                     text
                                 }

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/chat/TTSAutoPlay.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/chat/TTSAutoPlay.kt
@@ -9,6 +9,7 @@ import me.rerere.rikkahub.data.datastore.Settings
 import me.rerere.rikkahub.data.model.Conversation
 import me.rerere.rikkahub.ui.context.LocalTTSState
 import me.rerere.rikkahub.utils.extractQuotedContentAsText
+import me.rerere.rikkahub.utils.removeBracketedContent
 
 @Composable
 fun TTSAutoPlay(vm: ChatVM, setting: Settings, conversation: Conversation) {
@@ -24,6 +25,8 @@ fun TTSAutoPlay(vm: ChatVM, setting: Settings, conversation: Conversation) {
                     val text = lastMessage.toText()
                     val textToSpeak = if (updatedSetting.displaySetting.ttsOnlyReadQuoted) {
                         text.extractQuotedContentAsText() ?: text
+                    } else if (updatedSetting.displaySetting.ttsOnlyReadOutsideBrackets) {
+                        text.removeBracketedContent() ?: text
                     } else {
                         text
                     }

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingPreferencesGeneralPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingPreferencesGeneralPage.kt
@@ -268,7 +268,29 @@ fun SettingPreferencesGeneralPage(vm: SettingVM = koinViewModel()) {
                             Switch(
                                 checked = displaySetting.ttsOnlyReadQuoted,
                                 onCheckedChange = {
-                                    updateDisplaySetting(displaySetting.copy(ttsOnlyReadQuoted = it))
+                                    updateDisplaySetting(
+                                        displaySetting.copy(
+                                            ttsOnlyReadQuoted = it,
+                                            ttsOnlyReadOutsideBrackets = if (it) false else displaySetting.ttsOnlyReadOutsideBrackets
+                                        )
+                                    )
+                                }
+                            )
+                        },
+                    )
+                    item(
+                        headlineContent = { Text(stringResource(R.string.setting_display_page_tts_read_outside_brackets_title)) },
+                        supportingContent = { Text(stringResource(R.string.setting_display_page_tts_read_outside_brackets_desc)) },
+                        trailingContent = {
+                            Switch(
+                                checked = displaySetting.ttsOnlyReadOutsideBrackets,
+                                onCheckedChange = {
+                                    updateDisplaySetting(
+                                        displaySetting.copy(
+                                            ttsOnlyReadOutsideBrackets = it,
+                                            ttsOnlyReadQuoted = if (it) false else displaySetting.ttsOnlyReadQuoted
+                                        )
+                                    )
                                 }
                             )
                         },

--- a/app/src/main/java/me/rerere/rikkahub/utils/StringUtils.kt
+++ b/app/src/main/java/me/rerere/rikkahub/utils/StringUtils.kt
@@ -130,3 +130,14 @@ fun String.extractQuotedContentAsText(separator: String = "\n"): String? {
         null
     }
 }
+
+/**
+ * 移除字符串中所有括号内的内容
+ * 支持英文括号 (...) 和中文括号（...）
+ * @return 移除括号内容后的字符串，如果全被移除则返回 null
+ */
+fun String.removeBracketedContent(): String? {
+    val pattern = """\([^)]*?\)|（[^）]*?）""".toRegex()
+    val result = pattern.replace(this, "").trim()
+    return result.ifBlank { null }
+}

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -721,6 +721,8 @@
   <string name="setting_display_page_title">显示设置</string>
   <string name="setting_display_page_tts_only_read_quoted_desc">启用后，TTS 仅朗读引号内的内容</string>
   <string name="setting_display_page_tts_only_read_quoted_title">TTS仅朗读引用内容</string>
+  <string name="setting_display_page_tts_read_outside_brackets_desc">启用后，TTS将跳过括号内的部分，仅朗读括号外的内容</string>
+  <string name="setting_display_page_tts_read_outside_brackets_title">TTS仅朗读括号外的内容</string>
   <string name="setting_display_page_use_app_icon_style_loading_indicator_desc">使用应用图标动画替代默认的圆形加载指示器</string>
   <string name="setting_display_page_use_app_icon_style_loading_indicator_title">使用APP图标风格的加载指示器</string>
   <string name="setting_display_page_volume_key_scroll_desc">使用音量键翻页，非常适合电子墨水屏</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -727,6 +727,8 @@
   <string name="setting_display_page_title">Display Settings</string>
   <string name="setting_display_page_tts_only_read_quoted_desc">When enabled, TTS will only read content within quotation marks</string>
   <string name="setting_display_page_tts_only_read_quoted_title">TTS Read Quoted Content Only</string>
+  <string name="setting_display_page_tts_read_outside_brackets_desc">When enabled, TTS will skip content inside brackets and read the remaining text</string>
+  <string name="setting_display_page_tts_read_outside_brackets_title">TTS Read Outside Brackets Only</string>
   <string name="setting_display_page_use_app_icon_style_loading_indicator_desc">Use the animated app icon instead of the default circular loading indicator</string>
   <string name="setting_display_page_use_app_icon_style_loading_indicator_title">Use App Icon-Style Loading Indicator</string>
   <string name="setting_display_page_volume_key_scroll_desc">Scroll pages with volume keys, ideal for e-ink screens</string>


### PR DESCRIPTION
## 变更内容

在 TTS 设置中新增"TTS仅朗读括号外的内容"开关。

### 功能说明
- 在 TTS 设置页面新增开关，启用后 TTS 将跳过括号内的内容，仅朗读括号外的文字
- 支持英文括号 `()` 和中文括号 `（）`
- 与现有的"TTS仅朗读引用内容"开关互斥，两个开关不可同时开启

### 场景
角色扮演场景中，括号内一般为动作描写（如 `（叹气）`、`（微笑）`），用户希望跳过这些内容，只朗读对话文本。

### 修改文件
1. `StringUtils.kt` - 新增 `removeBracketedContent()` 函数
2. `PreferencesStore.kt` - 新增 `ttsOnlyReadOutsideBrackets` 字段
3. `SettingPreferencesGeneralPage.kt` - 新增 UI 开关及互斥逻辑
4. `TTSAutoPlay.kt` - 自动播放 TTS 支持新设置
5. `ChatMessageActions.kt` - 手动 TTS 支持新设置
6. `values-zh/strings.xml` - 中文描述
7. `values/strings.xml` - 英文描述

Close #1463
