### PR TITLE
feat: broaden Qwen 3.5-3.7 and Doubao seed-2 model capability detection

### DIFF
--- a/ai/src/main/java/me/rerere/ai/registry/ModelRegistry.kt
+++ b/ai/src/main/java/me/rerere/ai/registry/ModelRegistry.kt
@@ -317,6 +317,21 @@ object ModelRegistry {
         toolReasoningAbility()
     }
 
+    private val QWEN_3_5_MAX = defineModel {
+        tokens("qwen", "3", "5", "max")
+        toolReasoningAbility()
+    }
+
+    private val QWEN_3_6_MAX = defineModel {
+        tokens("qwen", "3", "6", "max")
+        toolReasoningAbility()
+    }
+
+    private val QWEN_3_7_MAX = defineModel {
+        tokens("qwen", "3", "7", "max")
+        toolReasoningAbility()
+    }
+
     private val DOUBAO_1_6 = defineModel {
         tokens("doubao", "1", "6")
         visionInput()
@@ -325,6 +340,18 @@ object ModelRegistry {
 
     private val DOUBAO_1_8 = defineModel {
         tokens("doubao", "1", "8")
+        visionInput()
+        toolReasoningAbility()
+    }
+
+    private val DOUBAO_2_0 = defineModel {
+        tokens("doubao", "2", "0")
+        visionInput()
+        toolReasoningAbility()
+    }
+
+    private val DOUBAO_2_1 = defineModel {
+        tokens("doubao", "2", "1")
         visionInput()
         toolReasoningAbility()
     }
@@ -504,8 +531,13 @@ object ModelRegistry {
         QWEN_3_5,
         QWEN_3_6,
         QWEN_3_7,
+        QWEN_3_5_MAX,
+        QWEN_3_6_MAX,
+        QWEN_3_7_MAX,
         DOUBAO_1_6,
         DOUBAO_1_8,
+        DOUBAO_2_0,
+        DOUBAO_2_1,
         GROK_4,
         KIMI_K2,
         KIMI_K2_5,


### PR DESCRIPTION
## Summary

Added detection of model capabilities of Qwen 3.5/6/7 Max and Doubao 2.0/2.1.

1. Excluded QWEN_3_5/6/7_MAX from vision (higher token score wins, 4>3)
2. Add DOUBAO_2_0 and DOUBAO_2_1 with vision + tool + reasoning to support doubao-seed-2.0/2.1 models

## Evidence

| Q3.7 Max | Q3.6 Max | D2.1 | D2.0 |
| -- | -- | -- | -- |
| <img width="930" height="474" alt="image" src="https://github.com/user-attachments/assets/2b1a3646-4544-4689-83ef-a0d8663d54a9" /> | <img width="899" height="463" alt="image" src="https://github.com/user-attachments/assets/ce5e3378-3f0e-4a2e-ba3f-7f41875a9558" /> | <img width="1173" height="522" alt="image" src="https://github.com/user-attachments/assets/f806f490-6f5d-489f-9798-058067873e88" /> | <img width="1636" height="380" alt="image" src="https://github.com/user-attachments/assets/89685c51-c6cb-4a38-812d-0594ee8f1654" /> |
