### PR TITLE
refactor: Unify `fileSizeToString()` variants

### DIFF
--- a/app/src/main/java/me/rerere/rikkahub/ui/components/message/tools/WorkspaceToolUIs.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/message/tools/WorkspaceToolUIs.kt
@@ -426,13 +426,6 @@ private fun JsonElement?.int(key: String): Int? =
 private fun JsonElement?.long(key: String): Long? =
     this?.jsonObjectOrNull?.get(key)?.jsonPrimitiveOrNull?.longOrNull
 
-/** 将字节数格式化为人类可读大小 */
-private fun formatBytes(bytes: Long): String = when {
-    bytes < 1024 -> "$bytes B"
-    bytes < 1024 * 1024 -> "%.1f KB".format(bytes / 1024.0)
-    else -> "%.1f MB".format(bytes / (1024.0 * 1024.0))
-}
-
 private const val FILE_SUMMARY_MAX_LINES = 10
 
 /** 由文件扩展名推断语法高亮语言 */

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/extensions/workspace/WorkspaceDetailPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/extensions/workspace/WorkspaceDetailPage.kt
@@ -76,6 +76,7 @@ import me.rerere.rikkahub.ui.components.nav.BackButton
 import me.rerere.rikkahub.ui.components.ui.RikkaConfirmDialog
 import me.rerere.rikkahub.ui.context.LocalNavController
 import me.rerere.rikkahub.ui.theme.CustomColors
+import me.rerere.rikkahub.utils.fileSizeToString
 import me.rerere.rikkahub.utils.plus
 import me.rerere.workspace.RootfsInstallProgress
 import me.rerere.workspace.RootfsInstallStage
@@ -470,8 +471,8 @@ private fun RootfsProgress(progress: RootfsInstallProgress) {
         Text(
             text = when (progress.stage) {
                 RootfsInstallStage.DOWNLOADING -> {
-                    val total = progress.totalBytes?.let { " / ${formatBytes(it)}" }.orEmpty()
-                    stringResource(R.string.workspace_detail_downloading, formatBytes(progress.bytesRead), total)
+                    val total = progress.totalBytes?.let { " / ${it.fileSizeToString()}" }.orEmpty()
+                    stringResource(R.string.workspace_detail_downloading, progress.bytesRead.fileSizeToString(), total)
                 }
 
                 RootfsInstallStage.EXTRACTING -> {
@@ -682,7 +683,7 @@ private fun WorkspaceFileCard(
                     overflow = TextOverflow.Ellipsis,
                 )
                 Text(
-                    text = if (entry.isDirectory) entry.path else "${entry.path} · ${formatBytes(entry.sizeBytes)}",
+                    text = if (entry.isDirectory) entry.path else "${entry.path} · ${entry.sizeBytes.fileSizeToString()}",
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                     maxLines = 1,
@@ -781,18 +782,6 @@ private fun ErrorCard(message: String) {
             color = MaterialTheme.colorScheme.error,
         )
     }
-}
-
-private fun formatBytes(bytes: Long): String {
-    if (bytes < 1024) return "$bytes B"
-    val units = listOf("KB", "MB", "GB", "TB")
-    var value = bytes / 1024.0
-    var unitIndex = 0
-    while (value >= 1024 && unitIndex < units.lastIndex) {
-        value /= 1024
-        unitIndex++
-    }
-    return "%.1f %s".format(value, units[unitIndex])
 }
 
 @Composable

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingFilesPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingFilesPage.kt
@@ -53,6 +53,7 @@ import me.rerere.rikkahub.data.files.FilesManager
 import me.rerere.rikkahub.ui.components.nav.BackButton
 import me.rerere.rikkahub.ui.context.LocalToaster
 import me.rerere.rikkahub.ui.theme.CustomColors
+import me.rerere.rikkahub.utils.fileSizeToString
 import org.koin.compose.koinInject
 import java.io.File
 
@@ -253,21 +254,11 @@ private fun FileItem(
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
                 Text(
-                    text = formatBytes(file.sizeBytes),
+                    text = file.sizeBytes.fileSizeToString(),
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
             }
         }
     }
-}
-
-private fun formatBytes(bytes: Long): String {
-    if (bytes < 1024) return "${bytes}B"
-    val kb = bytes / 1024.0
-    if (kb < 1024) return String.format("%.1fKB", kb)
-    val mb = kb / 1024.0
-    if (mb < 1024) return String.format("%.1fMB", mb)
-    val gb = mb / 1024.0
-    return String.format("%.1fGB", gb)
 }

--- a/app/src/main/java/me/rerere/rikkahub/utils/StringUtils.kt
+++ b/app/src/main/java/me/rerere/rikkahub/utils/StringUtils.kt
@@ -45,12 +45,20 @@ fun String.applyPlaceholders(
 }
 
 fun Long.fileSizeToString(): String {
-    return when {
-        this < 1024 -> "$this B"
-        this < 1024 * 1024 -> "${this / 1024} KB"
-        this < 1024 * 1024 * 1024 -> "${this / (1024 * 1024)} MB"
-        else -> "${this / (1024 * 1024 * 1024)} GB"
+    if (this < 1024) return "$this B"
+    val units = arrayOf("KB", "MB", "GB", "TB")
+    var value = toDouble() / 1024.0
+    var unitIndex = 0
+    while (value >= 1024 && unitIndex < units.lastIndex) {
+        value /= 1024.0
+        unitIndex++
     }
+    val precision = when {
+        value >= 100 -> 0
+        value >= 10 -> 1
+        else -> 2
+    }
+    return "%.${precision}f %s".format(value, units[unitIndex])
 }
 
 fun Int.formatNumber(): String {


### PR DESCRIPTION
- Unified four `formatBytes`/`fileSizeToString` variants into a single implementation supporting up to TB with **3 decimal places**.
- Deleted unused `formatBytes()` in `WorkspaceToolUIs.kt`.
