### PR TITLE
feat: TTS不朗读括号内的内容，与引号过滤叠加生效

### DIFF
--- a/app/src/main/java/me/rerere/rikkahub/data/datastore/PreferencesStore.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/datastore/PreferencesStore.kt
@@ -587,6 +587,7 @@ data class DisplaySetting(
     val codeBlockAutoCollapse: Boolean = false,
     val showLineNumbers: Boolean = false,
     val ttsOnlyReadQuoted: Boolean = false,
+    val ttsOnlyReadOutsideBrackets: Boolean = false,
     val autoPlayTTSAfterGeneration: Boolean = false,
     val pasteLongTextAsFile: Boolean = false,
     val pasteLongTextThreshold: Int = 1000,

--- a/app/src/main/java/me/rerere/rikkahub/ui/components/message/ChatMessageActions.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/message/ChatMessageActions.kt
@@ -61,6 +61,7 @@ import me.rerere.rikkahub.ui.context.LocalSettings
 import me.rerere.rikkahub.ui.context.LocalTTSState
 import me.rerere.rikkahub.utils.copyMessageToClipboard
 import me.rerere.rikkahub.utils.extractQuotedContentAsText
+import me.rerere.rikkahub.utils.removeBracketedContent
 import me.rerere.rikkahub.utils.toLocalString
 import me.rerere.rikkahub.utils.toMessageTimeString
 import java.util.Locale
@@ -138,10 +139,12 @@ fun ColumnScope.ChatMessageActionButtons(
                         onClick = {
                             if (!isSpeaking) {
                                 val text = message.toText()
-                                val textToSpeak = if (settings.displaySetting.ttsOnlyReadQuoted) {
-                                    text.extractQuotedContentAsText() ?: text
-                                } else {
-                                    text
+                                var textToSpeak = text
+                                if (settings.displaySetting.ttsOnlyReadQuoted) {
+                                    textToSpeak = textToSpeak.extractQuotedContentAsText() ?: textToSpeak
+                                }
+                                if (settings.displaySetting.ttsOnlyReadOutsideBrackets) {
+                                    textToSpeak = textToSpeak.removeBracketedContent() ?: textToSpeak
                                 }
                                 tts.speak(textToSpeak)
                             } else {

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/chat/TTSAutoPlay.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/chat/TTSAutoPlay.kt
@@ -9,6 +9,7 @@ import me.rerere.rikkahub.data.datastore.Settings
 import me.rerere.rikkahub.data.model.Conversation
 import me.rerere.rikkahub.ui.context.LocalTTSState
 import me.rerere.rikkahub.utils.extractQuotedContentAsText
+import me.rerere.rikkahub.utils.removeBracketedContent
 
 @Composable
 fun TTSAutoPlay(vm: ChatVM, setting: Settings, conversation: Conversation) {
@@ -22,10 +23,12 @@ fun TTSAutoPlay(vm: ChatVM, setting: Settings, conversation: Conversation) {
                 val lastMessage = currentConversation.currentMessages.lastOrNull()
                 if (lastMessage != null && lastMessage.role == MessageRole.ASSISTANT) {
                     val text = lastMessage.toText()
-                    val textToSpeak = if (updatedSetting.displaySetting.ttsOnlyReadQuoted) {
-                        text.extractQuotedContentAsText() ?: text
-                    } else {
-                        text
+                    var textToSpeak = text
+                    if (updatedSetting.displaySetting.ttsOnlyReadQuoted) {
+                        textToSpeak = textToSpeak.extractQuotedContentAsText() ?: textToSpeak
+                    }
+                    if (updatedSetting.displaySetting.ttsOnlyReadOutsideBrackets) {
+                        textToSpeak = textToSpeak.removeBracketedContent() ?: textToSpeak
                     }
                     if (textToSpeak.isNotBlank()) {
                         tts.speak(textToSpeak)

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingPreferencesGeneralPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingPreferencesGeneralPage.kt
@@ -274,6 +274,18 @@ fun SettingPreferencesGeneralPage(vm: SettingVM = koinViewModel()) {
                         },
                     )
                     item(
+                        headlineContent = { Text(stringResource(R.string.setting_display_page_tts_read_outside_brackets_title)) },
+                        supportingContent = { Text(stringResource(R.string.setting_display_page_tts_read_outside_brackets_desc)) },
+                        trailingContent = {
+                            Switch(
+                                checked = displaySetting.ttsOnlyReadOutsideBrackets,
+                                onCheckedChange = {
+                                    updateDisplaySetting(displaySetting.copy(ttsOnlyReadOutsideBrackets = it))
+                                }
+                            )
+                        },
+                    )
+                    item(
                         headlineContent = { Text(stringResource(R.string.setting_display_page_auto_play_tts_title)) },
                         supportingContent = { Text(stringResource(R.string.setting_display_page_auto_play_tts_desc)) },
                         trailingContent = {

--- a/app/src/main/java/me/rerere/rikkahub/utils/StringUtils.kt
+++ b/app/src/main/java/me/rerere/rikkahub/utils/StringUtils.kt
@@ -130,3 +130,14 @@ fun String.extractQuotedContentAsText(separator: String = "\n"): String? {
         null
     }
 }
+
+/**
+ * 移除字符串中所有括号内的内容
+ * 支持英文括号 (...) 和中文括号（...）
+ * @return 移除括号内容后的字符串，如果全被移除则返回 null
+ */
+fun String.removeBracketedContent(): String? {
+    val pattern = """\([^)]*?\)|（[^）]*?）""".toRegex()
+    val result = pattern.replace(this, "").trim()
+    return result.ifBlank { null }
+}

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -721,6 +721,8 @@
   <string name="setting_display_page_title">显示设置</string>
   <string name="setting_display_page_tts_only_read_quoted_desc">启用后，TTS 仅朗读引号内的内容</string>
   <string name="setting_display_page_tts_only_read_quoted_title">TTS仅朗读引用内容</string>
+  <string name="setting_display_page_tts_read_outside_brackets_desc">启用后，TTS将不朗读括号内的内容</string>
+  <string name="setting_display_page_tts_read_outside_brackets_title">TTS不朗读括号内的内容</string>
   <string name="setting_display_page_use_app_icon_style_loading_indicator_desc">使用应用图标动画替代默认的圆形加载指示器</string>
   <string name="setting_display_page_use_app_icon_style_loading_indicator_title">使用APP图标风格的加载指示器</string>
   <string name="setting_display_page_volume_key_scroll_desc">使用音量键翻页，非常适合电子墨水屏</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -727,6 +727,8 @@
   <string name="setting_display_page_title">Display Settings</string>
   <string name="setting_display_page_tts_only_read_quoted_desc">When enabled, TTS will only read content within quotation marks</string>
   <string name="setting_display_page_tts_only_read_quoted_title">TTS Read Quoted Content Only</string>
+  <string name="setting_display_page_tts_read_outside_brackets_desc">When enabled, TTS will not read content inside brackets</string>
+  <string name="setting_display_page_tts_read_outside_brackets_title">TTS Skip Bracketed Content</string>
   <string name="setting_display_page_use_app_icon_style_loading_indicator_desc">Use the animated app icon instead of the default circular loading indicator</string>
   <string name="setting_display_page_use_app_icon_style_loading_indicator_title">Use App Icon-Style Loading Indicator</string>
   <string name="setting_display_page_volume_key_scroll_desc">Scroll pages with volume keys, ideal for e-ink screens</string>


### PR DESCRIPTION
## 变更内容

修改 #1464，根据维护者的反馈将互斥设计改为叠加过滤。

### 核心变更

1. **语义变更**：从「TTS仅朗读括号外的内容」改为「TTS不朗读括号内的内容」
2. **互斥 → 叠加**：删除了与「仅朗读引号内」的互斥逻辑，两个正则可同时开启
3. **叠加效果**：当两个正则同时打开时，TTS 仅朗读引号内的括号外的内容

### 修改文件

- `ChatMessageActions.kt` — 叠加过滤逻辑
- `TTSAutoPlay.kt` — 叠加过滤逻辑
- `SettingPreferencesGeneralPage.kt` — 去掉 UI 互锁
- `values-zh/strings.xml` — 更新中文文案
- `values/strings.xml` — 更新英文文案
- `PreferencesStore.kt` — 新增设置项（不变）
- `StringUtils.kt` — 新增 `removeBracketedContent()` 函数（不变）

Close #1463