### PR TITLE
feat: 手动图片压缩支持 (#1000)

### DIFF
--- a/app/src/main/java/me/rerere/rikkahub/data/datastore/PreferencesStore.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/datastore/PreferencesStore.kt
@@ -581,6 +581,7 @@ data class DisplaySetting(
     val fontSizeRatio: Float = 1.0f,
     val enableMessageGenerationHapticEffect: Boolean = false,
     val skipCropImage: Boolean = true,
+    val manualImageCompression: Boolean = true,
     val enableNotificationOnMessageGeneration: Boolean = false,
     val enableLiveUpdateNotification: Boolean = false,
     val codeBlockAutoWrap: Boolean = false,

--- a/app/src/main/java/me/rerere/rikkahub/ui/components/ai/AttachmentChips.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/ai/AttachmentChips.kt
@@ -22,7 +22,10 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.core.net.toUri
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -31,7 +34,6 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.util.fastForEach
-import androidx.core.net.toUri
 import coil3.compose.AsyncImage
 import me.rerere.ai.ui.UIMessagePart
 import me.rerere.hugeicons.HugeIcons
@@ -40,7 +42,9 @@ import me.rerere.hugeicons.stroke.Files02
 import me.rerere.hugeicons.stroke.MusicNote03
 import me.rerere.hugeicons.stroke.Video01
 import me.rerere.rikkahub.data.files.FilesManager
+import me.rerere.rikkahub.ui.components.ui.ImageInfoDialog
 import me.rerere.rikkahub.ui.hooks.ChatInputState
+import me.rerere.rikkahub.ui.context.LocalSettings
 import org.koin.compose.koinInject
 
 @Composable
@@ -48,12 +52,22 @@ internal fun MediaFileInputRow(
     state: ChatInputState,
 ) {
     val filesManager: FilesManager = koinInject()
+    val settings = LocalSettings.current
     val managedFiles by filesManager.observe().collectAsState(initial = emptyList())
     val displayNameByRelativePath = remember(managedFiles) {
         managedFiles.associate { it.relativePath to it.displayName }
     }
     val displayNameByFileName = remember(managedFiles) {
         managedFiles.associate { it.relativePath.substringAfterLast('/') to it.displayName }
+    }
+
+    var compressTarget by remember { mutableStateOf<UIMessagePart.Image?>(null) }
+
+    compressTarget?.let { part ->
+        ImageInfoDialog(
+            part = part,
+            onDismiss = { compressTarget = null },
+        )
     }
 
     fun removePart(part: UIMessagePart, url: String) {
@@ -73,6 +87,9 @@ internal fun MediaFileInputRow(
         state.messageContent.fastForEach { part ->
             when (part) {
                 is UIMessagePart.Image -> {
+                    val ext = part.url.substringAfterLast('.').lowercase()
+                    val canCompress = settings.displaySetting.manualImageCompression &&
+                            ext in listOf("jpg", "jpeg", "png")
                     AttachmentChip(
                         title = attachmentNameFromUrl(
                             url = part.url,
@@ -94,6 +111,7 @@ internal fun MediaFileInputRow(
                                 )
                             }
                         },
+                        onClick = if (canCompress) {{ compressTarget = part }} else null,
                         onRemove = { removePart(part, part.url) }
                     )
                 }
@@ -148,6 +166,7 @@ private fun AttachmentChip(
     title: String,
     leading: @Composable () -> Unit,
     onRemove: () -> Unit,
+    onClick: (() -> Unit)? = null,
 ) {
     Surface(
         shape = RoundedCornerShape(18.dp),
@@ -159,9 +178,13 @@ private fun AttachmentChip(
         Row(
             modifier = Modifier
                 .height(44.dp)
+                .then(
+                    if (onClick != null) Modifier.clickable { onClick?.invoke() }
+                    else Modifier
+                )
                 .padding(start = 8.dp, end = 6.dp),
             verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(8.dp)
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
         ) {
             leading()
             Text(

--- a/app/src/main/java/me/rerere/rikkahub/ui/components/ui/ImageInfoDialog.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/ui/ImageInfoDialog.kt
@@ -1,0 +1,177 @@
+package me.rerere.rikkahub.ui.components.ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import androidx.core.net.toUri
+import coil3.compose.AsyncImage
+import coil3.memory.MemoryCache
+import com.dokar.sonner.ToastType
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import me.rerere.ai.ui.UIMessagePart
+import me.rerere.rikkahub.R
+import me.rerere.rikkahub.ui.context.LocalToaster
+import me.rerere.rikkahub.utils.fileSizeToString
+import kotlin.math.roundToInt
+import me.rerere.rikkahub.utils.ImageUtils
+import java.io.File
+
+@Composable
+fun ImageInfoDialog(
+    part: UIMessagePart.Image,
+    onDismiss: () -> Unit,
+) {
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+    val toaster = LocalToaster.current
+    var isCompressing by remember { mutableStateOf(false) }
+    var fileSize by remember { mutableStateOf(0L) }
+
+    val uri = remember { part.url.toUri() }
+    val file = remember { uri.path?.let { File(it) } }
+    var imageInfo by remember { mutableStateOf<ImageUtils.ImageInfo?>(null) }
+    val width = imageInfo?.width ?: 0
+    val height = imageInfo?.height ?: 0
+    val maxDimension = maxOf(width, height)
+
+    LaunchedEffect(uri) {
+        fileSize = file?.length() ?: 0L
+        imageInfo = withContext(Dispatchers.IO) {
+            ImageUtils.getImageInfo(context, uri)
+        }
+    }
+
+    fun doCompress(targetDimension: Int) {
+        if (isCompressing || targetDimension >= maxDimension) return
+        isCompressing = true
+        scope.launch {
+            val origSize = fileSize
+            val newSize = withContext(Dispatchers.IO) {
+                ImageUtils.compressImage(context, uri, targetDimension)
+            }
+            if (newSize != null && newSize > 0L && newSize < origSize) {
+                fileSize = newSize
+                runCatching {
+                    val loader = coil3.SingletonImageLoader.get(context)
+                    loader.memoryCache?.remove(MemoryCache.Key(part.url))
+                    loader.diskCache?.remove(part.url)
+                }
+                val saved = origSize - newSize
+                val pct = (saved.toFloat() / origSize * 100f).roundToInt()
+                toaster.show(
+                    "${origSize.fileSizeToString()} → ${newSize.fileSizeToString()} (-${pct}%)",
+                    type = ToastType.Success,
+                )
+            }
+            isCompressing = false
+            onDismiss()
+        }
+    }
+
+    Dialog(
+        onDismissRequest = { if (!isCompressing) onDismiss() },
+        properties = DialogProperties(dismissOnClickOutside = false),
+    ) {
+        Surface(
+            shape = RoundedCornerShape(16.dp),
+            tonalElevation = 6.dp,
+        ) {
+            Column(modifier = Modifier.padding(20.dp)) {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    AsyncImage(
+                        model = part.url,
+                        contentDescription = null,
+                        modifier = Modifier
+                            .size(56.dp)
+                            .clip(RoundedCornerShape(8.dp)),
+                        contentScale = ContentScale.Crop,
+                    )
+                    Spacer(Modifier.width(12.dp))
+                    Column {
+                        Text(
+                            text = file?.name ?: "",
+                            style = MaterialTheme.typography.titleSmall,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                        )
+                        Text(
+                            text = "${fileSize.fileSizeToString()} · ${width}×${height}",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                }
+
+                Spacer(Modifier.height(16.dp))
+
+                Text(
+                    text = stringResource(R.string.image_compression_header),
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Spacer(Modifier.height(8.dp))
+
+                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    val presets = listOf(
+                        "1/2" to (maxDimension / 2),
+                        "1/4" to (maxDimension / 4),
+                        "1024" to 1024,
+                    )
+                    presets.forEach { (label, target) ->
+                        if (target in 1 until maxDimension) {
+                            Button(
+                                onClick = { doCompress(target) },
+                                enabled = !isCompressing,
+                                modifier = Modifier.height(36.dp),
+                            ) {
+                                Text(label)
+                            }
+                        }
+                    }
+                }
+
+                Spacer(Modifier.height(20.dp))
+
+                Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
+                    TextButton(
+                        onClick = onDismiss,
+                        enabled = !isCompressing,
+                    ) {
+                        Text(stringResource(R.string.cancel))
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingPreferencesGeneralPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingPreferencesGeneralPage.kt
@@ -185,6 +185,18 @@ fun SettingPreferencesGeneralPage(vm: SettingVM = koinViewModel()) {
                         },
                     )
                     item(
+                        headlineContent = { Text(stringResource(R.string.setting_display_page_manual_image_compression_title)) },
+                        supportingContent = { Text(stringResource(R.string.setting_display_page_manual_image_compression_desc)) },
+                        trailingContent = {
+                            Switch(
+                                checked = displaySetting.manualImageCompression,
+                                onCheckedChange = {
+                                    updateDisplaySetting(displaySetting.copy(manualImageCompression = it))
+                                }
+                            )
+                        },
+                    )
+                    item(
                         headlineContent = { Text(stringResource(R.string.setting_display_page_paste_long_text_as_file_title)) },
                         supportingContent = { Text(stringResource(R.string.setting_display_page_paste_long_text_as_file_desc)) },
                         trailingContent = {

--- a/app/src/main/java/me/rerere/rikkahub/utils/ImageUtils.kt
+++ b/app/src/main/java/me/rerere/rikkahub/utils/ImageUtils.kt
@@ -7,7 +7,9 @@ import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.graphics.Matrix
 import android.net.Uri
+import androidx.core.net.toFile
 import androidx.exifinterface.media.ExifInterface
+import java.io.ByteArrayOutputStream
 import java.io.File
 import com.drew.imaging.ImageMetadataReader
 import com.drew.imaging.png.PngChunkType
@@ -33,12 +35,14 @@ object ImageUtils {
      * @param context Android上下文
      * @param uri 图片URI
      * @param maxSize 最大尺寸限制，默认1024px
+     * @param config 解码时的 Bitmap 配置，PNG 需 ARGB_8888 保留透明度，JPEG 可用 RGB_565 省内存
      * @return 压缩后的Bitmap，失败返回null
      */
     fun loadOptimizedBitmap(
         context: Context,
         uri: Uri,
-        maxSize: Int = 1024
+        maxSize: Int = 1024,
+        config: Bitmap.Config = Bitmap.Config.RGB_565
     ): Bitmap? {
         return runCatching {
             // 第一步：获取图片的原始尺寸，不加载到内存
@@ -56,7 +60,7 @@ object ImageUtils {
             // 第二步：使用采样率加载压缩后的图片
             val loadOptions = BitmapFactory.Options().apply {
                 inSampleSize = sampleSize
-                inPreferredConfig = Bitmap.Config.RGB_565 // 使用RGB_565减少内存占用
+                inPreferredConfig = config
             }
 
             val bitmap = context.contentResolver.openInputStream(uri)?.use { inputStream ->
@@ -64,7 +68,19 @@ object ImageUtils {
             }
 
             // 第三步：处理图片旋转（如果需要）
-            bitmap?.let { correctImageOrientation(context, uri, it) }
+            val oriented = bitmap?.let { correctImageOrientation(context, uri, it) }
+
+            // 第四步：精确缩放到目标尺寸（弥补 inSampleSize 只能 2ⁿ 采样的限制）
+            oriented?.let { bmp ->
+                val longSide = maxOf(bmp.width, bmp.height)
+                if (longSide > maxSize) {
+                    val ratio = maxSize.toFloat() / longSide
+                    val sw = (bmp.width * ratio).toInt()
+                    val sh = (bmp.height * ratio).toInt()
+                    Bitmap.createScaledBitmap(bmp, sw, sh, true)
+                        .also { if (it != bmp) bmp.recycle() }
+                } else bmp
+            }
         }.onFailure {
             it.printStackTrace()
         }.getOrNull()
@@ -260,6 +276,50 @@ object ImageUtils {
                 it.recycle()
             }
         }
+    }
+
+    /**
+     * 压缩图片到指定长边尺寸，消耗于调用线程（应在 IO 线程执行）
+     *
+     * JPEG 以 quality 80 重编码以降低体积，
+     * PNG 仅降分辨率（保持透明通道），
+     * 当压缩结果不小于原体积时保留原文件。
+     *
+     * @param context Android 上下文
+     * @param uri 本地 file:// URI，指向 [FilesManager] 管理的文件
+     * @param maxDimension 压缩后最长边的像素值
+     * @return 压缩后的文件字节数，失败或未缩小则返回 null
+     */
+    fun compressImage(context: Context, uri: Uri, maxDimension: Int): Long? {
+        return runCatching {
+            val info = getImageInfo(context, uri) ?: return@runCatching null
+            val mimeType = info.mimeType ?: "image/jpeg"
+            val format = when (mimeType) {
+                "image/png" -> Bitmap.CompressFormat.PNG
+                else -> Bitmap.CompressFormat.JPEG
+            }
+            val quality = if (format == Bitmap.CompressFormat.JPEG) 80 else 100
+            val config = if (format == Bitmap.CompressFormat.PNG)
+                Bitmap.Config.ARGB_8888 else Bitmap.Config.RGB_565
+
+            val bitmap = loadOptimizedBitmap(context, uri, maxDimension, config) ?: return@runCatching null
+            val file = uri.toFile()
+            val originalSize = file.length()
+
+            val compressed = ByteArrayOutputStream().use { output ->
+                bitmap.compress(format, quality, output)
+                output.toByteArray()
+            }
+            bitmap.recycle()
+            if (compressed.size >= originalSize) return@runCatching null
+            val tmp = File(file.parentFile, "${file.name}.tmp")
+            try {
+                tmp.writeBytes(compressed)
+                if (tmp.renameTo(file)) file.length() else null
+            } finally {
+                if (tmp.exists()) tmp.delete()
+            }
+        }.onFailure { it.printStackTrace() }.getOrNull()
     }
 
     /**

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -688,6 +688,9 @@
   <string name="setting_display_page_show_user_avatar_title">ユーザーアバターを表示</string>
   <string name="setting_display_page_skip_crop_image_desc">画像をインポートするか写真を撮影した後、クロップ画面をスキップ</string>
   <string name="setting_display_page_skip_crop_image_title">画像編集をスキップ</string>
+  <string name="setting_display_page_manual_image_compression_desc">添付画像をクリックして解像度を調整してから送信</string>
+  <string name="setting_display_page_manual_image_compression_title">手動画像圧縮</string>
+  <string name="image_compression_header">圧縮</string>
   <string name="setting_display_page_title">表示設定</string>
   <string name="setting_display_page_tts_only_read_quoted_desc">有効にすると、TTSは引用符内のコンテンツのみを読み上げます</string>
   <string name="setting_display_page_tts_only_read_quoted_title">引用部分のみTTSで読み上げ</string>

--- a/app/src/main/res/values-ko-rKR/strings.xml
+++ b/app/src/main/res/values-ko-rKR/strings.xml
@@ -688,6 +688,9 @@
   <string name="setting_display_page_show_user_avatar_title">사용자 아바타 표시</string>
   <string name="setting_display_page_skip_crop_image_desc">이미지를 가져오거나 사진을 찍은 후 자르기 화면 건너뛰기</string>
   <string name="setting_display_page_skip_crop_image_title">이미지 편집 건너뛰기</string>
+  <string name="setting_display_page_manual_image_compression_desc">첨부 이미지를 클릭하여 해상도를 줄인 후 전송</string>
+  <string name="setting_display_page_manual_image_compression_title">수동 이미지 압축</string>
+  <string name="image_compression_header">압축</string>
   <string name="setting_display_page_title">디스플레이 설정</string>
   <string name="setting_display_page_tts_only_read_quoted_desc">활성화하면 TTS가 따옴표 안의 내용만 읽습니다</string>
   <string name="setting_display_page_tts_only_read_quoted_title">TTS가 인용 콘텐츠만 읽기</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -688,6 +688,9 @@
   <string name="setting_display_page_show_user_avatar_title">Показывать аватар пользователя</string>
   <string name="setting_display_page_skip_crop_image_desc">Пропустить обрезку после импорта изображений или съёмки</string>
   <string name="setting_display_page_skip_crop_image_title">Пропустить редактирование изображения</string>
+  <string name="setting_display_page_manual_image_compression_desc">Нажмите на изображение, чтобы уменьшить его размер перед отправкой</string>
+  <string name="setting_display_page_manual_image_compression_title">Ручное сжатие изображений</string>
+  <string name="image_compression_header">Сжать</string>
   <string name="setting_display_page_title">Настройки отображения</string>
   <string name="setting_display_page_tts_only_read_quoted_desc">Если включено, TTS читает только текст в кавычках</string>
   <string name="setting_display_page_tts_only_read_quoted_title">TTS читать только цитированный контент</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -688,6 +688,9 @@
   <string name="setting_display_page_show_user_avatar_title">顯示用戶頭像</string>
   <string name="setting_display_page_skip_crop_image_desc">匯入圖片或拍照後跳過裁剪介面</string>
   <string name="setting_display_page_skip_crop_image_title">跳過圖片編輯</string>
+  <string name="setting_display_page_manual_image_compression_desc">點擊附件中的圖片可壓縮解析度再發送</string>
+  <string name="setting_display_page_manual_image_compression_title">手動壓縮圖片</string>
+  <string name="image_compression_header">壓縮</string>
   <string name="setting_display_page_title">顯示設定</string>
   <string name="setting_display_page_tts_only_read_quoted_desc">啟用後，TTS 只會朗讀引號內的內容</string>
   <string name="setting_display_page_tts_only_read_quoted_title">僅朗讀引用的 TTS 內容</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -718,6 +718,9 @@
   <string name="setting_display_page_show_user_avatar_title">显示用户头像</string>
   <string name="setting_display_page_skip_crop_image_desc">导入图片或拍照后跳过裁剪界面</string>
   <string name="setting_display_page_skip_crop_image_title">跳过图片编辑</string>
+  <string name="setting_display_page_manual_image_compression_desc">点击附件中的图片可压缩分辨率再发送</string>
+  <string name="setting_display_page_manual_image_compression_title">手动压缩图片</string>
+  <string name="image_compression_header">压缩</string>
   <string name="setting_display_page_title">显示设置</string>
   <string name="setting_display_page_tts_only_read_quoted_desc">启用后，TTS 仅朗读引号（包括 ""、\'\'、「」、『』）内的内容</string>
   <string name="setting_display_page_tts_only_read_quoted_title">TTS仅朗读引用内容</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -724,6 +724,9 @@
   <string name="setting_display_page_show_user_avatar_title">Show User Avatar</string>
   <string name="setting_display_page_skip_crop_image_desc">Skip crop interface after importing images or taking photos</string>
   <string name="setting_display_page_skip_crop_image_title">Skip Image Editing</string>
+  <string name="setting_display_page_manual_image_compression_desc">Click the image attachment to resize and reduce size before sending</string>
+  <string name="setting_display_page_manual_image_compression_title">Manual Image Compression</string>
+  <string name="image_compression_header">Compress</string>
   <string name="setting_display_page_title">Display Settings</string>
   <string name="setting_display_page_tts_only_read_quoted_desc">When enabled, TTS will only read content within quotation marks (including "", \'\', 「」, 『』)</string>
   <string name="setting_display_page_tts_only_read_quoted_title">TTS Read Quoted Content Only</string>


### PR DESCRIPTION
## Summary

Closes #1000

图片发送前可手动压缩 — 点击输入框图片 chip，弹窗**选择预设**即可**压缩分辨率**并展示压缩百分比，可以节省存储、带宽、**input tokens**。

## Changes

1. `DisplaySetting` 新增 `manualImageCompression` 开关（默认开启）
    - 注意这**不是**破坏性变更：即使开启，也只在**点击 chip**时弹出弹窗，供压缩。
    - 格式原样保留：JPEG→JPEG@80，PNG→PNG
    - 开启该设置项时，按 chip 的 `x` 区域仍然关闭，其他区域接管开启弹窗回调。
2. 新建 `ImageInfoDialog.kt`：弹窗展示文件名/尺寸/大小；预设按钮 `1/2` `1/4` `1024`；压缩后 SnackBar 显示。
3.  `loadOptimizedBitmap` 新增精确缩放（补 `inSampleSize` 只能处理 $2^n$ 的缺口）

## Impact

以一次典型手机截屏为例，两次点击将 tokens 从 ~2.8k 降至 ~1.1k（−60%），节省流量和推理费用，不影响模型任务完成度。见下面的视频（已压缩至 1MB 以下，放心食用）

https://github.com/user-attachments/assets/212eb349-3cfd-4ce6-ba51-7adc6b2d6dfe

## Further Discussion

如有更佳的方案或想法，欢迎提出和更改。