### PR TITLE
test: fix stale upstream unit tests

### DIFF
--- a/ai/src/test/java/me/rerere/ai/provider/providers/openai/ChatCompletionsAPIMessageTest.kt
+++ b/ai/src/test/java/me/rerere/ai/provider/providers/openai/ChatCompletionsAPIMessageTest.kt
@@ -6,6 +6,7 @@ import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import me.rerere.ai.core.MessageRole
+import me.rerere.ai.provider.Modality
 import me.rerere.ai.ui.UIMessage
 import me.rerere.ai.ui.UIMessagePart
 import me.rerere.ai.util.KeyRoulette
@@ -38,10 +39,16 @@ class ChatCompletionsAPIMessageTest {
         val method = ChatCompletionsAPI::class.java.getDeclaredMethod(
             "buildMessages",
             List::class.java,
-            Boolean::class.javaPrimitiveType
+            Boolean::class.javaPrimitiveType,
+            List::class.java
         )
         method.isAccessible = true
-        return method.invoke(api, messages, includeHistoryReasoning) as JsonArray
+        return method.invoke(
+            api,
+            messages,
+            includeHistoryReasoning,
+            listOf(Modality.TEXT, Modality.IMAGE)
+        ) as JsonArray
     }
 
     @Test

--- a/highlight/build.gradle.kts
+++ b/highlight/build.gradle.kts
@@ -42,4 +42,5 @@ dependencies {
     api(libs.quickjs)
     implementation(libs.kotlinx.serialization.json)
     implementation(libs.kotlinx.coroutines.core)
+    testImplementation(libs.junit)
 }

--- a/material3/build.gradle.kts
+++ b/material3/build.gradle.kts
@@ -30,4 +30,5 @@ android {
 dependencies {
     implementation(platform(libs.androidx.compose.bom))
     implementation(libs.androidx.material3)
+    testImplementation(libs.junit)
 }

--- a/search/build.gradle.kts
+++ b/search/build.gradle.kts
@@ -56,4 +56,5 @@ dependencies {
     implementation(libs.androidx.material3)
     api(libs.jsoup)
     implementation(libs.quickjs)
+    testImplementation(libs.junit)
 }

--- a/speech/src/test/java/me/rerere/tts/provider/TTSProviderSettingElevenLabsTest.kt
+++ b/speech/src/test/java/me/rerere/tts/provider/TTSProviderSettingElevenLabsTest.kt
@@ -16,7 +16,7 @@ class TTSProviderSettingElevenLabsTest {
             name = "Test ElevenLabs",
             apiKey = "test-key",
             baseUrl = "https://api.elevenlabs.io",
-            model = "eleven_multilingual_v2",
+            model = "eleven_v3",
             voiceId = "test-voice-id",
             stability = 0.5f,
             similarityBoost = 0.75f,
@@ -25,7 +25,7 @@ class TTSProviderSettingElevenLabsTest {
         val encoded = json.encodeToString(TTSProviderSetting.serializer(), setting)
         assertTrue(encoded.contains("\"elevenlabs\""))
         assertTrue(encoded.contains("\"test-key\""))
-        assertTrue(encoded.contains("\"eleven_multilingual_v2\""))
+        assertTrue(encoded.contains("\"eleven_v3\""))
 
         val decoded = json.decodeFromString(
             TTSProviderSetting.serializer(),

--- a/speech/src/test/java/me/rerere/tts/provider/TTSProviderSettingFishAudioTest.kt
+++ b/speech/src/test/java/me/rerere/tts/provider/TTSProviderSettingFishAudioTest.kt
@@ -16,7 +16,7 @@ class TTSProviderSettingFishAudioTest {
             name = "Test Fish Audio",
             apiKey = "test-key",
             baseUrl = "https://api.fish.audio",
-            model = "s2.1-pro",
+            model = "s2.1-pro-free",
             referenceId = "test-voice-id",
             temperature = 0.7f,
             speed = 1.0f,
@@ -25,7 +25,7 @@ class TTSProviderSettingFishAudioTest {
         val encoded = json.encodeToString(TTSProviderSetting.serializer(), setting)
         assertTrue(encoded.contains("\"fish-audio\""))
         assertTrue(encoded.contains("\"test-key\""))
-        assertTrue(encoded.contains("\"s2.1-pro\""))
+        assertTrue(encoded.contains("\"s2.1-pro-free\""))
 
         val decoded = json.decodeFromString(
             TTSProviderSetting.serializer(),

--- a/speech/src/test/java/me/rerere/tts/provider/TTSProviderSettingMiMoTest.kt
+++ b/speech/src/test/java/me/rerere/tts/provider/TTSProviderSettingMiMoTest.kt
@@ -11,7 +11,7 @@ class TTSProviderSettingMiMoTest {
 
         assertEquals("MiMo TTS", setting.name)
         assertEquals("https://api.xiaomimimo.com/v1", setting.baseUrl)
-        assertEquals("mimo-v2-tts", setting.model)
+        assertEquals("mimo-v2.5-tts", setting.model)
         assertEquals("mimo_default", setting.voice)
         assertEquals("", setting.apiKey)
     }


### PR DESCRIPTION
## Summary
- use non-default model values in TTS serialization tests whose defaults are omitted by Kotlin serialization
- update stale MiMo default-model and OpenAI message helper test expectations
- add missing JUnit local-test dependencies for Android modules that have local unit tests

## Tests
- ./gradlew :speech:testDebugUnitTest --tests "*TTSProviderSettingElevenLabsTest.testElevenLabsSerialization"
- ./gradlew :speech:testDebugUnitTest --tests "*TTSProviderSettingElevenLabsTest.testElevenLabsSerialization" --tests "*TTSProviderSettingFishAudioTest.testFishAudioSerialization" --tests "*TTSProviderSettingMiMoTest.*"
- ./gradlew :highlight:testDebugUnitTest :material3:testDebugUnitTest
- ./gradlew :search:testDebugUnitTest :ai:testDebugUnitTest --tests "*ChatCompletionsAPIMessageTest"

## Note
- ./gradlew test still fails in existing app tests unrelated to this branch: ShareSheetTest, TimeReminderTransformerTest, and ChatServiceTest.