### PR TITLE
feat: 支持为助手自定义聊天输入框提示

### DIFF
--- a/app/src/main/java/me/rerere/rikkahub/data/model/Assistant.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/model/Assistant.kt
@@ -48,6 +48,8 @@ data class Assistant(
     val enableTimeReminder: Boolean = false,            // 时间间隔提醒注入
     val allowConversationSystemPrompt: Boolean = false, // 允许对话单独重写 system prompt
     val allowConversationPromptInjection: Boolean = false, // 允许对话单独绑定提示词注入
+    val enableCustomInputPlaceholder: Boolean = false, // 是否启用自定义聊天输入框占位符
+    val inputPlaceholder: String = "", // 自定义聊天输入框占位符文本
 )
 
 @Serializable
@@ -91,6 +93,21 @@ private fun compileRegexCached(pattern: String): Regex? {
     val result = runCatching { Regex(pattern) }.onFailure { it.printStackTrace() }
     regexCache.put(pattern, result)
     return result.getOrNull()
+}
+
+/**
+ * 解析当前助手生效的聊天输入框占位符文本。
+ *
+ * - 主开关关闭时，始终返回 [defaultPlaceholder]，忽略已保存的自定义文本。
+ * - 主开关开启且已保存文本为空字符串时，回退为 [defaultPlaceholder]。
+ * - 主开关开启且已保存文本非空（包括仅由空格组成的文本）时，原样返回已保存文本，
+ *   不进行 trim/blank 判断，以支持用户输入空格制造“看起来为空”的占位符效果。
+ *
+ * 返回值始终非空，可直接传入 Compose 的 [androidx.compose.material3.Text] 等非空参数。
+ */
+fun Assistant.resolveInputPlaceholder(defaultPlaceholder: String): String {
+    if (!enableCustomInputPlaceholder) return defaultPlaceholder
+    return inputPlaceholder.ifEmpty { defaultPlaceholder }
 }
 
 fun String.replaceRegexes(

--- a/app/src/main/java/me/rerere/rikkahub/ui/components/ai/ChatInput.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/ai/ChatInput.kt
@@ -98,10 +98,12 @@ import me.rerere.rikkahub.data.datastore.getQuickMessagesOfAssistant
 import me.rerere.rikkahub.data.files.FilesManager
 import me.rerere.rikkahub.data.model.Assistant
 import me.rerere.rikkahub.data.model.QuickMessage
+import me.rerere.rikkahub.data.model.resolveInputPlaceholder
 import me.rerere.rikkahub.ui.components.ai.completion.ChatCompletionContext
 import me.rerere.rikkahub.ui.components.ai.completion.ChatCompletionItem
 import me.rerere.rikkahub.ui.components.ai.completion.ChatCompletionList
 import me.rerere.rikkahub.ui.components.ai.completion.ChatCompletionProvider
+import me.rerere.rikkahub.ui.components.richtext.MarkdownBlock
 import me.rerere.rikkahub.ui.components.ui.KeepScreenOn
 import me.rerere.rikkahub.ui.components.ui.permission.PermissionManager
 import me.rerere.rikkahub.ui.components.ui.permission.PermissionRecordAudio
@@ -134,6 +136,8 @@ fun ChatInput(
 ) {
     val toaster = LocalToaster.current
     val assistant = settings.getCurrentAssistant()
+    val defaultInputPlaceholder = stringResource(R.string.chat_input_placeholder)
+    val inputPlaceholder = assistant.resolveInputPlaceholder(defaultInputPlaceholder)
     val hazeTintColor = MaterialTheme.colorScheme.surfaceContainerLow
     val inputHazeStyle = HazeMaterials.thin(containerColor = hazeTintColor)
 
@@ -235,6 +239,7 @@ fun ChatInput(
                     TextInputRow(
                         state = state,
                         completionProviders = completionProviders,
+                        inputPlaceholder = inputPlaceholder,
                         onSendMessage = { sendMessage() }
                     )
 
@@ -419,6 +424,7 @@ private fun ActionIconButton(
 private fun TextInputRow(
     state: ChatInputState,
     completionProviders: List<ChatCompletionProvider>,
+    inputPlaceholder: String,
     onSendMessage: () -> Unit,
 ) {
     val settings = LocalSettings.current
@@ -554,7 +560,7 @@ private fun TextInputRow(
                 },
             shape = MaterialTheme.shapes.largeIncreased,
             placeholder = {
-                Text(stringResource(R.string.chat_input_placeholder))
+                MarkdownBlock(content = inputPlaceholder)
             },
             lineLimits = TextFieldLineLimits.MultiLine(maxHeightInLines = 5),
             keyboardOptions = KeyboardOptions(
@@ -588,7 +594,7 @@ private fun TextInputRow(
             } else null,
         )
         if (isFullScreen) {
-            FullScreenEditor(state = state) {
+            FullScreenEditor(state = state, inputPlaceholder = inputPlaceholder) {
                 isFullScreen = false
             }
         }
@@ -726,7 +732,7 @@ private fun QuickMessageButton(
 
 @Composable
 private fun FullScreenEditor(
-    state: ChatInputState, onDone: () -> Unit
+    state: ChatInputState, inputPlaceholder: String, onDone: () -> Unit
 ) {
     BasicAlertDialog(
         onDismissRequest = {
@@ -771,7 +777,7 @@ private fun FullScreenEditor(
                             .fillMaxSize(),
                         shape = RoundedCornerShape(32.dp),
                         placeholder = {
-                            Text(stringResource(R.string.chat_input_placeholder))
+                            MarkdownBlock(content = inputPlaceholder)
                         },
                         colors = TextFieldDefaults.colors().copy(
                             unfocusedIndicatorColor = Color.Transparent,

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/assistant/detail/AssistantBasicPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/assistant/detail/AssistantBasicPage.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Card
@@ -30,8 +31,10 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -106,6 +109,8 @@ internal fun AssistantBasicContent(
     onUpdate: (Assistant) -> Unit,
     vm: AssistantDetailVM
 ) {
+    val focusManager = LocalFocusManager.current
+
     Column(
         modifier = Modifier
             .fillMaxSize()
@@ -230,6 +235,52 @@ internal fun AssistantBasicContent(
                     )
                 }
             )
+
+            HorizontalDivider()
+
+            FormItem(
+                modifier = Modifier.padding(8.dp),
+                label = {
+                    Text(stringResource(R.string.assistant_page_custom_input_placeholder))
+                },
+                description = {
+                    Text(stringResource(R.string.assistant_page_custom_input_placeholder_desc))
+                },
+                tail = {
+                    Switch(
+                        checked = assistant.enableCustomInputPlaceholder,
+                        onCheckedChange = {
+                            onUpdate(
+                                assistant.copy(
+                                    enableCustomInputPlaceholder = it
+                                )
+                            )
+                        }
+                    )
+                }
+            ) {
+                if (assistant.enableCustomInputPlaceholder) {
+                    OutlinedTextField(
+                        value = assistant.inputPlaceholder,
+                        onValueChange = { placeholder ->
+                            onUpdate(
+                                assistant.copy(
+                                    inputPlaceholder = placeholder
+                                )
+                            )
+                        },
+                        modifier = Modifier.fillMaxWidth(),
+                        placeholder = {
+                            Text(stringResource(R.string.chat_input_placeholder))
+                        },
+                        keyboardActions = KeyboardActions(
+                            onDone = { focusManager.clearFocus() },
+                        ),
+                        keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+                        singleLine = true,
+                    )
+                }
+            }
         }
 
         Card(

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -71,6 +71,8 @@
   <string name="assistant_page_current_assistant">現在のアシスタント</string>
   <string name="assistant_page_custom_bodies">カスタムボディ</string>
   <string name="assistant_page_custom_headers">カスタムヘッダー</string>
+  <string name="assistant_page_custom_input_placeholder">入力欄のヒントをカスタマイズ</string>
+  <string name="assistant_page_custom_input_placeholder_desc">入力欄に表示するヒントをカスタマイズします</string>
   <string name="assistant_page_default_assistant">デフォルトアシスタント</string>
   <string name="assistant_page_delete">削除</string>
   <string name="assistant_page_delete_body">ボディを削除</string>

--- a/app/src/main/res/values-ko-rKR/strings.xml
+++ b/app/src/main/res/values-ko-rKR/strings.xml
@@ -71,6 +71,8 @@
   <string name="assistant_page_current_assistant">현재 어시스턴트</string>
   <string name="assistant_page_custom_bodies">사용자 정의 본문</string>
   <string name="assistant_page_custom_headers">사용자 정의 헤더</string>
+  <string name="assistant_page_custom_input_placeholder">입력창 안내 문구 사용자 지정</string>
+  <string name="assistant_page_custom_input_placeholder_desc">입력창에 표시할 안내 문구를 사용자 지정합니다</string>
   <string name="assistant_page_default_assistant">기본 어시스턴트</string>
   <string name="assistant_page_delete">삭제</string>
   <string name="assistant_page_delete_body">본문 삭제</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -71,6 +71,8 @@
   <string name="assistant_page_current_assistant">Текущий ассистент</string>
   <string name="assistant_page_custom_bodies">Пользовательский контекст</string>
   <string name="assistant_page_custom_headers">Пользовательские заголовки</string>
+  <string name="assistant_page_custom_input_placeholder">Настроить подсказку в поле ввода</string>
+  <string name="assistant_page_custom_input_placeholder_desc">Настройте подсказку, отображаемую в поле ввода</string>
   <string name="assistant_page_default_assistant">Ассистент по умолчанию</string>
   <string name="assistant_page_delete">Удалить</string>
   <string name="assistant_page_delete_body">Удалить текст</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -71,6 +71,8 @@
   <string name="assistant_page_current_assistant">當前助手</string>
   <string name="assistant_page_custom_bodies">自定義 Body</string>
   <string name="assistant_page_custom_headers">自定義 Headers</string>
+  <string name="assistant_page_custom_input_placeholder">自訂輸入框提示</string>
+  <string name="assistant_page_custom_input_placeholder_desc">自訂輸入框中的提示</string>
   <string name="assistant_page_default_assistant">預設助手</string>
   <string name="assistant_page_delete">刪除</string>
   <string name="assistant_page_delete_body">刪除 Body</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -71,6 +71,8 @@
   <string name="assistant_page_current_assistant">当前助手</string>
   <string name="assistant_page_custom_bodies">自定义 Body</string>
   <string name="assistant_page_custom_headers">自定义 Headers</string>
+  <string name="assistant_page_custom_input_placeholder">自定义输入框提示</string>
+  <string name="assistant_page_custom_input_placeholder_desc">自定义输入框中的提示</string>
   <string name="assistant_page_default_assistant">默认助手</string>
   <string name="assistant_page_delete">删除</string>
   <string name="assistant_page_delete_body">删除 Body</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -71,6 +71,8 @@
   <string name="assistant_page_current_assistant">Current Assistant</string>
   <string name="assistant_page_custom_bodies">Custom Body</string>
   <string name="assistant_page_custom_headers">Custom Headers</string>
+  <string name="assistant_page_custom_input_placeholder">Custom Input Prompt</string>
+  <string name="assistant_page_custom_input_placeholder_desc">Customize the prompt shown in the input field</string>
   <string name="assistant_page_default_assistant">Default Assistant</string>
   <string name="assistant_page_delete">Delete</string>
   <string name="assistant_page_delete_body">Delete Body</string>

--- a/app/src/test/java/me/rerere/rikkahub/data/model/AssistantInputPlaceholderTest.kt
+++ b/app/src/test/java/me/rerere/rikkahub/data/model/AssistantInputPlaceholderTest.kt
@@ -1,0 +1,45 @@
+package me.rerere.rikkahub.data.model
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class AssistantInputPlaceholderTest {
+
+    private val defaultPlaceholder = "Type a message"
+
+    @Test
+    fun `disabled custom placeholder falls back to default regardless of saved text`() {
+        val assistant = Assistant(
+            enableCustomInputPlaceholder = false,
+            inputPlaceholder = "custom text",
+        )
+        assertEquals(defaultPlaceholder, assistant.resolveInputPlaceholder(defaultPlaceholder))
+    }
+
+    @Test
+    fun `enabled custom placeholder with normal text returns saved text`() {
+        val assistant = Assistant(
+            enableCustomInputPlaceholder = true,
+            inputPlaceholder = "custom text",
+        )
+        assertEquals("custom text", assistant.resolveInputPlaceholder(defaultPlaceholder))
+    }
+
+    @Test
+    fun `enabled custom placeholder with empty string falls back to default`() {
+        val assistant = Assistant(
+            enableCustomInputPlaceholder = true,
+            inputPlaceholder = "",
+        )
+        assertEquals(defaultPlaceholder, assistant.resolveInputPlaceholder(defaultPlaceholder))
+    }
+
+    @Test
+    fun `enabled custom placeholder with three spaces preserves whitespace exactly`() {
+        val assistant = Assistant(
+            enableCustomInputPlaceholder = true,
+            inputPlaceholder = "   ",
+        )
+        assertEquals("   ", assistant.resolveInputPlaceholder(defaultPlaceholder))
+    }
+}


### PR DESCRIPTION
## 功能说明

- 为每个助手增加“自定义输入框提示”开关和单行编辑框
- 开关关闭时使用本地化默认提示；开启后，空字符串仍回退默认提示
- 纯空格内容会原样保留，允许用户有意隐藏输入框提示
- 普通聊天输入框与全屏编辑器共用同一套提示解析逻辑
- 自定义提示支持 Markdown 显示
- 设置输入框按下键盘“完成”后会清除焦点
- 补充现有六套 Android 本地化资源及解析逻辑单元测试

## 范围

本 PR 仅修改 Android App 中的助手配置与聊天输入框，不包含 Web UI 助手设置或 Web 输入框改动。

## 验证

- `AssistantInputPlaceholderTest`：通过
- `:app:assembleDebug`：通过
- Fork GitHub Actions：https://github.com/c45v3/rikkahub/actions/runs/29316188269
- `git diff --check`：通过
