### PR TITLE
fix: 本地备份不再沿用 WebDAV 备份项设置

### DIFF
--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/backup/BackupVM.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/backup/BackupVM.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import me.rerere.rikkahub.data.datastore.Settings
 import me.rerere.rikkahub.data.datastore.SettingsStore
+import me.rerere.rikkahub.data.datastore.WebDavConfig
 import me.rerere.rikkahub.data.repository.ConversationRepository
 import me.rerere.rikkahub.data.sync.importer.ChatboxImporter
 import me.rerere.rikkahub.data.sync.importer.CherryStudioProviderImporter
@@ -82,13 +83,18 @@ class BackupVM(
     }
 
     suspend fun exportToFile(): File {
-        val file = webDavSync.prepareBackupFile(settings.value.webDavConfig.copy())
+        val file = webDavSync.prepareBackupFile(
+            settings.value.webDavConfig.copy(items = WebDavConfig.BackupItem.entries)
+        )
         recordBackupTime()
         return file
     }
 
     suspend fun restoreFromLocalFile(file: File) {
-        webDavSync.restoreFromLocalFile(file, settings.value.webDavConfig)
+        webDavSync.restoreFromLocalFile(
+            file,
+            settings.value.webDavConfig.copy(items = WebDavConfig.BackupItem.entries),
+        )
     }
 
     suspend fun restoreFromChatBox(file: File): ChatboxRestoreResult {


### PR DESCRIPTION
## 问题

本地 ZIP 导出和恢复直接复用了 `webDavConfig`，包括 WebDAV 中选择的备份项目。如果 WebDAV 备份未勾选 `FILES`，本地 ZIP 导出和恢复也会跳过上传文件，导致恢复后的图片无法显示。

## 修复

本地 ZIP 导出和恢复时始终使用全部备份项目。WebDAV 备份仍然遵循用户在 WebDAV 设置中选择的项目，不受影响。

## 检查

- 已通过 `git diff --check`
- 未完成完整编译：上游 Gradle 配置在本地尝试下载额外的 Java toolchain