### PR TITLE
fix: 使用消息创建时间渲染模板时间变量

### DIFF
--- a/app/src/main/java/me/rerere/rikkahub/data/ai/transformers/MessageTimeVariables.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/ai/transformers/MessageTimeVariables.kt
@@ -1,0 +1,20 @@
+package me.rerere.rikkahub.data.ai.transformers
+
+import kotlinx.datetime.toJavaLocalDateTime
+import me.rerere.ai.ui.UIMessage
+import java.time.format.DateTimeFormatter
+import java.time.format.FormatStyle
+import java.util.Locale
+
+internal data class MessageTimeVariables(
+    val date: String,
+    val time: String,
+)
+
+internal fun UIMessage.timeVariables(locale: Locale = Locale.getDefault()): MessageTimeVariables {
+    val value = createdAt.toJavaLocalDateTime()
+    return MessageTimeVariables(
+        date = DateTimeFormatter.ofLocalizedDate(FormatStyle.MEDIUM).withLocale(locale).format(value),
+        time = DateTimeFormatter.ofLocalizedTime(FormatStyle.MEDIUM).withLocale(locale).format(value),
+    )
+}

--- a/app/src/main/java/me/rerere/rikkahub/data/ai/transformers/TemplateTransformer.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/ai/transformers/TemplateTransformer.kt
@@ -5,12 +5,9 @@ import io.pebbletemplates.pebble.loader.Loader
 import me.rerere.ai.ui.UIMessage
 import me.rerere.ai.ui.UIMessagePart
 import me.rerere.rikkahub.data.datastore.SettingsStore
-import me.rerere.rikkahub.utils.toLocalDate
-import me.rerere.rikkahub.utils.toLocalTime
 import java.io.Reader
 import java.io.StringReader
 import java.io.StringWriter
-import java.time.Instant
 
 class TemplateTransformer(
     private val engine: PebbleEngine,
@@ -27,12 +24,13 @@ class TemplateTransformer(
                     when (part) {
                         is UIMessagePart.Text -> {
                             val result = StringWriter()
+                            val timeVariables = message.timeVariables()
                             template.evaluate(
                                 result, mapOf(
                                     "message" to part.text,
                                     "role" to message.role.name.lowercase(),
-                                    "time" to Instant.now().toLocalTime(),
-                                    "date" to Instant.now().toLocalDate(),
+                                    "time" to timeVariables.time,
+                                    "date" to timeVariables.date,
                                 )
                             )
                             part.copy(

--- a/app/src/test/java/me/rerere/rikkahub/data/ai/transformers/MessageTimeVariablesTest.kt
+++ b/app/src/test/java/me/rerere/rikkahub/data/ai/transformers/MessageTimeVariablesTest.kt
@@ -1,0 +1,25 @@
+package me.rerere.rikkahub.data.ai.transformers
+
+import kotlinx.datetime.LocalDateTime
+import me.rerere.ai.core.MessageRole
+import me.rerere.ai.ui.UIMessage
+import me.rerere.ai.ui.UIMessagePart
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.util.Locale
+
+class MessageTimeVariablesTest {
+    @Test
+    fun `time variables come from message creation time`() {
+        val message = UIMessage(
+            role = MessageRole.USER,
+            parts = listOf(UIMessagePart.Text("hello")),
+            createdAt = LocalDateTime(2026, 7, 24, 9, 30, 15),
+        )
+
+        val variables = message.timeVariables(Locale.US)
+
+        assertEquals("Jul 24, 2026", variables.date)
+        assertEquals("9:30:15\u202fAM", variables.time)
+    }
+}


### PR DESCRIPTION
## 问题

消息模板中的 `{{message}}`、`{{role}}`、`{{date}}` 和 `{{time}}` 都是当前消息的属性。按照这一设计语义，`date/time` 应表示对应消息的创建时间。

但 `TemplateTransformer` 当前通过 `Instant.now()` 生成 `date/time`，实际得到的是**本次请求构建时间**。因此同一条历史消息在不同请求中会显示不同的日期和时间，没有实现消息模板变量应有的语义。

历史消息内容随请求时间变化、进而影响 Context Cache，是这一语义错误带来的结果，而不是本次修复的首要定义。

## 修改

- 使用每条 `UIMessage` 已有的 `createdAt` 渲染 `date/time`
- 保持现有本地化的 MEDIUM 日期和时间格式
- 增加回归测试，确认模板时间来自消息创建时间

本 PR 不修改 `PlaceholderTransformer` 的语义，也不处理请求时动态环境变量；相关设计讨论继续放在 #1562。

## 行为变化

修复前，同一条消息的模板时间取决于请求何时构建：

```text
message A + request time → date/time
```

修复后，模板时间由消息自身决定：

```text
message A.createdAt → date/time
```

因此历史消息能够稳定地表达其实际创建时间。Context Cache 不再因为这些消息时间被重复计算而失效，是修复后的附带收益。

## 验证

- `./gradlew :app:testDebugUnitTest --tests me.rerere.rikkahub.data.ai.transformers.MessageTimeVariablesTest`
- `./gradlew :app:assembleDebug`
- `git diff --check`

以上检查均通过。