### PR TITLE
fix: use_skill 无法读取展示名称与目录名不同的 Skill

### DIFF
--- a/app/src/main/java/me/rerere/rikkahub/data/ai/tools/SkillsTools.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/ai/tools/SkillsTools.kt
@@ -7,13 +7,13 @@ import kotlinx.serialization.json.put
 import me.rerere.ai.core.InputSchema
 import me.rerere.ai.core.Tool
 import me.rerere.ai.ui.UIMessagePart
-import me.rerere.rikkahub.data.files.SkillManager
+import me.rerere.rikkahub.data.files.SkillFrontmatterParser
 import me.rerere.rikkahub.data.files.SkillMetadata
+import me.rerere.rikkahub.data.files.SkillPaths
 
 fun createSkillTools(
     enabledSkills: Set<String>,
     allSkills: List<SkillMetadata>,
-    skillManager: SkillManager,
 ): List<Tool> {
     val available = allSkills.filter { it.name in enabledSkills }
     if (available.isEmpty()) return emptyList()
@@ -61,15 +61,14 @@ fun createSkillTools(
             execute = {
                 val name = it.jsonObject["name"]?.jsonPrimitive?.content
                     ?: error("name is required")
-                if (name !in enabledSkills) {
-                    error("Skill '$name' is not available. Available skills: ${enabledSkills.joinToString()}")
-                }
+                val skill = available.firstOrNull { skill -> skill.name == name }
+                    ?: error("Skill '$name' is not available. Available skills: ${available.joinToString { it.name }}")
                 val path = it.jsonObject["path"]?.jsonPrimitive?.content
                 val content = if (path.isNullOrBlank()) {
-                    skillManager.readSkillBody(name)
-                        ?: error("Skill '$name' not found")
+                    require(skill.skillFile.exists()) { "Skill '$name' not found" }
+                    SkillFrontmatterParser.extractBody(skill.skillFile.readText())
                 } else {
-                    val target = skillManager.resolveSkillFile(name, path)
+                    val target = SkillPaths.resolveSkillFile(skill.skillDir, path)
                         ?: error("Path '$path' is outside the skill directory")
                     require(target.exists()) { "File '$path' not found in skill '$name'" }
                     target.readText()

--- a/app/src/main/java/me/rerere/rikkahub/service/ChatService.kt
+++ b/app/src/main/java/me/rerere/rikkahub/service/ChatService.kt
@@ -543,7 +543,6 @@ class ChatService(
                             createSkillTools(
                                 enabledSkills = assistant.enabledSkills,
                                 allSkills = skillManager.listSkills(),
-                                skillManager = skillManager,
                             )
                         )
                     }

--- a/app/src/test/java/me/rerere/rikkahub/data/ai/tools/SkillsToolsTest.kt
+++ b/app/src/test/java/me/rerere/rikkahub/data/ai/tools/SkillsToolsTest.kt
@@ -1,0 +1,48 @@
+package me.rerere.rikkahub.data.ai.tools
+
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import me.rerere.ai.ui.UIMessagePart
+import me.rerere.rikkahub.data.files.SkillMetadata
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+class SkillsToolsTest {
+    @get:Rule
+    val tempFolder = TemporaryFolder()
+
+    @Test
+    fun `use_skill reads metadata directory when display name differs`() = runBlocking {
+        val skillDir = tempFolder.newFolder("directory-name")
+        skillDir.resolve("SKILL.md").writeText(
+            """
+                ---
+                name: Display Name
+                description: Test skill
+                ---
+                Skill instructions
+            """.trimIndent()
+        )
+        val tool = createSkillTools(
+            enabledSkills = setOf("Display Name"),
+            allSkills = listOf(
+                SkillMetadata(
+                    name = "Display Name",
+                    description = "Test skill",
+                    skillDir = skillDir,
+                )
+            ),
+        ).single()
+
+        val result = tool.execute(
+            buildJsonObject {
+                put("name", "Display Name")
+            }
+        )
+
+        assertEquals("Skill instructions", (result.single() as UIMessagePart.Text).text)
+    }
+}


### PR DESCRIPTION
## 问题

Skill 扫描阶段已经将 frontmatter 中的展示名称与实际目录记录在 `SkillMetadata` 中：

```text
name: Rikkahub Workspace
skillDir: /skills/rikkahub-workspace
```

但 `use_skill` 执行时丢弃了这个解析结果，再次将展示名称作为目录名交给 `SkillManager` 查找，最终尝试读取：

```text
/skills/Rikkahub Workspace/SKILL.md
```

因此，只要 frontmatter `name` 与目录名不同，扩展管理页面可以正常识别和启用 Skill，但 AI 调用 `use_skill` 时会报 `Skill not found`。

## 修改

- 从已经筛选出的 `SkillMetadata` 中取得目标 Skill
- 使用 `skillFile` 读取默认 `SKILL.md`
- 使用 `skillDir` 和 `SkillPaths.resolveSkillFile` 读取 Skill 内的关联文件
- 移除 `createSkillTools` 不再需要的 `SkillManager` 参数
- 增加目录名与展示名称不同的回归测试

## 影响

Skill 的 frontmatter 名称只负责展示和工具选择，实际文件读取始终使用扫描阶段记录的真实目录。目录名不再需要与 frontmatter `name` 完全一致。

## 验证

- `./gradlew :app:testDebugUnitTest --tests me.rerere.rikkahub.data.ai.tools.SkillsToolsTest :app:assembleDebug --no-configuration-cache --console=plain`
- `git diff --check`

以上检查均通过。

Fixes #1563