### PR TITLE
[codex] Keep chat generation alive in background

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -10,6 +10,7 @@
   <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
   <uses-permission android:name="android.permission.CHANGE_WIFI_MULTICAST_STATE" />
   <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+  <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
   <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE" />
   <uses-permission android:name="android.permission.ACCESS_LOCAL_NETWORK" />
   <uses-permission
@@ -125,6 +126,10 @@
       android:name="com.yalantis.ucrop.UCropActivity"
       android:theme="@style/Theme.AppCompat.Light.NoActionBar" />
 
+    <service
+      android:name=".service.ChatGenerationService"
+      android:exported="false"
+      android:foregroundServiceType="dataSync" />
     <service
       android:name=".service.WebServerService"
       android:exported="false"

--- a/app/src/main/java/me/rerere/rikkahub/RikkaHubApp.kt
+++ b/app/src/main/java/me/rerere/rikkahub/RikkaHubApp.kt
@@ -45,6 +45,7 @@ private const val TAG = "RikkaHubApp"
 
 const val CHAT_COMPLETED_NOTIFICATION_CHANNEL_ID = "chat_completed"
 const val CHAT_LIVE_UPDATE_NOTIFICATION_CHANNEL_ID = "chat_live_update"
+const val CHAT_GENERATION_NOTIFICATION_ID = 1001
 const val WEB_SERVER_NOTIFICATION_CHANNEL_ID = "web_server"
 
 class RikkaHubApp : Application() {

--- a/app/src/main/java/me/rerere/rikkahub/service/ChatGenerationService.kt
+++ b/app/src/main/java/me/rerere/rikkahub/service/ChatGenerationService.kt
@@ -1,0 +1,102 @@
+package me.rerere.rikkahub.service
+
+import android.app.PendingIntent
+import android.app.Service
+import android.content.Context
+import android.content.Intent
+import android.content.pm.ServiceInfo
+import android.os.Build
+import android.os.IBinder
+import android.util.Log
+import androidx.core.app.NotificationCompat
+import androidx.core.app.ServiceCompat
+import androidx.core.content.ContextCompat
+import me.rerere.rikkahub.CHAT_GENERATION_NOTIFICATION_ID
+import me.rerere.rikkahub.CHAT_LIVE_UPDATE_NOTIFICATION_CHANNEL_ID
+import me.rerere.rikkahub.R
+import me.rerere.rikkahub.RouteActivity
+
+private const val TAG = "ChatGenerationService"
+
+class ChatGenerationService : Service() {
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        val conversationId = intent?.getStringExtra(EXTRA_CONVERSATION_ID) ?: return START_NOT_STICKY
+        val senderName = intent.getStringExtra(EXTRA_SENDER_NAME).orEmpty()
+        if (!startForegroundCompat(conversationId, senderName)) {
+            stopSelfResult(startId)
+        }
+
+        return START_NOT_STICKY
+    }
+
+    private fun startForegroundCompat(conversationId: String, senderName: String): Boolean {
+        return try {
+            val notification = NotificationCompat.Builder(this, CHAT_LIVE_UPDATE_NOTIFICATION_CHANNEL_ID)
+                .setSmallIcon(R.drawable.small_icon)
+                .setContentTitle(getString(R.string.notification_live_update_title))
+                .setContentText(senderName)
+                .setContentIntent(buildChatPendingIntent(conversationId))
+                .setCategory(NotificationCompat.CATEGORY_PROGRESS)
+                .setOngoing(true)
+                .setOnlyAlertOnce(true)
+                .build()
+
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+                ServiceCompat.startForeground(
+                    this,
+                    CHAT_GENERATION_NOTIFICATION_ID,
+                    notification,
+                    ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC,
+                )
+            } else {
+                startForeground(CHAT_GENERATION_NOTIFICATION_ID, notification)
+            }
+            true
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to start chat generation foreground service", e)
+            false
+        }
+    }
+
+    private fun buildChatPendingIntent(conversationId: String): PendingIntent {
+        val intent = Intent(this, RouteActivity::class.java).apply {
+            flags = Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP
+            putExtra(EXTRA_CONVERSATION_ID, conversationId)
+        }
+        return PendingIntent.getActivity(
+            this,
+            conversationId.hashCode(),
+            intent,
+            PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT,
+        )
+    }
+
+    companion object {
+        private const val EXTRA_CONVERSATION_ID = "conversationId"
+        private const val EXTRA_SENDER_NAME = "senderName"
+
+        fun start(context: Context, conversationId: String, senderName: String) {
+            runCatching {
+                ContextCompat.startForegroundService(
+                    context,
+                    Intent(context, ChatGenerationService::class.java).apply {
+                        putExtra(EXTRA_CONVERSATION_ID, conversationId)
+                        putExtra(EXTRA_SENDER_NAME, senderName)
+                    },
+                )
+            }.onFailure {
+                Log.e(TAG, "Unable to request chat generation foreground service", it)
+            }
+        }
+
+        fun stop(context: Context) {
+            runCatching {
+                context.stopService(Intent(context, ChatGenerationService::class.java))
+            }.onFailure {
+                Log.e(TAG, "Unable to stop the chat generation foreground service", it)
+            }
+        }
+    }
+}

--- a/app/src/main/java/me/rerere/rikkahub/service/ChatNotificationManager.kt
+++ b/app/src/main/java/me/rerere/rikkahub/service/ChatNotificationManager.kt
@@ -16,13 +16,13 @@ import me.rerere.ai.ui.UIMessage
 import me.rerere.ai.ui.UIMessagePart
 import me.rerere.rikkahub.AppScope
 import me.rerere.rikkahub.CHAT_COMPLETED_NOTIFICATION_CHANNEL_ID
+import me.rerere.rikkahub.CHAT_GENERATION_NOTIFICATION_ID
 import me.rerere.rikkahub.CHAT_LIVE_UPDATE_NOTIFICATION_CHANNEL_ID
 import me.rerere.rikkahub.R
 import me.rerere.rikkahub.RouteActivity
 import me.rerere.rikkahub.data.datastore.SettingsStore
 import me.rerere.rikkahub.data.event.AppEvent
 import me.rerere.rikkahub.data.event.AppEventBus
-import me.rerere.rikkahub.utils.cancelNotification
 import me.rerere.rikkahub.utils.sendNotification
 import java.util.concurrent.ConcurrentHashMap
 import kotlin.uuid.Uuid
@@ -83,7 +83,7 @@ class ChatNotificationManager(
     }
 
     private fun handleGenerationEnded(event: AppEvent.ChatGenerationEnded) {
-        cancelLiveUpdateNotification(event.conversationId)
+        liveUpdateLastSentAt.remove(event.conversationId)
 
         val contentPreview = event.contentPreview ?: return
         if (isForeground.value) return
@@ -109,10 +109,6 @@ class ChatNotificationManager(
         }
     }
 
-    private fun getLiveUpdateNotificationId(conversationId: Uuid): Int {
-        return conversationId.hashCode() + 10000
-    }
-
     private fun sendLiveUpdateNotification(
         conversationId: Uuid,
         lastMessage: UIMessage,
@@ -123,7 +119,7 @@ class ChatNotificationManager(
 
         context.sendNotification(
             channelId = CHAT_LIVE_UPDATE_NOTIFICATION_CHANNEL_ID,
-            notificationId = getLiveUpdateNotificationId(conversationId)
+            notificationId = CHAT_GENERATION_NOTIFICATION_ID
         ) {
             title = senderName
             content = contentText
@@ -179,11 +175,6 @@ class ChatNotificationManager(
                 )
             }
         }
-    }
-
-    private fun cancelLiveUpdateNotification(conversationId: Uuid) {
-        liveUpdateLastSentAt.remove(conversationId)
-        context.cancelNotification(getLiveUpdateNotificationId(conversationId))
     }
 
     private fun getPendingIntent(context: Context, conversationId: Uuid): PendingIntent {

--- a/app/src/main/java/me/rerere/rikkahub/service/ChatService.kt
+++ b/app/src/main/java/me/rerere/rikkahub/service/ChatService.kt
@@ -2,6 +2,7 @@ package me.rerere.rikkahub.service
 
 import android.app.Application
 import android.content.Context
+import android.os.SystemClock
 import android.util.Log
 import androidx.core.net.toUri
 import kotlinx.coroutines.CancellationException
@@ -90,6 +91,7 @@ import java.util.concurrent.ConcurrentHashMap
 import kotlin.uuid.Uuid
 
 private const val TAG = "ChatService"
+private const val GENERATION_CHECKPOINT_INTERVAL_MS = 1_000L
 
 internal fun backgroundTextGenerationParams(
     model: Model,
@@ -149,6 +151,8 @@ class ChatService(
     private val workspaceRepository: WorkspaceRepository,
     private val folderRepository: FolderRepository,
 ) {
+    private val activeGenerations = ActiveGenerationRegistry()
+
     // workspace 系统提示注入 (依赖 workspaceRepository, 故在类内构造)
     private val workspaceReminderTransformer = WorkspaceReminderTransformer(workspaceRepository)
 
@@ -479,6 +483,7 @@ class ChatService(
         } else {
             model.displayName
         }
+        val checkpointPolicy = GenerationCheckpointPolicy(GENERATION_CHECKPOINT_INTERVAL_MS)
 
         runCatching {
 
@@ -502,7 +507,7 @@ class ChatService(
 
             // start generating
             val session = getOrCreateSession(conversationId)
-            generationHandler.generateText(
+            val generationFlow = generationHandler.generateText(
                 settings = settings,
                 model = model,
                 processingStatus = session.processingStatus,
@@ -577,7 +582,13 @@ class ChatService(
                         )
                     }
                 },
-            ).onCompletion {
+            )
+
+            if (activeGenerations.add(conversationId.toString())) {
+                ChatGenerationService.start(context, conversationId.toString(), senderName)
+            }
+
+            generationFlow.onCompletion {
                 // 可能被取消了，或者意外结束，兜底更新
                 val updatedConversation = getConversationFlow(conversationId).value.copy(
                     messageNodes = getConversationFlow(conversationId).value.messageNodes.map { node ->
@@ -586,6 +597,9 @@ class ChatService(
                     updateAt = Instant.now()
                 )
                 updateConversation(conversationId, updatedConversation)
+                if (checkpointPolicy.shouldCheckpoint(SystemClock.elapsedRealtime(), force = true)) {
+                    conversationRepo.updateConversation(updatedConversation)
+                }
 
                 // 生成结束：取消 Live Update 通知，后台时发送完成通知
                 appEventBus.emit(
@@ -602,6 +616,9 @@ class ChatService(
                         val updatedConversation = getConversationFlow(conversationId).value
                             .updateCurrentMessages(chunk.messages)
                         updateConversation(conversationId, updatedConversation)
+                        if (checkpointPolicy.shouldCheckpoint(SystemClock.elapsedRealtime())) {
+                            conversationRepo.updateConversation(updatedConversation)
+                        }
 
                         // 通知等边缘副作用由 ChatNotificationManager 消费；
                         // tryEmit 不挂起，事件丢失只影响单次通知更新，不能反压生成链
@@ -614,6 +631,8 @@ class ChatService(
                 }
             }
         }.onFailure {
+            stopGenerationForegroundService(conversationId)
+
             // 兜底取消 Live Update 通知（生成开始前失败时 onCompletion 不会执行）
             appEventBus.tryEmit(AppEvent.ChatGenerationEnded(conversationId, senderName, null))
 
@@ -622,6 +641,8 @@ class ChatService(
             Logging.log(TAG, "handleMessageComplete: $it")
             Logging.log(TAG, it.stackTraceToString())
         }.onSuccess {
+            stopGenerationForegroundService(conversationId)
+
             val finalConversation = getConversationFlow(conversationId).value
             saveConversation(conversationId, finalConversation)
 
@@ -631,6 +652,12 @@ class ChatService(
             launchWithConversationReference(conversationId) {
                 generateSuggestion(conversationId, finalConversation)
             }
+        }
+    }
+
+    private fun stopGenerationForegroundService(conversationId: Uuid) {
+        if (activeGenerations.remove(conversationId.toString())) {
+            ChatGenerationService.stop(context)
         }
     }
 

--- a/app/src/main/java/me/rerere/rikkahub/service/GenerationLifetime.kt
+++ b/app/src/main/java/me/rerere/rikkahub/service/GenerationLifetime.kt
@@ -1,0 +1,39 @@
+package me.rerere.rikkahub.service
+
+internal class ActiveGenerationRegistry {
+    private val conversationIds = mutableSetOf<String>()
+
+    val size: Int
+        @Synchronized get() = conversationIds.size
+
+    @Synchronized
+    fun add(conversationId: String): Boolean {
+        val wasIdle = conversationIds.isEmpty()
+        val added = conversationIds.add(conversationId)
+        return added && wasIdle
+    }
+
+    @Synchronized
+    fun remove(conversationId: String): Boolean {
+        val removed = conversationIds.remove(conversationId)
+        return removed && conversationIds.isEmpty()
+    }
+}
+
+internal class GenerationCheckpointPolicy(
+    private val intervalMillis: Long,
+) {
+    private var lastCheckpointAt: Long? = null
+
+    fun shouldCheckpoint(nowMillis: Long, force: Boolean = false): Boolean {
+        val previousCheckpointAt = lastCheckpointAt
+        val isDue = previousCheckpointAt == null ||
+            nowMillis < previousCheckpointAt ||
+            nowMillis - previousCheckpointAt >= intervalMillis
+
+        if (!force && !isDue) return false
+
+        lastCheckpointAt = nowMillis
+        return true
+    }
+}

--- a/app/src/test/java/me/rerere/rikkahub/service/ActiveGenerationRegistryTest.kt
+++ b/app/src/test/java/me/rerere/rikkahub/service/ActiveGenerationRegistryTest.kt
@@ -1,0 +1,33 @@
+package me.rerere.rikkahub.service
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ActiveGenerationRegistryTest {
+    @Test
+    fun `first active generation starts foreground lifetime and last completion stops it`() {
+        val registry = ActiveGenerationRegistry()
+
+        assertTrue(registry.add("conversation-1"))
+        assertFalse(registry.add("conversation-1"))
+        assertEquals(1, registry.size)
+
+        assertFalse(registry.remove("missing-conversation"))
+        assertTrue(registry.remove("conversation-1"))
+        assertEquals(0, registry.size)
+    }
+
+    @Test
+    fun `foreground lifetime remains active while another generation is running`() {
+        val registry = ActiveGenerationRegistry()
+
+        assertTrue(registry.add("conversation-1"))
+        assertFalse(registry.add("conversation-2"))
+
+        assertFalse(registry.remove("conversation-1"))
+        assertEquals(1, registry.size)
+        assertTrue(registry.remove("conversation-2"))
+    }
+}

--- a/app/src/test/java/me/rerere/rikkahub/service/GenerationCheckpointPolicyTest.kt
+++ b/app/src/test/java/me/rerere/rikkahub/service/GenerationCheckpointPolicyTest.kt
@@ -1,0 +1,26 @@
+package me.rerere.rikkahub.service
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class GenerationCheckpointPolicyTest {
+    @Test
+    fun `first update is checkpointed and rapid streaming updates are throttled`() {
+        val policy = GenerationCheckpointPolicy(intervalMillis = 1_000L)
+
+        assertTrue(policy.shouldCheckpoint(nowMillis = 100L))
+        assertFalse(policy.shouldCheckpoint(nowMillis = 1_099L))
+        assertTrue(policy.shouldCheckpoint(nowMillis = 1_100L))
+    }
+
+    @Test
+    fun `terminal update always checkpoints and resets the interval`() {
+        val policy = GenerationCheckpointPolicy(intervalMillis = 1_000L)
+
+        assertTrue(policy.shouldCheckpoint(nowMillis = 100L))
+        assertTrue(policy.shouldCheckpoint(nowMillis = 500L, force = true))
+        assertFalse(policy.shouldCheckpoint(nowMillis = 1_499L))
+        assertTrue(policy.shouldCheckpoint(nowMillis = 1_500L))
+    }
+}


### PR DESCRIPTION
## Summary

- keep active chat generations in an Android `dataSync` foreground service
- reuse the existing live-update notification as the foreground notification
- checkpoint streamed messages, reasoning, and tool progress to the conversation database once per second and at completion
- keep the service alive until all concurrent chat generations have finished

## Why

RikkaHub currently runs generation in the application coroutine scope and posts an ongoing notification, but it does not start an Android foreground service. After the app is backgrounded, Android can therefore reclaim or restrict the process even when battery usage is set to Unrestricted. This is especially visible during longer reasoning and MCP/tool transitions.

The foreground service gives the active generation the process lifetime represented by the existing notification. Periodic checkpoints also limit lost progress if the provider connection or process still terminates unexpectedly.

## Validation

- focused lifetime/checkpoint tests pass (4 tests)
- debug Kotlin compilation succeeds
- merged debug manifest contains the `dataSync` service and permission
- full app unit run: 120/129 pass; the 9 failures are existing assertions in `ShareSheetTest`, `TimeReminderTransformerTest`, and `ChatServiceTest`
- Android lint was attempted, but the project-wide task stalled in `:app:lintAnalyzeDebug` and was stopped

## Testing limitations

- physical-device testing was not available because the reporter's phone could not be connected over ADB
- the debug APK installed and launched in Waydroid, but Waydroid's HTTPS connections timed out despite working ICMP and DNS, so an end-to-end generation test could not be completed
- this change has therefore not yet been verified during a real background generation and remains a draft pending device validation

Closes #1080
