### PR TITLE
fix(ai): 流式中途错误事件交给 Flow 而非抛出线程

### DIFF
--- a/ai/src/main/java/me/rerere/ai/provider/providers/openai/ChatCompletionsAPI.kt
+++ b/ai/src/main/java/me/rerere/ai/provider/providers/openai/ChatCompletionsAPI.kt
@@ -167,51 +167,61 @@ class ChatCompletionsAPI(
                     return
                 }
                 Log.d(TAG, "onEvent: $data")
-                data
-                    .trim()
-                    .split("\n")
-                    .filter { it.isNotBlank() }
-                    .map { json.parseToJsonElement(it).jsonObject }
-                    .forEach {
-                        if (it["error"] != null) {
-                            val error = it["error"]!!.parseErrorDetail()
-                            throw error
-                        }
-                        val id = it["id"]?.jsonPrimitive?.contentOrNull ?: ""
-                        val model = it["model"]?.jsonPrimitive?.contentOrNull ?: ""
+                // 整个事件处理运行在 OkHttp 调度线程上，任何异常都必须交给 Flow（#1575）
+                runCatching {
+                    data
+                        .trim()
+                        .split("\n")
+                        .filter { it.isNotBlank() }
+                        .map { json.parseToJsonElement(it).jsonObject }
+                        .forEach {
+                            if (it["error"] != null) {
+                                // 流式中途的错误事件必须交给 Flow：onEvent 运行在 OkHttp 调度线程上，
+                                // 直接 throw 收集方永远收不到（流卡死），且未捕获异常可能导致应用崩溃
+                                val error = it["error"]!!.parseErrorDetail()
+                                Log.w(TAG, "onEvent: stream error: $error")
+                                close(error)
+                                return
+                            }
+                            val id = it["id"]?.jsonPrimitive?.contentOrNull ?: ""
+                            val model = it["model"]?.jsonPrimitive?.contentOrNull ?: ""
 
-                        val choices = it["choices"]?.jsonArray ?: JsonArray(emptyList())
-                        val choiceList = buildList {
-                            if (choices.isNotEmpty()) {
-                                val choice = choices[0].jsonObject
-                                val message =
-                                    choice["delta"]?.jsonObject ?: choice["message"]?.jsonObject
-                                    ?: throw Exception("delta/message is null")
-                                val finishReason =
-                                    choice["finish_reason"]?.jsonPrimitive?.contentOrNull
-                                        ?: "unknown"
-                                add(
-                                    UIMessageChoice(
-                                        index = 0,
-                                        delta = parseMessage(message),
-                                        message = null,
-                                        finishReason = finishReason,
+                            val choices = it["choices"]?.jsonArray ?: JsonArray(emptyList())
+                            val choiceList = buildList {
+                                if (choices.isNotEmpty()) {
+                                    val choice = choices[0].jsonObject
+                                    val message =
+                                        choice["delta"]?.jsonObject ?: choice["message"]?.jsonObject
+                                        ?: throw Exception("delta/message is null")
+                                    val finishReason =
+                                        choice["finish_reason"]?.jsonPrimitive?.contentOrNull
+                                            ?: "unknown"
+                                    add(
+                                        UIMessageChoice(
+                                            index = 0,
+                                            delta = parseMessage(message),
+                                            message = null,
+                                            finishReason = finishReason,
+                                        )
                                     )
-                                )
+                                }
+                            }
+                            val usage = parseTokenUsage(it["usage"] as? JsonObject)
+
+                            val messageChunk = MessageChunk(
+                                id = id,
+                                model = model,
+                                choices = choiceList,
+                                usage = usage
+                            )
+                            trySend(messageChunk).onFailure { e ->
+                                Log.w(TAG, "onEvent: chunk dropped (${e?.message})")
                             }
                         }
-                        val usage = parseTokenUsage(it["usage"] as? JsonObject)
-
-                        val messageChunk = MessageChunk(
-                            id = id,
-                            model = model,
-                            choices = choiceList,
-                            usage = usage
-                        )
-                        trySend(messageChunk).onFailure { e ->
-                            Log.w(TAG, "onEvent: chunk dropped (${e?.message})")
-                        }
-                    }
+                }.onFailure { e ->
+                    Log.w(TAG, "onEvent: closing stream with error", e)
+                    close(e)
+                }
             }
 
             override fun onFailure(eventSource: EventSource, t: Throwable?, response: Response?) {

--- a/ai/src/main/java/me/rerere/ai/provider/providers/openai/ResponseAPI.kt
+++ b/ai/src/main/java/me/rerere/ai/provider/providers/openai/ResponseAPI.kt
@@ -142,15 +142,26 @@ class ResponseAPI(
                     return
                 }
                 Log.d(TAG, "onEvent: $id/$type $data")
-                val json = json.parseToJsonElement(data).jsonObject
-                val chunk = parseResponseDelta(json)
-                if (chunk != null) {
-                    trySend(chunk).onFailure { e ->
-                        Log.w(TAG, "onEvent: chunk dropped (${e?.message})")
+                // onEvent 运行在 OkHttp 调度线程上，解析失败与失败事件都必须交给 Flow：
+                // 直接抛出收集方永远收不到（流卡死），且未捕获异常可能导致应用崩溃（#1575）
+                runCatching {
+                    val json = json.parseToJsonElement(data).jsonObject
+                    if (type == "response.failed" || type == "error") {
+                        throw (json["response"]?.jsonObject?.get("error")?.parseErrorDetail()
+                            ?: json.parseErrorDetail())
                     }
-                }
-                if (type == "response.completed") {
-                    close()
+                    val chunk = parseResponseDelta(json)
+                    if (chunk != null) {
+                        trySend(chunk).onFailure { e ->
+                            Log.w(TAG, "onEvent: chunk dropped (${e?.message})")
+                        }
+                    }
+                    if (type == "response.completed") {
+                        close()
+                    }
+                }.onFailure { e ->
+                    Log.w(TAG, "onEvent: closing stream with error", e)
+                    close(e)
                 }
             }
 


### PR DESCRIPTION
## 关联
Fixes #1575

## 问题
`ChatCompletionsAPI.streamText` 的 SSE `onEvent` 回调运行在 OkHttp 调度线程上，对流式响应内携带的 `{"error": ...}` 直接 `throw`：异常不会经 `close(cause)` 传给 Flow 收集方（UI 表现为生成永远卡住），且成为后台线程未捕获异常，Android 上可能直接导致应用崩溃。

触发场景：部分 OpenAI 兼容服务在流式输出中途以 SSE data 事件发送错误（限流/上下文溢出/过载），HTTP 状态码仍是 200，`onFailure` 路径不会触发。

## 改动
- error 事件改为 `close(error)`，收集方按异常正常终止；
- `onEvent` 处理链加 `runCatching` 兜底，解析异常同样 `close(e)`；
- `ResponseAPI.onEvent` 加同样防护（`parseResponseDelta` 内的 `error()` 此前也在 OkHttp 线程上抛出），并显式处理 `response.failed` / `error` 事件。

## 测试
`:ai:testDebugUnitTest` 通过（含既有 ChatCompletions/ResponseAPI 消息测试，无回归）。