### PR TITLE
fix(ai): cached tokens 按 provider 方言兜底解析

### DIFF
--- a/ai/src/main/java/me/rerere/ai/provider/providers/openai/ChatCompletionsAPI.kt
+++ b/ai/src/main/java/me/rerere/ai/provider/providers/openai/ChatCompletionsAPI.kt
@@ -791,7 +791,11 @@ class ChatCompletionsAPI(
             promptTokens = jsonObject["prompt_tokens"]?.jsonPrimitive?.intOrNull ?: 0,
             completionTokens = jsonObject["completion_tokens"]?.jsonPrimitive?.intOrNull ?: 0,
             totalTokens = jsonObject["total_tokens"]?.jsonPrimitive?.intOrNull ?: 0,
+            // 各 provider 汇报缓存命中的字段形状不统一，按方言兜底解析（#1576）：
+            // OpenAI 嵌套 -> Moonshot 顶层 cached_tokens -> DeepSeek prompt_cache_hit_tokens
             cachedTokens = jsonObject["prompt_tokens_details"]?.jsonObjectOrNull?.get("cached_tokens")?.jsonPrimitive?.intOrNull
+                ?: jsonObject["cached_tokens"]?.jsonPrimitive?.intOrNull
+                ?: jsonObject["prompt_cache_hit_tokens"]?.jsonPrimitive?.intOrNull
                 ?: 0
         )
     }

--- a/ai/src/test/java/me/rerere/ai/provider/providers/openai/ChatCompletionsAPIUsageTest.kt
+++ b/ai/src/test/java/me/rerere/ai/provider/providers/openai/ChatCompletionsAPIUsageTest.kt
@@ -1,0 +1,66 @@
+package me.rerere.ai.provider.providers.openai
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonObject
+import me.rerere.ai.core.TokenUsage
+import me.rerere.ai.util.KeyRoulette
+import okhttp3.OkHttpClient
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Unit tests for ChatCompletionsAPI token usage parsing.
+ */
+class ChatCompletionsAPIUsageTest {
+
+    private lateinit var api: ChatCompletionsAPI
+
+    @Before
+    fun setUp() {
+        api = ChatCompletionsAPI(OkHttpClient(), KeyRoulette.default())
+    }
+
+    // Helper to invoke private parseTokenUsage via reflection
+    private fun parseTokenUsage(usage: JsonObject): TokenUsage? {
+        val method = ChatCompletionsAPI::class.java.getDeclaredMethod(
+            "parseTokenUsage",
+            JsonObject::class.java
+        )
+        method.isAccessible = true
+        return method.invoke(api, usage) as TokenUsage?
+    }
+
+    // #1576: cached tokens 按 provider 方言兜底解析
+    @Test
+    fun `cached tokens fall back across provider dialects`() {
+        fun usage(jsonStr: String) = parseTokenUsage(Json.parseToJsonElement(jsonStr).jsonObject)
+
+        // OpenAI 官方嵌套格式
+        assertEquals(
+            12,
+            usage("""{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2,"prompt_tokens_details":{"cached_tokens":12}}""")?.cachedTokens
+        )
+        // Moonshot 顶层 cached_tokens
+        assertEquals(
+            7,
+            usage("""{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2,"cached_tokens":7}""")?.cachedTokens
+        )
+        // DeepSeek 顶层 prompt_cache_hit_tokens
+        assertEquals(
+            5,
+            usage("""{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2,"prompt_cache_hit_tokens":5,"prompt_cache_miss_tokens":3}""")?.cachedTokens
+        )
+        // 嵌套字段优先于顶层兜底
+        assertEquals(
+            12,
+            usage("""{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2,"prompt_tokens_details":{"cached_tokens":12},"cached_tokens":7}""")?.cachedTokens
+        )
+        // 都没有时为 0
+        assertEquals(
+            0,
+            usage("""{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}""")?.cachedTokens
+        )
+    }
+}


### PR DESCRIPTION
## 关联
Fixes #1576

## 问题
`parseTokenUsage` 只解析 OpenAI 官方嵌套格式 `usage.prompt_tokens_details.cached_tokens`；其他 OpenAI 兼容 provider 汇报缓存命中的字段形状不同（DeepSeek 顶层 `prompt_cache_hit_tokens`、Moonshot 顶层 `cached_tokens`），客户端展示的 cached tokens 恒为 0，无法判断前缀缓存是否生效，也无法做成本核算。

## 改动
按方言增加兜底链：OpenAI 嵌套 -> Moonshot 顶层 `cached_tokens` -> DeepSeek `prompt_cache_hit_tokens` -> 0。

## 测试
新增 `ChatCompletionsAPIUsageTest` 覆盖四种形状（OpenAI 嵌套 / Moonshot 顶层 / DeepSeek 顶层 / 缺失）及嵌套字段优先级，`:ai:testDebugUnitTest` 通过。