### PR TITLE
fix(ai): 月之暗面方言按模型分派

### DIFF
--- a/ai/src/main/java/me/rerere/ai/provider/providers/openai/ChatCompletionsAPI.kt
+++ b/ai/src/main/java/me/rerere/ai/provider/providers/openai/ChatCompletionsAPI.kt
@@ -70,6 +70,42 @@ private const val TAG = "ChatCompletionsAPI"
 // 月之暗面系 host：开放平台（国内/国际）与 Kimi Code 网关（api.kimi.com/coding）
 private val MOONSHOT_HOSTS = setOf("api.moonshot.cn", "api.moonshot.ai", "api.kimi.com")
 
+// OpenAI 兼容网关的方言家族。URL -> 方言的映射全仓库只存在于 fromHost，
+// 各分支一律按方言分派，不再直接比较 host 字符串
+private enum class OpenAIDialect {
+    OPENAI,
+    OPENROUTER,
+    DASHSCOPE,
+    VOLCES,
+    MISTRAL,
+    INTERNLM,
+    SILICONFLOW,
+    AIPING,
+    BIGMODEL,
+    MOONSHOT,
+    DEEPSEEK,
+    NVIDIA,
+    OPENCODE;
+
+    companion object {
+        fun fromHost(host: String): OpenAIDialect = when (host) {
+            "openrouter.ai" -> OPENROUTER
+            "dashscope.aliyuncs.com" -> DASHSCOPE
+            "ark.cn-beijing.volces.com" -> VOLCES
+            "api.mistral.ai" -> MISTRAL
+            "chat.intern-ai.org.cn" -> INTERNLM
+            "api.siliconflow.cn" -> SILICONFLOW
+            "aiping.cn" -> AIPING
+            "open.bigmodel.cn" -> BIGMODEL
+            in MOONSHOT_HOSTS -> MOONSHOT
+            "api.deepseek.com" -> DEEPSEEK
+            "integrate.api.nvidia.com" -> NVIDIA
+            "opencode.ai" -> OPENCODE
+            else -> OPENAI
+        }
+    }
+}
+
 class ChatCompletionsAPI(
     private val client: OkHttpClient,
     private val keyRoulette: KeyRoulette
@@ -261,7 +297,7 @@ class ChatCompletionsAPI(
         providerSetting: ProviderSetting.OpenAI,
         stream: Boolean = false,
     ): JsonObject {
-        val host = providerSetting.baseUrl.toHttpUrl().host
+        val dialect = OpenAIDialect.fromHost(providerSetting.baseUrl.toHttpUrl().host)
         return buildJsonObject {
             put("model", params.model.modelId)
             put(
@@ -273,7 +309,7 @@ class ChatCompletionsAPI(
                 )
             )
 
-            if (isModelAllowTemperature(params.model, host)) {
+            if (isModelAllowTemperature(params.model, dialect)) {
                 if (params.temperature != null) put("temperature", params.temperature)
                 if (params.topP != null) put("top_p", params.topP)
             }
@@ -281,7 +317,7 @@ class ChatCompletionsAPI(
 
             put("stream", stream)
             if (stream) {
-                if (host != "api.mistral.ai") { // mistral 不支持 stream_options
+                if (dialect != OpenAIDialect.MISTRAL) { // mistral 不支持 stream_options
                     put("stream_options", buildJsonObject {
                         put("include_usage", true)
                     })
@@ -289,8 +325,8 @@ class ChatCompletionsAPI(
             }
 
             // open router适配
-            if(host == "openrouter.ai") {
-                if(params.model.outputModalities.contains(Modality.IMAGE)) {
+            if (dialect == OpenAIDialect.OPENROUTER) {
+                if (params.model.outputModalities.contains(Modality.IMAGE)) {
                     put("modalities", buildJsonArray {
                         add("image")
                         add("text")
@@ -300,8 +336,8 @@ class ChatCompletionsAPI(
 
             if (params.model.abilities.contains(ModelAbility.REASONING)) {
                 val level = params.reasoningLevel
-                when (host) {
-                    "openrouter.ai" -> {
+                when (dialect) {
+                    OpenAIDialect.OPENROUTER -> {
                         // https://openrouter.ai/docs/use-cases/reasoning-tokens
                         put("reasoning", buildJsonObject {
                             when (level) {
@@ -312,31 +348,31 @@ class ChatCompletionsAPI(
                         })
                     }
 
-                    "dashscope.aliyuncs.com" -> {
+                    OpenAIDialect.DASHSCOPE -> {
                         // 阿里云百炼
                         // https://bailian.console.aliyun.com/console?tab=doc#/doc/?type=model&url=https%3A%2F%2Fhelp.aliyun.com%2Fdocument_detail%2F2870973.html&renderType=iframe
                         put("enable_thinking", level.isEnabled)
                         if (level != ReasoningLevel.AUTO) put("thinking_budget", level.budgetTokens)
                     }
 
-                    "ark.cn-beijing.volces.com" -> {
+                    OpenAIDialect.VOLCES -> {
                         // 豆包 (火山)
                         put("thinking", buildJsonObject {
                             put("type", if (!level.isEnabled) "disabled" else "enabled")
                         })
                     }
 
-                    "api.mistral.ai" -> {
+                    OpenAIDialect.MISTRAL -> {
                         // Mistral 不支持
                     }
 
-                    "chat.intern-ai.org.cn" -> {
+                    OpenAIDialect.INTERNLM -> {
                         // 书生
                         // https://internlm.intern-ai.org.cn/api/document?lang=zh
                         put("thinking_mode", level.isEnabled)
                     }
 
-                    "api.siliconflow.cn" -> {
+                    OpenAIDialect.SILICONFLOW -> {
                         // https://docs.siliconflow.cn/cn/userguide/capabilities/reasoning#3-1-api-%E5%8F%82%E6%95%B0
                         val modelId = params.model.modelId
                         val siliconflowThinkingModels = setOf(
@@ -371,19 +407,17 @@ class ChatCompletionsAPI(
                         }
                     }
 
-                    "aiping.cn" -> {
+                    OpenAIDialect.AIPING -> {
                         put("enable_thinking", level.isEnabled)
                     }
 
-                    "open.bigmodel.cn" -> {
+                    OpenAIDialect.BIGMODEL -> {
                         put("thinking", buildJsonObject {
                             put("type", if (!level.isEnabled) "disabled" else "enabled")
                         })
                     }
 
-                    // api.kimi.com 是 Kimi Code 网关（用户常以 https://api.kimi.com/coding/v1 配置），
-                    // 与开放平台共用同一套月之暗面方言
-                    in MOONSHOT_HOSTS -> {
+                    OpenAIDialect.MOONSHOT -> {
                         // 月之暗面各模型的思考参数体系不同，需按模型 id 区分（#1573）
                         when {
                             // K3 系列（kimi-k3* / k3 / k3-256k）：不使用 thinking 参数，
@@ -422,7 +456,7 @@ class ChatCompletionsAPI(
                         }
                     }
 
-                    "api.deepseek.com" -> {
+                    OpenAIDialect.DEEPSEEK -> {
                         put("thinking", buildJsonObject {
                             put("type", if (!level.isEnabled) "disabled" else "enabled")
                         })
@@ -431,7 +465,7 @@ class ChatCompletionsAPI(
                         }
                     }
 
-                    "integrate.api.nvidia.com" -> {
+                    OpenAIDialect.NVIDIA -> {
                         if ("deepseek-v4" in params.model.modelId.lowercase()) {
                             if (level != ReasoningLevel.AUTO) {
                                 val effort = when (level) {
@@ -448,13 +482,13 @@ class ChatCompletionsAPI(
                         }
                     }
 
-                    "opencode.ai" -> {
+                    OpenAIDialect.OPENCODE -> {
                         if (level != ReasoningLevel.AUTO) {
                             put("reasoning_effort", level.effort)
                         }
                     }
 
-                    else -> {
+                    OpenAIDialect.OPENAI -> {
                         // OpenAI 官方
                         // 文档中，completions API 只支持 "low", "medium", "high"
                         if (level != ReasoningLevel.AUTO) {
@@ -486,12 +520,12 @@ class ChatCompletionsAPI(
         }.mergeCustomBody(params.customBody)
     }
 
-    private fun isModelAllowTemperature(model: Model, host: String): Boolean {
+    private fun isModelAllowTemperature(model: Model, dialect: OpenAIDialect): Boolean {
         if (ModelRegistry.OPENAI_O_MODELS.match(model.modelId) || ModelRegistry.GPT_5.match(model.modelId)) {
             return false
         }
         // 月之暗面 K2.5 及以上模型的 temperature/top_p 为固定值，显式传入会被 API 以 400 拒绝（#1574）
-        if (host in MOONSHOT_HOSTS && ModelRegistry.KIMI_K2_5_PLUS.match(model.modelId)) {
+        if (dialect == OpenAIDialect.MOONSHOT && ModelRegistry.KIMI_K2_5_PLUS.match(model.modelId)) {
             return false
         }
         return true

--- a/ai/src/main/java/me/rerere/ai/provider/providers/openai/ChatCompletionsAPI.kt
+++ b/ai/src/main/java/me/rerere/ai/provider/providers/openai/ChatCompletionsAPI.kt
@@ -67,6 +67,9 @@ import kotlin.time.Clock
 
 private const val TAG = "ChatCompletionsAPI"
 
+// 月之暗面系 host：开放平台（国内/国际）与 Kimi Code 网关（api.kimi.com/coding）
+private val MOONSHOT_HOSTS = setOf("api.moonshot.cn", "api.moonshot.ai", "api.kimi.com")
+
 class ChatCompletionsAPI(
     private val client: OkHttpClient,
     private val keyRoulette: KeyRoulette
@@ -270,7 +273,7 @@ class ChatCompletionsAPI(
                 )
             )
 
-            if (isModelAllowTemperature(params.model)) {
+            if (isModelAllowTemperature(params.model, host)) {
                 if (params.temperature != null) put("temperature", params.temperature)
                 if (params.topP != null) put("top_p", params.topP)
             }
@@ -378,15 +381,45 @@ class ChatCompletionsAPI(
                         })
                     }
 
-                    "api.moonshot.cn" -> {
-                        put("thinking", buildJsonObject {
-                            put("type", if (!level.isEnabled) "disabled" else "enabled")
-                            // K2.6 的 thinking.keep 默认为 null（忽略历史思考），思考开启时
-                            // 需显式传 "all" 才是保留式思考；文档推荐与 enabled 搭配（#1586）
-                            if (level.isEnabled && ModelRegistry.KIMI_K2_6.match(params.model.modelId)) {
-                                put("keep", "all")
+                    // api.kimi.com 是 Kimi Code 网关（用户常以 https://api.kimi.com/coding/v1 配置），
+                    // 与开放平台共用同一套月之暗面方言
+                    in MOONSHOT_HOSTS -> {
+                        // 月之暗面各模型的思考参数体系不同，需按模型 id 区分（#1573）
+                        when {
+                            // K3 系列（kimi-k3* / k3 / k3-256k）：不使用 thinking 参数，
+                            // 顶层 reasoning_effort 仅接受 low/high/max，客户端需自行映射；
+                            // K3 始终推理，OFF 映射为 low
+                            ModelRegistry.KIMI_K3_FAMILY.match(params.model.modelId) -> {
+                                if (level != ReasoningLevel.AUTO) {
+                                    put(
+                                        "reasoning_effort", when (level) {
+                                            ReasoningLevel.OFF, ReasoningLevel.LOW -> "low"
+                                            ReasoningLevel.MEDIUM, ReasoningLevel.HIGH -> "high"
+                                            ReasoningLevel.XHIGH -> "max"
+                                            // 不可达（外层已排除 AUTO），与 Kimi Code 官方默认一致
+                                            ReasoningLevel.AUTO -> "high"
+                                        }
+                                    )
+                                }
                             }
-                        })
+                            // K2.7 Code 系列（kimi-k2.7-code / kimi-for-coding，均含 -highspeed）
+                            // 始终开启思考，显式设置 thinking 仅接受 {"type":"enabled","keep":"all"}，
+                            // 传入 disabled 会报错，官方建议完全不传
+                            ModelRegistry.KIMI_K2_7.match(params.model.modelId) -> {
+                                // 不传任何思考参数
+                            }
+                            // K2.5/K2.6 等：支持 enabled/disabled
+                            else -> {
+                                put("thinking", buildJsonObject {
+                                    put("type", if (!level.isEnabled) "disabled" else "enabled")
+                                    // K2.6 的 thinking.keep 默认为 null（忽略历史思考），思考开启时
+                                    // 需显式传 "all" 才是保留式思考；文档推荐与 enabled 搭配（#1586）
+                                    if (level.isEnabled && ModelRegistry.KIMI_K2_6.match(params.model.modelId)) {
+                                        put("keep", "all")
+                                    }
+                                })
+                            }
+                        }
                     }
 
                     "api.deepseek.com" -> {
@@ -453,8 +486,15 @@ class ChatCompletionsAPI(
         }.mergeCustomBody(params.customBody)
     }
 
-    private fun isModelAllowTemperature(model: Model): Boolean {
-        return !ModelRegistry.OPENAI_O_MODELS.match(model.modelId) && !ModelRegistry.GPT_5.match(model.modelId)
+    private fun isModelAllowTemperature(model: Model, host: String): Boolean {
+        if (ModelRegistry.OPENAI_O_MODELS.match(model.modelId) || ModelRegistry.GPT_5.match(model.modelId)) {
+            return false
+        }
+        // 月之暗面 K2.5 及以上模型的 temperature/top_p 为固定值，显式传入会被 API 以 400 拒绝（#1574）
+        if (host in MOONSHOT_HOSTS && ModelRegistry.KIMI_K2_5_PLUS.match(model.modelId)) {
+            return false
+        }
+        return true
     }
 
     private fun buildMessages(

--- a/ai/src/main/java/me/rerere/ai/registry/ModelRegistry.kt
+++ b/ai/src/main/java/me/rerere/ai/registry/ModelRegistry.kt
@@ -379,17 +379,52 @@ object ModelRegistry {
         toolReasoningAbility()
     }
 
-    private val KIMI_K3 = defineModel {
+    // kimi-k2.7-code（含 -highspeed）：始终开启思考，不应传 thinking 参数。
+    // 纯 matcher，不加入 ALL_MODELS，能力/模态解析仍由 KIMI_K2 承担
+    private val KIMI_K2_7_CODE = defineModel {
+        tokens("kimi", "k", "2", "7")
+    }
+
+    // Kimi Code 网关（api.kimi.com/coding）的 kimi-for-coding（含 -highspeed），
+    // 即网关上 K2.7 Code 系列的模型 id，方言与 kimi-k2.7-code 一致
+    val KIMI_FOR_CODING = defineModel {
+        tokens("kimi", "for", "coding")
+        toolReasoningAbility()
+    }
+
+    // K2.7 Code 系列：始终开启思考，仅作为方言分派的 matcher 使用
+    val KIMI_K2_7 = defineGroup {
+        add(KIMI_K2_7_CODE, KIMI_FOR_CODING)
+    }
+
+    val KIMI_K3 = defineModel {
         tokens("kimi", "k", "3")
         visionInput()
         toolReasoningAbility()
     }
 
     // 兼容不带 kimi 前缀的裸 id "k3"
-    private val KIMI_K3_ALIAS = defineModel {
+    val KIMI_K3_ALIAS = defineModel {
         exact("k3")
         visionInput()
         toolReasoningAbility()
+    }
+
+    // Kimi Code 网关的 k3-256k（K3 的 256K 上下文版本）
+    val KIMI_K3_256K = defineModel {
+        exact("k3-256k")
+        visionInput()
+        toolReasoningAbility()
+    }
+
+    // K3 系列：使用顶层 reasoning_effort（low/high/max），不使用 thinking 参数
+    val KIMI_K3_FAMILY = defineGroup {
+        add(KIMI_K3, KIMI_K3_ALIAS, KIMI_K3_256K)
+    }
+
+    // 月之暗面 K2.5 及以上模型：temperature/top_p 为固定值，显式传入会被 API 拒绝
+    val KIMI_K2_5_PLUS = defineGroup {
+        add(KIMI_K2_5, KIMI_K2_6, KIMI_K2_7, KIMI_K3_FAMILY)
     }
 
     private val STEP_3 = defineModel {
@@ -555,8 +590,10 @@ object ModelRegistry {
         KIMI_K2,
         KIMI_K2_5,
         KIMI_K2_6,
+        KIMI_FOR_CODING,
         KIMI_K3,
         KIMI_K3_ALIAS,
+        KIMI_K3_256K,
         STEP_3,
         STEP_3_7_FLASH,
         INTERN_S1,

--- a/ai/src/test/java/me/rerere/ai/ModelRegistryTest.kt
+++ b/ai/src/test/java/me/rerere/ai/ModelRegistryTest.kt
@@ -103,4 +103,45 @@ class ModelRegistryTest {
             ModelRegistry.MODEL_ABILITIES.getData("deepseek-v4-pro")
         )
     }
+
+    @Test
+    fun testKimiDialectMatchers() {
+        // K3 系列（含 Kimi Code 网关的裸 id k3 / k3-256k）
+        assertTrue(ModelRegistry.KIMI_K3_FAMILY.match("kimi-k3"))
+        assertTrue(ModelRegistry.KIMI_K3_FAMILY.match("Kimi-K3.5"))
+        assertTrue(ModelRegistry.KIMI_K3_FAMILY.match("k3"))
+        assertTrue(ModelRegistry.KIMI_K3_FAMILY.match("k3-256k"))
+        assertFalse(ModelRegistry.KIMI_K3_ALIAS.match("kimi-k3"))
+        assertFalse(ModelRegistry.KIMI_K3_FAMILY.match("kimi-k2.5"))
+
+        // K2.7 Code 系列：kimi-k2.7-code（含 -highspeed）与网关的 kimi-for-coding（含 -highspeed）
+        assertTrue(ModelRegistry.KIMI_K2_7.match("kimi-k2.7-code"))
+        assertTrue(ModelRegistry.KIMI_K2_7.match("kimi-k2.7-code-highspeed"))
+        assertTrue(ModelRegistry.KIMI_K2_7.match("kimi-for-coding"))
+        assertTrue(ModelRegistry.KIMI_K2_7.match("kimi-for-coding-highspeed"))
+        assertFalse(ModelRegistry.KIMI_K2_7.match("kimi-k2.5"))
+        assertFalse(ModelRegistry.KIMI_K2_7.match("kimi-k2-0905-preview"))
+
+        // K2.5 及以上（采样参数固定的模型集合）
+        assertTrue(ModelRegistry.KIMI_K2_5_PLUS.match("kimi-k2.5"))
+        assertTrue(ModelRegistry.KIMI_K2_5_PLUS.match("kimi-k2.6"))
+        assertTrue(ModelRegistry.KIMI_K2_5_PLUS.match("kimi-k2.7-code"))
+        assertTrue(ModelRegistry.KIMI_K2_5_PLUS.match("kimi-for-coding"))
+        assertTrue(ModelRegistry.KIMI_K2_5_PLUS.match("kimi-k3"))
+        assertTrue(ModelRegistry.KIMI_K2_5_PLUS.match("k3"))
+        assertTrue(ModelRegistry.KIMI_K2_5_PLUS.match("k3-256k"))
+        assertFalse(ModelRegistry.KIMI_K2_5_PLUS.match("kimi-k2"))
+        assertFalse(ModelRegistry.KIMI_K2_5_PLUS.match("kimi-k2-0905-preview"))
+        assertFalse(ModelRegistry.KIMI_K2_5_PLUS.match("kimi-k2-thinking"))
+
+        // 网关模型 id 的能力注册
+        assertEquals(
+            listOf(ModelAbility.TOOL, ModelAbility.REASONING),
+            ModelRegistry.MODEL_ABILITIES.getData("k3-256k")
+        )
+        assertEquals(
+            listOf(ModelAbility.TOOL, ModelAbility.REASONING),
+            ModelRegistry.MODEL_ABILITIES.getData("kimi-for-coding")
+        )
+    }
 }

--- a/ai/src/test/java/me/rerere/ai/provider/providers/openai/ChatCompletionsAPIDialectTest.kt
+++ b/ai/src/test/java/me/rerere/ai/provider/providers/openai/ChatCompletionsAPIDialectTest.kt
@@ -1,0 +1,258 @@
+package me.rerere.ai.provider.providers.openai
+
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.floatOrNull
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import me.rerere.ai.core.ReasoningLevel
+import me.rerere.ai.provider.Model
+import me.rerere.ai.provider.ModelAbility
+import me.rerere.ai.provider.ProviderSetting
+import me.rerere.ai.provider.TextGenerationParams
+import me.rerere.ai.ui.UIMessage
+import me.rerere.ai.util.KeyRoulette
+import okhttp3.OkHttpClient
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Unit tests for ChatCompletionsAPI Moonshot-dialect handling:
+ * - Moonshot per-model reasoning params (#1573)
+ * - Moonshot K2.5+ sampling param filtering (#1574)
+ */
+class ChatCompletionsAPIDialectTest {
+
+    private lateinit var api: ChatCompletionsAPI
+
+    @Before
+    fun setUp() {
+        api = ChatCompletionsAPI(OkHttpClient(), KeyRoulette.default())
+    }
+
+    // Helper to invoke private buildChatCompletionRequest via reflection
+    private fun buildRequest(
+        baseUrl: String,
+        modelId: String,
+        reasoningLevel: ReasoningLevel = ReasoningLevel.OFF,
+        temperature: Float? = null,
+        topP: Float? = null,
+        reasoning: Boolean = true,
+    ): JsonObject {
+        val method = ChatCompletionsAPI::class.java.getDeclaredMethod(
+            "buildChatCompletionRequest",
+            List::class.java,
+            TextGenerationParams::class.java,
+            ProviderSetting.OpenAI::class.java,
+            Boolean::class.javaPrimitiveType
+        )
+        method.isAccessible = true
+        val model = Model(
+            modelId = modelId,
+            abilities = if (reasoning) listOf(ModelAbility.REASONING) else emptyList()
+        )
+        val params = TextGenerationParams(
+            model = model,
+            temperature = temperature,
+            topP = topP,
+            reasoningLevel = reasoningLevel,
+        )
+        val providerSetting = ProviderSetting.OpenAI(baseUrl = baseUrl)
+        return method.invoke(
+            api,
+            listOf(UIMessage.user("hi")),
+            params,
+            providerSetting,
+            true
+        ) as JsonObject
+    }
+
+    // #1573: kimi-k3 不使用 thinking 参数，顶层 reasoning_effort 仅接受 low/high/max
+    @Test
+    fun `k3 uses reasoning_effort with mapped levels`() {
+        val body = buildRequest(
+            "https://api.moonshot.cn/v1", "kimi-k3",
+            reasoningLevel = ReasoningLevel.HIGH
+        )
+        assertEquals("high", body["reasoning_effort"]?.jsonPrimitive?.content)
+        assertFalse(body.containsKey("thinking"))
+
+        assertEquals(
+            "max",
+            buildRequest("https://api.moonshot.cn/v1", "kimi-k3", reasoningLevel = ReasoningLevel.XHIGH)
+                ["reasoning_effort"]?.jsonPrimitive?.content
+        )
+        assertEquals(
+            "high",
+            buildRequest("https://api.moonshot.cn/v1", "kimi-k3", reasoningLevel = ReasoningLevel.MEDIUM)
+                ["reasoning_effort"]?.jsonPrimitive?.content
+        )
+        assertEquals(
+            "low",
+            buildRequest("https://api.moonshot.cn/v1", "kimi-k3", reasoningLevel = ReasoningLevel.LOW)
+                ["reasoning_effort"]?.jsonPrimitive?.content
+        )
+        // K3 始终推理，OFF 映射为最低档 low
+        assertEquals(
+            "low",
+            buildRequest("https://api.moonshot.cn/v1", "kimi-k3", reasoningLevel = ReasoningLevel.OFF)
+                ["reasoning_effort"]?.jsonPrimitive?.content
+        )
+    }
+
+    // #1573: AUTO 时什么都不发，让服务端默认值生效
+    @Test
+    fun `k3 auto sends no reasoning params`() {
+        val body = buildRequest(
+            "https://api.moonshot.cn/v1", "kimi-k3",
+            reasoningLevel = ReasoningLevel.AUTO
+        )
+        assertFalse(body.containsKey("reasoning_effort"))
+        assertFalse(body.containsKey("thinking"))
+    }
+
+    // #1573: 裸 id "k3" 与国际站 api.moonshot.ai 走同一 K3 方言
+    @Test
+    fun `bare k3 id and international host share the k3 dialect`() {
+        val bare = buildRequest(
+            "https://api.moonshot.cn/v1", "k3",
+            reasoningLevel = ReasoningLevel.HIGH
+        )
+        assertEquals("high", bare["reasoning_effort"]?.jsonPrimitive?.content)
+        assertFalse(bare.containsKey("thinking"))
+
+        val intl = buildRequest(
+            "https://api.moonshot.ai/v1", "kimi-k3",
+            reasoningLevel = ReasoningLevel.XHIGH
+        )
+        assertEquals("max", intl["reasoning_effort"]?.jsonPrimitive?.content)
+        assertFalse(intl.containsKey("thinking"))
+    }
+
+    // #1573: kimi-k2.7-code 始终开启思考，关闭推理时也不能发送 thinking disabled（会 400）
+    @Test
+    fun `k2_7-code sends no thinking params even when off`() {
+        val off = buildRequest(
+            "https://api.moonshot.cn/v1", "kimi-k2.7-code",
+            reasoningLevel = ReasoningLevel.OFF
+        )
+        assertFalse(off.containsKey("thinking"))
+        assertFalse(off.containsKey("reasoning_effort"))
+
+        val high = buildRequest(
+            "https://api.moonshot.cn/v1", "kimi-k2.7-code-highspeed",
+            reasoningLevel = ReasoningLevel.HIGH
+        )
+        assertFalse(high.containsKey("thinking"))
+        assertFalse(high.containsKey("reasoning_effort"))
+    }
+
+    // #1573: K2.5/K2.6 等仍使用 thinking enabled/disabled 方言
+    @Test
+    fun `k2_5 keeps the thinking enabled_disabled dialect`() {
+        val off = buildRequest(
+            "https://api.moonshot.cn/v1", "kimi-k2.5",
+            reasoningLevel = ReasoningLevel.OFF
+        )
+        assertEquals(
+            "disabled",
+            off["thinking"]?.jsonObject?.get("type")?.jsonPrimitive?.content
+        )
+
+        val on = buildRequest(
+            "https://api.moonshot.cn/v1", "kimi-k2.5",
+            reasoningLevel = ReasoningLevel.HIGH
+        )
+        assertEquals(
+            "enabled",
+            on["thinking"]?.jsonObject?.get("type")?.jsonPrimitive?.content
+        )
+    }
+
+    // #1574: 月之暗面 K2.5 及以上模型不发送 temperature/top_p（固定值，显式传入会 400）
+    @Test
+    fun `sampling params are dropped for moonshot restricted models`() {
+        val k3 = buildRequest(
+            "https://api.moonshot.cn/v1", "kimi-k3",
+            temperature = 0.7f, topP = 0.9f, reasoning = false
+        )
+        assertFalse(k3.containsKey("temperature"))
+        assertFalse(k3.containsKey("top_p"))
+
+        val k25 = buildRequest(
+            "https://api.moonshot.cn/v1", "kimi-k2.5",
+            temperature = 0.7f, reasoning = false
+        )
+        assertFalse(k25.containsKey("temperature"))
+
+        val intl = buildRequest(
+            "https://api.moonshot.ai/v1", "kimi-k2.6",
+            temperature = 0.7f, reasoning = false
+        )
+        assertFalse(intl.containsKey("temperature"))
+    }
+
+    // #1574: 受限范围之外的模型与 host 照常发送采样参数
+    @Test
+    fun `sampling params are kept for unrestricted models and hosts`() {
+        // 早期 K2 不受限
+        val k2 = buildRequest(
+            "https://api.moonshot.cn/v1", "kimi-k2-0905-preview",
+            temperature = 0.7f, topP = 0.9f, reasoning = false
+        )
+        assertEquals(0.7f, k2["temperature"]?.jsonPrimitive?.floatOrNull)
+        assertEquals(0.9f, k2["top_p"]?.jsonPrimitive?.floatOrNull)
+
+        // 非 moonshot host 不受限
+        val ds = buildRequest(
+            "https://api.deepseek.com/v1", "deepseek-chat",
+            temperature = 0.7f, reasoning = false
+        )
+        assertEquals(0.7f, ds["temperature"]?.jsonPrimitive?.floatOrNull)
+    }
+
+    // #1573: Kimi Code 网关（api.kimi.com/coding）与开放平台共用同一套月之暗面方言
+    @Test
+    fun `kimi code gateway uses the same moonshot dialect`() {
+        // k3 / k3-256k：顶层 reasoning_effort 原生档位
+        val k3 = buildRequest(
+            "https://api.kimi.com/coding/v1", "k3",
+            reasoningLevel = ReasoningLevel.HIGH
+        )
+        assertEquals("high", k3["reasoning_effort"]?.jsonPrimitive?.content)
+        assertFalse(k3.containsKey("thinking"))
+
+        val k3256k = buildRequest(
+            "https://api.kimi.com/coding/v1", "k3-256k",
+            reasoningLevel = ReasoningLevel.XHIGH
+        )
+        assertEquals("max", k3256k["reasoning_effort"]?.jsonPrimitive?.content)
+        assertFalse(k3256k.containsKey("thinking"))
+
+        // kimi-for-coding：K2.7 Code 方言，任何档位都不传思考参数
+        val coding = buildRequest(
+            "https://api.kimi.com/coding/v1", "kimi-for-coding",
+            reasoningLevel = ReasoningLevel.OFF
+        )
+        assertFalse(coding.containsKey("thinking"))
+        assertFalse(coding.containsKey("reasoning_effort"))
+    }
+
+    // #1574: Kimi Code 网关同样过滤 K2.5+ 模型的采样参数
+    @Test
+    fun `sampling params are dropped on the kimi code gateway`() {
+        val coding = buildRequest(
+            "https://api.kimi.com/coding/v1", "kimi-for-coding",
+            temperature = 0.7f, topP = 0.9f, reasoning = false
+        )
+        assertFalse(coding.containsKey("temperature"))
+        assertFalse(coding.containsKey("top_p"))
+
+        val k3 = buildRequest(
+            "https://api.kimi.com/coding/v1", "k3",
+            temperature = 0.7f, reasoning = false
+        )
+        assertFalse(k3.containsKey("temperature"))
+    }
+}


### PR DESCRIPTION
## 关联
Fixes #1573
Fixes #1574

## 问题
见两个 issue。核心：月之暗面各模型思考参数体系不同，按 host 一刀切发送 K2.x 风格 `thinking` 导致：`kimi-k3` 推理档位完全失效（K3 用顶层 `reasoning_effort`，仅 low/high/max）；`kimi-k2.7-code` OFF 档必 400（始终思考，传 disabled 报错）；`api.moonshot.ai` 与 Kimi Code 网关（`api.kimi.com/coding`）不命中分支，落入 OpenAI 风格 `reasoning_effort`（K3 拒绝 medium/xhigh）；K2.5 及以上模型 temperature/top_p 为固定值，显式传入会 400。

## 改动（commit 1，按官方文档对齐）
- K3 系列（`kimi-k3*` / `k3` / `k3-256k`）：顶层 `reasoning_effort`，客户端自行映射 OFF/LOW->low、MEDIUM/HIGH->high、XHIGH->max，AUTO 不发（服务端默认值生效）；
- K2.7 Code 系列（`kimi-k2.7-code` / `kimi-for-coding`，含 -highspeed）：任何档位都不传 thinking 参数；
- K2.5/K2.6 等保持 `thinking` enabled/disabled；
- K2.5 及以上模型在 moonshot 系 host 下不发送 temperature/top_p；
- `ModelRegistry` 注册网关模型 id（`k3-256k`、`kimi-for-coding`），此前连推理能力都识别不出。

文档依据：[模型参数参考](https://platform.moonshot.cn/docs/api/models-overview) / [思考模式](https://platform.kimi.com/docs/guide/use-kimi-k2-thinking-model) / [推理强度](https://platform.kimi.com/docs/guide/use-thinking-effort) / [Kimi Code Claude Code 接入文档](https://www.kimi.com/code/docs/third-party-tools/claude-code.html)（档位映射表，网关输入词表含 max，因此直接发 K3 原生 low/high/max 在网关侧同样合法）。

## 改动（commit 2，纯重构，可选）
新增 `OpenAIDialect` 枚举，URL -> 方言的映射集中到 `fromHost` 一处，各分支不再直接比较 host 字符串，新增 provider 只需修改 `fromHost`。机械抽取，行为零变化，commit 1 的测试即回归网。如不希望随本 PR 合入，可直接 drop 该 commit。

## 测试
新增 `ChatCompletionsAPIDialectTest`（9 用例：K3 档位映射 / AUTO 不发 / 裸 k3 / 国际站 / Kimi Code 网关 / k2.7-code / K2.5 方言 / 采样过滤），`ModelRegistryTest` 补 Kimi matcher 用例，`:ai:testDebugUnitTest` 全部通过。