### PR TITLE
fix: 避免切换助手后新对话归属旧助手

### DIFF
--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ChatDrawer.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ChatDrawer.kt
@@ -286,8 +286,9 @@ fun ChatDrawerContent(
             AssistantPicker(
                 settings = settings,
                 onUpdateSettings = {
-                    vm.updateSettings(it)
+                    val updateJob = vm.updateSettings(it)
                     scope.launch {
+                        updateJob.join()
                         val id = if (context.readBooleanPreference("create_new_conversation_on_start", true)) {
                             Uuid.random()
                         } else {

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ChatVM.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ChatVM.kt
@@ -126,8 +126,8 @@ class ChatVM(
     val mcpManager = chatService.mcpManager
 
     // 更新设置
-    fun updateSettings(newSettings: Settings) {
-        viewModelScope.launch {
+    fun updateSettings(newSettings: Settings): Job {
+        return viewModelScope.launch {
             val oldSettings = settings.value
             // 检查用户头像是否有变化，如果有则删除旧头像
             checkUserAvatarDelete(oldSettings, newSettings)


### PR DESCRIPTION
## 问题

在侧栏切换助手后，新建对话并发送第一条消息时，新对话有一定概率仍被归到切换前的助手。

助手选择会通过 `ChatVM.updateSettings` 异步写入设置，同时 `ChatDrawer` 会在另一个协程中立即创建并导航到新对话。新对话初始化可能先读取到旧的 `assistantId`，因此该问题表现为偶发。

## 修复

- 让 `ChatVM.updateSettings` 返回对应的 `Job`。
- 切换助手时等待设置更新完成，再创建或导航到目标助手的新对话。

这样新会话初始化读取设置时，助手选择已经完成持久化。