### PR TITLE
fix(chat): 等待会话删除完成后再跳转

### DIFF
--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ChatDrawer.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ChatDrawer.kt
@@ -260,13 +260,12 @@ fun ChatDrawerContent(
                     vm.generateTitle(it, true)
                 },
                 onDelete = {
-                    vm.deleteConversation(it)
-                    // Refresh the conversation list to immediately remove the deleted item
-                    // This fixes the issue where deleted conversations sometimes remain visible
-                    // until manually clicked (issue #747)
-                    conversations.refresh()
-                    if (it.id == current.id) {
-                        navigateToChatPage(navController)
+                    scope.launch {
+                        vm.deleteConversation(it).join()
+                        conversations.refresh()
+                        if (it.id == current.id) {
+                            navigateToChatPage(navController)
+                        }
                     }
                 },
                 onPin = {

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ChatVM.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ChatVM.kt
@@ -265,11 +265,10 @@ class ChatVM(
         }
     }
 
-    fun deleteConversation(conversation: Conversation) {
+    fun deleteConversation(conversation: Conversation): Job =
         viewModelScope.launch {
             conversationRepo.deleteConversation(conversation)
         }
-    }
 
     fun updatePinnedStatus(conversation: Conversation) {
         viewModelScope.launch {


### PR DESCRIPTION
## 问题

[PR #784](https://github.com/rikkahub/rikkahub/pull/784) 为 [Issue #747](https://github.com/rikkahub/rikkahub/issues/747) 增加了 Paging 刷新，但刷新与导航都没有等待异步删除完成。

删除当前打开的会话时，`deleteConversation` 在 `ChatVM` 的 `viewModelScope` 中启动后会立即返回，随后 `clearAndNavigate` 清空导航栈并销毁当前 ViewModel。数据库删除任务因此可能在完成前随 `viewModelScope` 一起被取消，表现为会话偶发未被删除。同时，提前执行的 `conversations.refresh()` 也可能读取到删除前的数据。

## 修改

- 让 `ChatVM.deleteConversation` 返回删除任务
- 等待删除任务完成后再刷新会话列表
- 删除当前会话时，仅在删除完成后跳转到新会话

这样可以保证数据库删除先于 Paging 刷新和页面导航完成。