### PR TITLE
fix(ai): DeepSeek 强制回放历史 reasoning_content，修复思考模式工具调用 400

### DIFF
--- a/ai/src/main/java/me/rerere/ai/provider/providers/openai/ChatCompletionsAPI.kt
+++ b/ai/src/main/java/me/rerere/ai/provider/providers/openai/ChatCompletionsAPI.kt
@@ -265,7 +265,9 @@ class ChatCompletionsAPI(
                 "messages",
                 buildMessages(
                     messages = messages,
-                    includeHistoryReasoning = providerSetting.includeHistoryReasoning,
+                    // DeepSeek 思考模式下，工具调用轮次必须回传 reasoning_content，否则 400；
+                    // 其余轮次回传会被服务端忽略，因此对该 host 强制回放历史思考（#1587）
+                    includeHistoryReasoning = providerSetting.includeHistoryReasoning || host == "api.deepseek.com",
                     supportInputModalities = params.model.inputModalities,
                 )
             )

--- a/ai/src/test/java/me/rerere/ai/provider/providers/openai/ChatCompletionsAPIMessageTest.kt
+++ b/ai/src/test/java/me/rerere/ai/provider/providers/openai/ChatCompletionsAPIMessageTest.kt
@@ -1,12 +1,16 @@
 package me.rerere.ai.provider.providers.openai
 
 import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import me.rerere.ai.core.MessageRole
 import me.rerere.ai.provider.Modality
+import me.rerere.ai.provider.Model
+import me.rerere.ai.provider.ProviderSetting
+import me.rerere.ai.provider.TextGenerationParams
 import me.rerere.ai.ui.UIMessage
 import me.rerere.ai.ui.UIMessagePart
 import me.rerere.ai.util.KeyRoulette
@@ -49,6 +53,29 @@ class ChatCompletionsAPIMessageTest {
             includeHistoryReasoning,
             listOf(Modality.TEXT, Modality.IMAGE)
         ) as JsonArray
+    }
+
+    // Helper to invoke private buildChatCompletionRequest via reflection and return its messages array
+    private fun buildRequestMessages(
+        baseUrl: String,
+        includeHistoryReasoning: Boolean,
+        messages: List<UIMessage>,
+    ): JsonArray {
+        val method = ChatCompletionsAPI::class.java.getDeclaredMethod(
+            "buildChatCompletionRequest",
+            List::class.java,
+            TextGenerationParams::class.java,
+            ProviderSetting.OpenAI::class.java,
+            Boolean::class.javaPrimitiveType
+        )
+        method.isAccessible = true
+        val params = TextGenerationParams(model = Model(modelId = "test-model"))
+        val providerSetting = ProviderSetting.OpenAI(
+            baseUrl = baseUrl,
+            includeHistoryReasoning = includeHistoryReasoning,
+        )
+        val body = method.invoke(api, messages, params, providerSetting, true) as JsonObject
+        return body.getValue("messages").jsonArray
     }
 
     @Test
@@ -383,6 +410,59 @@ class ChatCompletionsAPIMessageTest {
         assertEquals("assistant", result[1].jsonObject["role"]?.jsonPrimitive?.content)
         assertEquals("thinking", result[1].jsonObject["reasoning_content"]?.jsonPrimitive?.content)
         assertEquals("", result[1].jsonObject["content"]?.jsonPrimitive?.content)
+    }
+
+    // #1587: DeepSeek 思考模式下工具调用轮次必须回传 reasoning_content，否则 API 400；
+    // 其余轮次回传会被服务端忽略，因此 api.deepseek.com 强制回放历史思考，无视开关
+    @Test
+    fun `deepseek host forces history reasoning replay even when disabled`() {
+        val messages = listOf(
+            UIMessage.user("Question 1"),
+            UIMessage(
+                role = MessageRole.ASSISTANT,
+                parts = listOf(
+                    UIMessagePart.Reasoning(reasoning = "thinking"),
+                    UIMessagePart.Text("answer")
+                )
+            )
+        )
+
+        val result = buildRequestMessages(
+            baseUrl = "https://api.deepseek.com/v1",
+            includeHistoryReasoning = false,
+            messages = messages,
+        )
+
+        val assistant = result.single {
+            it.jsonObject["role"]?.jsonPrimitive?.content == "assistant"
+        }.jsonObject
+        assertEquals("thinking", assistant["reasoning_content"]?.jsonPrimitive?.content)
+    }
+
+    // #1587 对照组：非 deepseek host 仍然尊重 includeHistoryReasoning 开关
+    @Test
+    fun `other hosts still strip history reasoning when disabled`() {
+        val messages = listOf(
+            UIMessage.user("Question 1"),
+            UIMessage(
+                role = MessageRole.ASSISTANT,
+                parts = listOf(
+                    UIMessagePart.Reasoning(reasoning = "thinking"),
+                    UIMessagePart.Text("answer")
+                )
+            )
+        )
+
+        val result = buildRequestMessages(
+            baseUrl = "https://api.openai.com/v1",
+            includeHistoryReasoning = false,
+            messages = messages,
+        )
+
+        val assistant = result.single {
+            it.jsonObject["role"]?.jsonPrimitive?.content == "assistant"
+        }.jsonObject
+        assertFalse(assistant.containsKey("reasoning_content"))
     }
 
     // ==================== Helper Functions ====================


### PR DESCRIPTION
Fixes #1587

## 问题

DeepSeek 思考模式（thinking enabled）下，如果用户在 provider 设置里关闭了 `includeHistoryReasoning`，历史 assistant 消息中的 `reasoning_content` 会被剥掉。而 DeepSeek 官方文档要求：**含工具调用（tool_calls）的轮次必须回传 `reasoning_content`，否则返回 400**。

## 修复

对 `api.deepseek.com` 强制回放历史思考内容，无视 `includeHistoryReasoning` 开关：

```kotlin
includeHistoryReasoning = providerSetting.includeHistoryReasoning || host == "api.deepseek.com"
```

安全性：DeepSeek 文档明确说明，非工具调用轮次即使回传 `reasoning_content` 也会被服务端忽略，因此"永远回放"对 DeepSeek 无副作用；其他 host 行为不变。

## 测试

- `deepseek host forces history reasoning replay even when disabled`：deepseek host + 开关关闭 → messages 仍含 `reasoning_content`
- `other hosts still strip history reasoning when disabled`：对照组（OpenAI host）→ 正常剥除

`./gradlew :ai:testDebugUnitTest` 全绿。