### PR TITLE
fix(ai): 月之暗面 K2.6 思考开启时发送 thinking.keep=all，启用保留式思考

### DIFF
--- a/ai/src/main/java/me/rerere/ai/provider/providers/openai/ChatCompletionsAPI.kt
+++ b/ai/src/main/java/me/rerere/ai/provider/providers/openai/ChatCompletionsAPI.kt
@@ -381,6 +381,11 @@ class ChatCompletionsAPI(
                     "api.moonshot.cn" -> {
                         put("thinking", buildJsonObject {
                             put("type", if (!level.isEnabled) "disabled" else "enabled")
+                            // K2.6 的 thinking.keep 默认为 null（忽略历史思考），思考开启时
+                            // 需显式传 "all" 才是保留式思考；文档推荐与 enabled 搭配（#1586）
+                            if (level.isEnabled && ModelRegistry.KIMI_K2_6.match(params.model.modelId)) {
+                                put("keep", "all")
+                            }
                         })
                     }
 

--- a/ai/src/main/java/me/rerere/ai/registry/ModelRegistry.kt
+++ b/ai/src/main/java/me/rerere/ai/registry/ModelRegistry.kt
@@ -373,7 +373,7 @@ object ModelRegistry {
         toolReasoningAbility()
     }
 
-    private val KIMI_K2_6 = defineModel {
+    val KIMI_K2_6 = defineModel {
         tokens("kimi", "k", "2", "6")
         visionInput()
         toolReasoningAbility()

--- a/ai/src/test/java/me/rerere/ai/provider/providers/openai/ChatCompletionsAPIMoonshotTest.kt
+++ b/ai/src/test/java/me/rerere/ai/provider/providers/openai/ChatCompletionsAPIMoonshotTest.kt
@@ -1,0 +1,89 @@
+package me.rerere.ai.provider.providers.openai
+
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import me.rerere.ai.core.ReasoningLevel
+import me.rerere.ai.provider.Model
+import me.rerere.ai.provider.ModelAbility
+import me.rerere.ai.provider.ProviderSetting
+import me.rerere.ai.provider.TextGenerationParams
+import me.rerere.ai.ui.UIMessage
+import me.rerere.ai.util.KeyRoulette
+import okhttp3.OkHttpClient
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Unit tests for Moonshot (api.moonshot.cn) thinking.keep handling:
+ * - K2.6 kept-thinking via thinking.keep = "all" (#1586)
+ */
+class ChatCompletionsAPIMoonshotTest {
+
+    private lateinit var api: ChatCompletionsAPI
+
+    @Before
+    fun setUp() {
+        api = ChatCompletionsAPI(OkHttpClient(), KeyRoulette.default())
+    }
+
+    // Helper to invoke private buildChatCompletionRequest via reflection
+    private fun buildRequest(
+        modelId: String,
+        reasoningLevel: ReasoningLevel,
+    ): JsonObject {
+        val method = ChatCompletionsAPI::class.java.getDeclaredMethod(
+            "buildChatCompletionRequest",
+            List::class.java,
+            TextGenerationParams::class.java,
+            ProviderSetting.OpenAI::class.java,
+            Boolean::class.javaPrimitiveType
+        )
+        method.isAccessible = true
+        val model = Model(
+            modelId = modelId,
+            abilities = listOf(ModelAbility.REASONING)
+        )
+        val params = TextGenerationParams(
+            model = model,
+            reasoningLevel = reasoningLevel,
+        )
+        val providerSetting = ProviderSetting.OpenAI(baseUrl = "https://api.moonshot.cn/v1")
+        return method.invoke(
+            api,
+            listOf(UIMessage.user("hi")),
+            params,
+            providerSetting,
+            true
+        ) as JsonObject
+    }
+
+    // #1586: K2.6 思考开启时发送 thinking.keep = "all"（保留式思考）
+    @Test
+    fun `k2_6 sends thinking keep all when reasoning enabled`() {
+        val body = buildRequest("kimi-k2.6", ReasoningLevel.HIGH)
+        val thinking = body["thinking"]?.jsonObject
+        assertEquals("enabled", thinking?.get("type")?.jsonPrimitive?.content)
+        assertEquals("all", thinking?.get("keep")?.jsonPrimitive?.content)
+    }
+
+    // #1586: K2.6 关闭思考时不发送 keep（文档推荐 keep 与 enabled 搭配）
+    @Test
+    fun `k2_6 omits keep when reasoning disabled`() {
+        val body = buildRequest("kimi-k2.6", ReasoningLevel.OFF)
+        val thinking = body["thinking"]?.jsonObject
+        assertEquals("disabled", thinking?.get("type")?.jsonPrimitive?.content)
+        assertFalse(thinking?.containsKey("keep") == true)
+    }
+
+    // #1586: K2.5 不支持 keep 参数，即使思考开启也不发送
+    @Test
+    fun `k2_5 never sends keep`() {
+        val body = buildRequest("kimi-k2.5", ReasoningLevel.HIGH)
+        val thinking = body["thinking"]?.jsonObject
+        assertEquals("enabled", thinking?.get("type")?.jsonPrimitive?.content)
+        assertFalse(thinking?.containsKey("keep") == true)
+    }
+}


### PR DESCRIPTION
Fixes #1586

## 问题

月之暗面 K2.6 的 `thinking.keep` 参数默认为 `null`（忽略历史思考），要启用保留式思考（kept thinking）必须显式传 `"all"`。当前客户端只发送 `thinking.type`，导致 K2.6 的多轮对话中历史思考被丢弃。

## 修复

`api.moonshot.cn` 方言分支中，模型命中 `KIMI_K2_6` 且思考开启时：

```json
{"thinking": {"type": "enabled", "keep": "all"}}
```

- 文档推荐 `keep` 与 `type: enabled` 搭配，因此 `disabled` 时不发送 `keep`
- K2.5 不支持 `keep` 参数，不发送
- 将 `ModelRegistry.KIMI_K2_6` 从 private 提升为可访问（与 K2_5/K3 等保持一致）

## 测试

新增 `ChatCompletionsAPIMoonshotTest`：
- K2.6 + 思考开启 → `thinking.keep == "all"`
- K2.6 + 关闭思考 → 无 `keep` 字段
- K2.5 + 思考开启 → 无 `keep` 字段

`./gradlew :ai:testDebugUnitTest` 全绿。

注：本 PR 与 #1585（moonshot 方言按模型分派）修改同一区域，若 #1585 先合并我会 rebase 适配。