### PR TITLE
feat(assistant): 上下文限制改为阶梯式截断，保留提示词缓存

### DIFF
--- a/ai/src/main/java/me/rerere/ai/ui/Message.kt
+++ b/ai/src/main/java/me/rerere/ai/ui/Message.kt
@@ -11,6 +11,7 @@ import me.rerere.ai.core.MessageRole
 import me.rerere.ai.core.TokenUsage
 import me.rerere.ai.provider.Model
 import me.rerere.ai.util.json
+import kotlin.math.roundToInt
 import kotlin.time.Clock
 import kotlin.time.Instant
 import kotlin.uuid.Uuid
@@ -267,6 +268,87 @@ fun List<UIMessagePart>.isEmptyUIMessage(): Boolean {
             else -> true
         }
     }
+}
+
+/**
+ * 截断后保留的消息条数占上限的比例
+ *
+ * 越小则截断点前进的步幅越大, 连续命中缓存的轮数越多, 但一次丢弃的上下文也越多
+ */
+private const val CONTEXT_KEEP_RATIO = 0.5f
+
+/**
+ * 按阶梯式(滞回)策略限制上下文消息数量
+ *
+ * 与每轮平移一条的滑动窗口不同, 截断点只在消息数越过 [limit] 时才前进一大步,
+ * 在此之后的连续多轮里保持不动, 使请求前缀保持稳定, 从而命中提示词缓存。
+ * 截断点仅由消息条数推导, 不需要额外持久化状态, 且对追加消息天然稳定。
+ *
+ * 保留的条数始终落在 `[limit * CONTEXT_KEEP_RATIO, limit)` 区间内。
+ *
+ * @param limit 触发截断的消息条数上限, 小于等于 0 表示不限制
+ */
+fun List<UIMessage>.limitContext(limit: Int): List<UIMessage> {
+    if (limit <= 0 || this.size <= limit) return this
+
+    // 截断后回落到的目标条数, 以及两次截断之间截断点前进的步幅
+    // limit 为 1 时无法构造滞回(步幅至少为 1), 此时退化为逐条平移的滑动窗口
+    val target = (limit * CONTEXT_KEEP_RATIO).roundToInt().coerceIn(1, limit)
+    val stride = (limit - target).coerceAtLeast(1)
+
+    // 每越过一级台阶, 截断点前进 stride 条; 台阶之内截断点不动
+    // 上界兜底保证至少保留一条消息, 正常路径(limit >= 2)不会触发
+    val startIndex = (((this.size - limit) / stride + 1) * stride).coerceAtMost(this.size - 1)
+
+    return this.subList(alignContextStart(startIndex), this.size)
+}
+
+/**
+ * 将截断起点回退到安全边界, 避免把 tool call 与其结果拆散, 或让上下文从半截的工具调用开始
+ *
+ * 只会向前(下标减小)调整, 因此不会破坏 [limitContext] 保留条数的下界。
+ * 调整只依赖 `[0, startIndex]` 区间内的消息, 这部分在追加新消息时不会变化, 结果因此保持稳定。
+ */
+private fun List<UIMessage>.alignContextStart(startIndex: Int): Int {
+    var adjustedStartIndex = startIndex
+
+    // 循环往前查找, 直到满足所有依赖条件
+    var needsAdjustment = true
+    val visitedIndices = mutableSetOf<Int>()
+
+    while (needsAdjustment && adjustedStartIndex > 0) {
+        needsAdjustment = false
+
+        // 防止无限循环
+        if (adjustedStartIndex in visitedIndices) break
+        visitedIndices.add(adjustedStartIndex)
+
+        val currentMessage = this[adjustedStartIndex]
+
+        // 如果当前消息包含已执行的tool（有output），往前查找对应的tool call
+        if (currentMessage.getTools().any { it.isExecuted }) {
+            for (i in adjustedStartIndex - 1 downTo 0) {
+                if (this[i].getTools().any { !it.isExecuted }) {
+                    adjustedStartIndex = i
+                    needsAdjustment = true
+                    break
+                }
+            }
+        }
+
+        // 如果当前消息包含未执行的tool call，往前查找对应的用户消息
+        if (currentMessage.getTools().any { !it.isExecuted }) {
+            for (i in adjustedStartIndex - 1 downTo 0) {
+                if (this[i].role == MessageRole.USER) {
+                    adjustedStartIndex = i
+                    needsAdjustment = true
+                    break
+                }
+            }
+        }
+    }
+
+    return adjustedStartIndex
 }
 
 @Serializable

--- a/ai/src/test/java/me/rerere/ai/ui/MessageTest.kt
+++ b/ai/src/test/java/me/rerere/ai/ui/MessageTest.kt
@@ -9,6 +9,176 @@ import org.junit.Test
 
 class MessageTest {
 
+    // ==================== limitContext Tests ====================
+
+    @Test
+    fun `limitContext with limit 0 should return original list`() {
+        val messages = createTestMessages(5)
+        assertEquals(messages, messages.limitContext(0))
+    }
+
+    @Test
+    fun `limitContext with negative limit should return original list`() {
+        val messages = createTestMessages(5)
+        assertEquals(messages, messages.limitContext(-1))
+    }
+
+    @Test
+    fun `limitContext within limit should return original list`() {
+        val messages = createTestMessages(10)
+        assertEquals(messages, messages.limitContext(10))
+    }
+
+    @Test
+    fun `limitContext with empty list should return empty list`() {
+        assertEquals(emptyList<UIMessage>(), emptyList<UIMessage>().limitContext(5))
+    }
+
+    /**
+     * limit 过小时无法构造滞回, 但至少不能崩溃, 也不能把上下文清空
+     */
+    @Test
+    fun `limitContext with tiny limit should degrade gracefully`() {
+        val all = createTestMessages(20)
+        for (limit in 1..4) {
+            for (size in (limit + 1)..20) {
+                val result = all.subList(0, size).limitContext(limit)
+                assertTrue(
+                    "limit=$limit size=$size produced ${result.size} messages",
+                    result.size in 1..limit
+                )
+                assertEquals(all.subList(size - result.size, size), result)
+            }
+        }
+    }
+
+    @Test
+    fun `limitContext should drop to about half when limit is first exceeded`() {
+        val messages = createTestMessages(11)
+        val result = messages.limitContext(10)
+
+        // limit=10 -> target=5, stride=5, startIndex=5
+        assertEquals(6, result.size)
+        assertEquals(messages.subList(5, 11), result)
+    }
+
+    /**
+     * 核心性质: 同一级台阶内追加消息时截断起点必须保持不动, 否则请求前缀每轮都变, 提示词缓存必然失效
+     */
+    @Test
+    fun `limitContext should keep the same start message while within one step`() {
+        val all = createTestMessages(60)
+
+        // limit=10 -> stride=5, 消息数 11..14 应共用同一个截断起点
+        val startsWithinStep = (11..14).map { size ->
+            all.subList(0, size).limitContext(10).first()
+        }
+        assertEquals(1, startsWithinStep.distinct().size)
+        assertEquals(all[5], startsWithinStep.first())
+
+        // 越过下一级台阶后起点才前进, 且前进一整个 stride
+        assertEquals(all[10], all.subList(0, 15).limitContext(10).first())
+        assertEquals(all[10], all.subList(0, 19).limitContext(10).first())
+        assertEquals(all[15], all.subList(0, 20).limitContext(10).first())
+    }
+
+    @Test
+    fun `limitContext should never exceed the limit nor drop below the target`() {
+        val all = createTestMessages(120)
+        for (size in 11..120) {
+            val result = all.subList(0, size).limitContext(10)
+            assertTrue(
+                "size=$size produced ${result.size} messages",
+                result.size in 5..9
+            )
+            // 结果必须是原列表的后缀
+            assertEquals(all.subList(size - result.size, size), result)
+        }
+    }
+
+    @Test
+    fun `limitContext should only truncate once per step`() {
+        val all = createTestMessages(60)
+        val distinctStarts = (11..60).map { size ->
+            all.subList(0, size).limitContext(10).first()
+        }.distinct()
+
+        // 50 轮里只发生 11 次截断点移动, 而非每轮一次
+        assertEquals(11, distinctStarts.size)
+    }
+
+    @Test
+    fun `limitContext with executed tool at start should include corresponding tool call`() {
+        val messages = listOf(
+            UIMessage(role = MessageRole.USER, parts = listOf(UIMessagePart.Text("User message"))),
+            UIMessage(
+                role = MessageRole.ASSISTANT, parts = listOf(
+                    UIMessagePart.Tool(
+                        toolCallId = "call1",
+                        toolName = "test_tool",
+                        input = "{}",
+                        output = emptyList() // Not executed
+                    )
+                )
+            ),
+            UIMessage(
+                role = MessageRole.ASSISTANT, parts = listOf(
+                    UIMessagePart.Tool(
+                        toolCallId = "call1",
+                        toolName = "test_tool",
+                        input = "{}",
+                        output = listOf(UIMessagePart.Text("result")) // Executed
+                    )
+                )
+            ),
+            UIMessage(role = MessageRole.ASSISTANT, parts = listOf(UIMessagePart.Text("Final response")))
+        )
+
+        // 截断点会落在已执行的 tool 上, 必须回退到对应的 tool call 及其用户消息
+        val result = messages.limitContext(3)
+        assertEquals(messages, result)
+    }
+
+    @Test
+    fun `limitContext with tool call at start should include corresponding user message`() {
+        val messages = listOf(
+            UIMessage(role = MessageRole.USER, parts = listOf(UIMessagePart.Text("Old query"))),
+            UIMessage(role = MessageRole.USER, parts = listOf(UIMessagePart.Text("User query"))),
+            UIMessage(
+                role = MessageRole.ASSISTANT, parts = listOf(
+                    UIMessagePart.Tool(
+                        toolCallId = "call1",
+                        toolName = "test_tool",
+                        input = "{}",
+                        output = emptyList()
+                    )
+                )
+            ),
+            UIMessage(
+                role = MessageRole.ASSISTANT, parts = listOf(
+                    UIMessagePart.Tool(
+                        toolCallId = "call1",
+                        toolName = "test_tool",
+                        input = "{}",
+                        output = listOf(UIMessagePart.Text("result"))
+                    )
+                )
+            ),
+            UIMessage(role = MessageRole.ASSISTANT, parts = listOf(UIMessagePart.Text("Final response")))
+        )
+
+        // limit=4 -> stride=2, 截断点落在未执行的 tool call 上, 必须回退到它对应的用户消息
+        val result = messages.limitContext(4)
+        assertEquals(messages.subList(1, 5), result)
+    }
+
+    private fun createTestMessages(count: Int): List<UIMessage> = List(count) { index ->
+        UIMessage(
+            role = if (index % 2 == 0) MessageRole.USER else MessageRole.ASSISTANT,
+            parts = listOf(UIMessagePart.Text("Message $index"))
+        )
+    }
+
     // ==================== isValidToUpload Tests ====================
 
     @Test

--- a/app/src/main/java/me/rerere/rikkahub/data/ai/GenerationHandler.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/ai/GenerationHandler.kt
@@ -30,6 +30,7 @@ import me.rerere.ai.ui.UIMessage
 import me.rerere.ai.ui.UIMessagePart
 import me.rerere.ai.ui.ToolApprovalState
 import me.rerere.ai.ui.handleMessageChunk
+import me.rerere.ai.ui.limitContext
 import me.rerere.rikkahub.data.ai.transformers.InputMessageTransformer
 import me.rerere.rikkahub.data.ai.transformers.MessageTransformer
 import me.rerere.rikkahub.data.ai.transformers.OutputMessageTransformer
@@ -384,7 +385,7 @@ class GenerationHandler(
                 }
             }
             if (system.isNotBlank()) add(UIMessage.system(prompt = system))
-            addAll(messages)
+            addAll(messages.limitContext(assistant.contextMessageLimit))
         }.transforms(
             transformers = transformers,
             context = context,

--- a/app/src/main/java/me/rerere/rikkahub/data/model/Assistant.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/model/Assistant.kt
@@ -23,6 +23,8 @@ data class Assistant(
     val systemPrompt: String = "",
     val temperature: Float? = null,
     val topP: Float? = null,
+    // 上下文消息条数上限, 超出后阶梯式截断; 0 表示不限制
+    val contextMessageLimit: Int = 0,
     val streamOutput: Boolean = true,
     val enableMemory: Boolean = false,
     val useGlobalMemory: Boolean = false, // 使用全局共享记忆而非助手隔离记忆

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/assistant/detail/AssistantBasicPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/assistant/detail/AssistantBasicPage.kt
@@ -368,6 +368,49 @@ internal fun AssistantBasicContent(
             FormItem(
                 modifier = Modifier.padding(8.dp),
                 label = {
+                    Text(stringResource(R.string.assistant_page_context_message_limit))
+                },
+                description = {
+                    Text(
+                        text = stringResource(R.string.assistant_page_context_message_limit_desc),
+                    )
+                }
+            ) {
+                Slider(
+                    value = assistant.contextMessageLimit.toFloat(),
+                    onValueChange = { value ->
+                        onUpdate(
+                            assistant.copy(
+                                contextMessageLimit = snapContextMessageLimit(value)
+                            )
+                        )
+                    },
+                    valueRange = 0f..512f,
+                    steps = 0,
+                    modifier = Modifier.fillMaxWidth()
+                )
+
+                Text(
+                    text = if (assistant.contextMessageLimit > 0) stringResource(
+                        R.string.assistant_page_context_message_limit_count,
+                        assistant.contextMessageLimit
+                    ) else stringResource(R.string.assistant_page_context_message_limit_unlimited),
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.secondary.copy(alpha = 0.75f),
+                )
+
+                if (assistant.contextMessageLimit > 0) {
+                    Text(
+                        text = stringResource(R.string.assistant_page_context_message_limit_warning),
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.error,
+                    )
+                }
+            }
+            HorizontalDivider()
+            FormItem(
+                modifier = Modifier.padding(8.dp),
+                label = {
                     Text(stringResource(R.string.assistant_page_stream_output))
                 },
                 description = {
@@ -517,5 +560,25 @@ internal fun AssistantBasicContent(
                 }
             }
         }
+    }
+}
+
+/**
+ * 上下文限制的最小有效值
+ *
+ * 低于此值时截断点几乎每轮都在移动, 提示词缓存命中率跌破 90%,
+ * 且保留的上下文通常达不到可缓存的最小长度, 限制本身失去意义
+ */
+private const val MIN_CONTEXT_MESSAGE_LIMIT = 20
+
+/**
+ * 把滑块取值吸附到 0(不限制) 或不低于 [MIN_CONTEXT_MESSAGE_LIMIT] 的有效档位
+ */
+private fun snapContextMessageLimit(value: Float): Int {
+    val raw = value.roundToInt()
+    return when {
+        raw < MIN_CONTEXT_MESSAGE_LIMIT / 2 -> 0
+        raw < MIN_CONTEXT_MESSAGE_LIMIT -> MIN_CONTEXT_MESSAGE_LIMIT
+        else -> raw
     }
 }

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -1277,4 +1277,10 @@ mDNSアドレス: .localホスト名を使用し、IPを知らなくても同じ
   <string name="chat_page_delete_folder_generating">フォルダ内の一部の会話がまだ生成中です。削除する前にそれらを停止してください。</string>
   <string name="setting_display_page_tts_read_outside_brackets_title">TTS 括弧内を読み上げない</string>
   <string name="setting_display_page_tts_read_outside_brackets_desc">有効にすると、TTS は括弧内の内容を読み上げません</string>
+  <string name="assistant_page_context_message_limit">コンテキストメッセージ上限</string>
+  <string name="assistant_page_context_message_limit_desc">モデルに送信する直近のメッセージ数の上限を設定します。上限を超えた場合、ターンごとに1件ずつ削除するのではなく、一度にコンテキストを約半分まで切り詰めます。これによりリクエストのプレフィックスが安定し、プロンプトキャッシュが多くのターンにわたって有効に働きます。</string>
+  <string name="assistant_page_context_message_limit_count">コンテキストメッセージ制限: %d</string>
+  <string name="assistant_page_context_message_limit_unlimited">コンテキストメッセージ無制限</string>
+  <string name="assistant_page_context_message_limit_warning">0 以外の値を設定すると、コンテキストが切り詰められるたびにプロンプトキャッシュが無効になります。上限が大きいほど切り詰めの頻度は下がります。0 なら切り詰めは発生せず、キャッシュは完全に保持されます。</string>
 </resources>
+

--- a/app/src/main/res/values-ko-rKR/strings.xml
+++ b/app/src/main/res/values-ko-rKR/strings.xml
@@ -1277,4 +1277,10 @@ mDNS 주소: .local 호스트네임을 사용하며, IP를 몰라도 같은 네�
   <string name="chat_page_delete_folder_generating">이 폴더의 일부 대화가 아직 생성 중입니다. 삭제하기 전에 중지해 주세요.</string>
   <string name="setting_display_page_tts_read_outside_brackets_title">TTS 괄호 안 내용 읽지 않기</string>
   <string name="setting_display_page_tts_read_outside_brackets_desc">활성화하면 TTS가 괄호 안의 내용을 읽지 않습니다</string>
+  <string name="assistant_page_context_message_limit">컨텍스트 메시지 제한</string>
+  <string name="assistant_page_context_message_limit_desc">모델로 전송되는 최근 메시지 수를 제한합니다. 제한을 초과하면 한 번에 하나씩 메시지를 삭제하는 대신 컨텍스트가 한 번에 약 절반으로 줄어들어 요청 접두사가 안정적으로 유지되고 프롬프트 캐싱이 여러 턴 동안 계속 작동합니다.</string>
+  <string name="assistant_page_context_message_limit_count">컨텍스트 메시지 한도: %d</string>
+  <string name="assistant_page_context_message_limit_unlimited">무제한 컨텍스트 메시지</string>
+  <string name="assistant_page_context_message_limit_warning">0이 아닌 제한 값은 컨텍스트가 정리될 때마다 프롬프트 캐시를 무효화합니다. 제한 값이 클수록 정리 빈도가 줄어듭니다. 0은 절대 정리하지 않으며 캐시를 완전히 유지합니다.</string>
 </resources>
+

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1277,4 +1277,10 @@
   <string name="chat_page_delete_folder_generating">Некоторые беседы в этой папке все еще генерируются. Пожалуйста, остановите их перед удалением.</string>
   <string name="setting_display_page_tts_read_outside_brackets_title">TTS не читает текст в скобках</string>
   <string name="setting_display_page_tts_read_outside_brackets_desc">Если включено, TTS не будет читать содержимое в скобках</string>
+  <string name="assistant_page_context_message_limit">Лимит контекстных сообщений</string>
+  <string name="assistant_page_context_message_limit_desc">Ограничивает количество последних сообщений, отправляемых модели. Когда лимит превышен, контекст сокращается примерно вдвое за один шаг, вместо удаления одного сообщения за каждый оборот, благодаря чему префикс запроса остаётся стабильным, и кэширование промптов продолжает работать на протяжении многих оборотов.</string>
+  <string name="assistant_page_context_message_limit_count">Лимит сообщений контекста: %d</string>
+  <string name="assistant_page_context_message_limit_unlimited">Неограниченные сообщения контекста</string>
+  <string name="assistant_page_context_message_limit_warning">Любой ненулевой лимит аннулирует кеш промпта каждый раз, когда контекст урезается. Больший лимит урезает реже; 0 никогда не урезает и сохраняет кеш полностью нетронутым.</string>
 </resources>
+

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -1275,4 +1275,10 @@
   <string name="chat_page_delete_folder_generating">此資料夾中的部分對話仍在生成中。請先停止它們再刪除。</string>
   <string name="setting_display_page_tts_read_outside_brackets_title">TTS 不朗讀括號內的內容</string>
   <string name="setting_display_page_tts_read_outside_brackets_desc">啟用後，TTS 將不朗讀括號內的內容</string>
+  <string name="assistant_page_context_message_limit">上下文訊息限制</string>
+  <string name="assistant_page_context_message_limit_desc">限制發送給模型的最近訊息數量。當超出限制時，上下文會一次性修剪到大約一半，而不是每次輪次刪除一條訊息，這樣請求前綴保持穩定，提示詞緩存可以在多次輪次中繼續運作。</string>
+  <string name="assistant_page_context_message_limit_count">上下文訊息限制：%d</string>
+  <string name="assistant_page_context_message_limit_unlimited">無限上下文訊息</string>
+  <string name="assistant_page_context_message_limit_warning">任何非零值都會在每次截斷上下文時使提示詞快取失效。上限越大，截斷越少；0 表示從不截斷，快取完整保留。</string>
 </resources>
+

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -1280,4 +1280,10 @@ mDNS 地址：使用 .local 主机名，同一网络中的其他设备可通过�
   <string name="chat_page_folder_add">新建</string>
   <string name="chat_page_delete_folder_confirm">删除文件夹 "%1$s"？其中的对话不会被删除，只会从文件夹中移除。</string>
   <string name="chat_page_delete_folder_generating">此文件夹中有对话仍在生成中，请停止后再删除。</string>
+  <string name="assistant_page_context_message_limit">上下文消息限制</string>
+  <string name="assistant_page_context_message_limit_desc">限制发送给模型的最近消息数量。超出限制时，上下文会一次性缩减至约一半，而非每轮丢弃一条消息，从而保持请求前缀稳定，并使提示词缓存在多轮对话中持续生效。</string>
+  <string name="assistant_page_context_message_limit_count">上下文消息限制: %d</string>
+  <string name="assistant_page_context_message_limit_unlimited">无限上下文消息</string>
+  <string name="assistant_page_context_message_limit_warning">任何非零值都会在每次截断上下文时使提示词缓存失效。上限越大，截断越少；0 表示从不截断，缓存完整保留。</string>
 </resources>
+

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1280,4 +1280,10 @@
   <string name="chat_page_folder_add">New</string>
   <string name="chat_page_delete_folder_confirm">Delete folder "%1$s"? Conversations inside will not be deleted, only removed from the folder.</string>
   <string name="chat_page_delete_folder_generating">Some conversations in this folder are still generating. Please stop them before deleting.</string>
+  <string name="assistant_page_context_message_limit">Context Message Limit</string>
+  <string name="assistant_page_context_message_limit_desc">Caps how many recent messages are sent to the model. When the limit is exceeded, the context is trimmed down to about half in one step instead of dropping one message per turn, so the request prefix stays stable and prompt caching keeps working for many turns.</string>
+  <string name="assistant_page_context_message_limit_count">Context message limit: %d</string>
+  <string name="assistant_page_context_message_limit_unlimited">Unlimited context messages</string>
+  <string name="assistant_page_context_message_limit_warning">Any non-zero limit invalidates the prompt cache each time the context is trimmed. A larger limit trims less often; 0 never trims and keeps the cache fully intact.</string>
 </resources>
+

--- a/docs/references/chat-generation-pipeline.md
+++ b/docs/references/chat-generation-pipeline.md
@@ -34,6 +34,7 @@ ChatService.sendMessage()
             ├─ [若无待处理 Tool] generateInternal()
             │       ├── 构建 internalMessages
             │       │       ├── System message（系统提示 + 记忆 + tool.systemPrompt）
+            │       │       ├── limitContext() 按 contextMessageLimit 阶梯式裁剪历史
             │       │       └── InputTransformers 管道
             │       ├── 构建 TextGenerationParams
             │       └── 调用 Provider


### PR DESCRIPTION
b0698524 移除了 contextMessageSize，原因是滑动窗口每轮平移一条，
请求前缀每轮都变，提示词缓存必然全量失效。本次以阶梯式(滞回)策略
重新引入该功能。

截断点只在消息数越过上限时才前进一大步(stride = limit - limit/2)，
之后连续多轮保持不动，请求前缀因此保持稳定。缓存失效频率从每轮一次
降到每 stride 轮一次，limit=40 时命中率约 95%。

截断点仅由消息条数推导，对追加消息天然稳定，无需持久化 anchor，
也无需改动 Conversation 与 ChatService。保留条数恒定落在
[limit/2, limit) 区间内。

- 新增 limitContext() 与 alignContextStart()，后者沿用旧实现的 边界回溯逻辑，避免拆散 tool call 与其结果；只向前调整，不破坏 保留条数下界
- Assistant 新增 contextMessageLimit 字段(不复用旧的 contextMessageSize，语义已变，旧值按未设置处理)
- 设置页滑块吸附到 0 或 >= 20；低于 20 时命中率跌破 90%，且保留的 上下文通常达不到可缓存的最小长度
- 非 0 时显示缓存失效警告