### PR TITLE
feat: 新增从本地 JSON 文件导入聊天记录功能

### DIFF
--- a/app/src/main/java/me/rerere/rikkahub/data/sync/importer/LocalJsonImporter.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/sync/importer/LocalJsonImporter.kt
@@ -1,0 +1,158 @@
+package me.rerere.rikkahub.data.sync.importer
+
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toLocalDateTime
+import me.rerere.ai.core.MessageRole
+import me.rerere.ai.ui.UIMessage
+import me.rerere.ai.ui.UIMessagePart
+import me.rerere.rikkahub.data.model.Conversation
+import me.rerere.rikkahub.data.model.MessageNode
+import me.rerere.rikkahub.data.repository.ConversationRepository
+import me.rerere.rikkahub.data.repository.MemoryRepository
+import me.rerere.rikkahub.utils.JsonInstant
+import java.io.File
+import java.nio.charset.StandardCharsets
+import java.time.OffsetDateTime
+import java.time.format.DateTimeFormatter
+import java.util.UUID
+import kotlin.time.Instant as KotlinInstant
+import kotlin.uuid.Uuid
+
+data class LocalJsonImportResult(
+    val importedConversations: Int,
+    val skippedExistingConversations: Int,
+    val importedMemories: Int,
+    val hasSystemPrompt: Boolean,
+)
+
+object LocalJsonImporter {
+    suspend fun import(
+        file: File,
+        assistantId: Uuid,
+        conversationRepo: ConversationRepository,
+        memoryRepo: MemoryRepository,
+    ): LocalJsonImportResult {
+        val root = JsonInstant.parseToJsonElement(file.readText()).jsonObject
+
+        val aiCharacter = root["aiCharacter"]?.jsonObjectOrNull
+        val conversations = root["conversations"]?.jsonArrayOrNull ?: emptyList()
+        val memories = root["memories"]?.jsonArrayOrNull ?: emptyList()
+
+        val hasSystemPrompt = aiCharacter?.get("systemPrompt")?.jsonPrimitive?.contentOrNull?.isNotBlank() == true
+
+        var importedConversations = 0
+        var skippedExistingConversations = 0
+
+        for (convElement in conversations) {
+            val conv = convElement.jsonObject
+            val convId = conv["id"]?.jsonPrimitive?.contentOrNull ?: continue
+            val stableId = stableUuid("localjson:conv:$convId")
+
+            if (conversationRepo.existsConversationById(stableId)) {
+                skippedExistingConversations++
+                continue
+            }
+
+            val title = conv["title"]?.jsonPrimitive?.contentOrNull?.takeIf { it.isNotBlank() } ?: convId
+            val messages = conv["messages"]?.jsonArrayOrNull ?: continue
+
+            var minTimestamp: java.time.Instant? = null
+            var maxTimestamp: java.time.Instant? = null
+
+            val nodes = messages.mapNotNull { msgElement ->
+                val msg = msgElement.jsonObject
+                val speaker = msg["speaker"]?.jsonPrimitive?.contentOrNull ?: return@mapNotNull null
+                val text = msg["text"]?.jsonPrimitive?.contentOrNull?.takeIf { it.isNotBlank() }
+                    ?: return@mapNotNull null
+                val timestamp = msg["timestamp"]?.jsonPrimitive?.contentOrNull?.let { parseTimestamp(it) }
+
+                val role = when (speaker) {
+                    "ai" -> MessageRole.ASSISTANT
+                    "user" -> MessageRole.USER
+                    else -> return@mapNotNull null
+                }
+
+                val javaInstant = timestamp ?: java.time.Instant.now()
+                if (minTimestamp == null || javaInstant < minTimestamp) minTimestamp = javaInstant
+                if (maxTimestamp == null || javaInstant > maxTimestamp) maxTimestamp = javaInstant
+
+                val messageId = stableUuid("localjson:msg:$convId:${msg.hashCode()}")
+                val nodeId = stableUuid("localjson:node:$convId:${msg.hashCode()}")
+
+                MessageNode(
+                    id = nodeId,
+                    messages = listOf(
+                        UIMessage(
+                            id = messageId,
+                            role = role,
+                            parts = listOf(UIMessagePart.Text(text)),
+                            createdAt = KotlinInstant.fromEpochMilliseconds(javaInstant.toEpochMilli())
+                                .toLocalDateTime(TimeZone.currentSystemDefault()),
+                        )
+                    ),
+                    selectIndex = 0,
+                )
+            }
+
+            if (nodes.isEmpty()) continue
+
+            conversationRepo.insertConversation(
+                Conversation(
+                    id = stableId,
+                    assistantId = assistantId,
+                    title = title,
+                    messageNodes = nodes,
+                    createAt = minTimestamp ?: java.time.Instant.now(),
+                    updateAt = maxTimestamp ?: java.time.Instant.now(),
+                )
+            )
+            importedConversations++
+        }
+
+        var importedMemories = 0
+        for (memElement in memories) {
+            val content = memElement.jsonPrimitive?.contentOrNull?.takeIf { it.isNotBlank() } ?: continue
+            memoryRepo.addMemory(assistantId.toString(), content)
+            importedMemories++
+        }
+
+        return LocalJsonImportResult(
+            importedConversations = importedConversations,
+            skippedExistingConversations = skippedExistingConversations,
+            importedMemories = importedMemories,
+            hasSystemPrompt = hasSystemPrompt,
+        )
+    }
+
+    fun extractSystemPrompt(file: File): String? {
+        val root = JsonInstant.parseToJsonElement(file.readText()).jsonObject
+        return root["aiCharacter"]?.jsonObjectOrNull
+            ?.get("systemPrompt")?.jsonPrimitive?.contentOrNull
+            ?.takeIf { it.isNotBlank() }
+    }
+
+    private fun parseTimestamp(text: String): java.time.Instant? {
+        return runCatching {
+            OffsetDateTime.parse(text, DateTimeFormatter.ISO_OFFSET_DATE_TIME).toInstant()
+        }.getOrElse {
+            runCatching { java.time.Instant.parse(text) }.getOrNull()
+        }
+    }
+
+    private fun stableUuid(value: String): Uuid =
+        Uuid.parse(UUID.nameUUIDFromBytes(value.toByteArray(StandardCharsets.UTF_8)).toString())
+
+    private val JsonElement.jsonObjectOrNull: JsonObject?
+        get() = this as? JsonObject
+
+    private val JsonElement.jsonArrayOrNull: JsonArray?
+        get() = this as? JsonArray
+}

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/backup/BackupVM.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/backup/BackupVM.kt
@@ -11,8 +11,11 @@ import me.rerere.rikkahub.data.datastore.Settings
 import me.rerere.rikkahub.data.datastore.SettingsStore
 import me.rerere.rikkahub.data.datastore.WebDavConfig
 import me.rerere.rikkahub.data.repository.ConversationRepository
+import me.rerere.rikkahub.data.repository.MemoryRepository
 import me.rerere.rikkahub.data.sync.importer.ChatboxImporter
 import me.rerere.rikkahub.data.sync.importer.CherryStudioProviderImporter
+import me.rerere.rikkahub.data.sync.importer.LocalJsonImporter
+import me.rerere.rikkahub.data.sync.importer.LocalJsonImportResult
 import me.rerere.rikkahub.data.sync.webdav.WebDavBackupItem
 import me.rerere.rikkahub.data.sync.webdav.WebDavSync
 import me.rerere.rikkahub.data.sync.S3BackupItem
@@ -27,6 +30,7 @@ class BackupVM(
     private val webDavSync: WebDavSync,
     private val s3Sync: S3Sync,
     private val conversationRepository: ConversationRepository,
+    private val memoryRepository: MemoryRepository,
 ) : ViewModel() {
     val settings = settingsStore.settingsFlow.stateIn(
         scope = viewModelScope,
@@ -157,6 +161,32 @@ class BackupVM(
                 providers = importProviders + settings.value.providers,
             )
         )
+    }
+
+    suspend fun restoreFromLocalJson(file: File): LocalJsonImportResult {
+        val result = LocalJsonImporter.import(
+            file = file,
+            assistantId = settings.value.assistantId,
+            conversationRepo = conversationRepository,
+            memoryRepo = memoryRepository,
+        )
+
+        val targetAssistantId = settings.value.assistantId
+        if (result.hasSystemPrompt) {
+            settingsStore.update(
+                settings.value.copy(
+                    assistants = settings.value.assistants.map { assistant ->
+                        if (assistant.id == targetAssistantId) {
+                            assistant.copy(
+                                systemPrompt = LocalJsonImporter.extractSystemPrompt(file) ?: "",
+                                enableMemory = true,
+                            )
+                        } else assistant
+                    }
+                )
+            )
+        }
+        return result
     }
 
     // S3 Backup methods

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/backup/tabs/ImportExportTab.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/backup/tabs/ImportExportTab.kt
@@ -47,7 +47,7 @@ fun ImportExportTab(
     var isExporting by remember { mutableStateOf(false) }
     var isRestoring by remember { mutableStateOf(false) }
 
-    // 导入类型：local 为本地备份，chatbox 为 Chatbox 导入，cherry 为 Cherry Studio 导入
+    // local 本地备份 / chatbox Chatbox / cherry Cherry Studio / json 本地JSON导入
     var importType by remember { mutableStateOf("local") }
 
     // 创建文件保存的launcher
@@ -147,6 +147,18 @@ fun ImportExportTab(
                             vm.restoreFromCherryStudio(tempFile)
 
                             // 清理临时文件
+                            tempFile.delete()
+                        }
+
+                        "json" -> {
+                            val tempFile =
+                                File(context.cacheDir, "temp_json_${System.currentTimeMillis()}.json")
+                            context.contentResolver.openInputStream(sourceUri)?.use { inputStream ->
+                                FileOutputStream(tempFile).use { outputStream ->
+                                    inputStream.copyTo(outputStream)
+                                }
+                            }
+                            vm.restoreFromLocalJson(tempFile)
                             tempFile.delete()
                         }
                     }
@@ -273,6 +285,24 @@ fun ImportExportTab(
                     supportingContent = { Text(stringResource(R.string.backup_page_import_cherry_studio_desc)) },
                     leadingContent = {
                         if (isRestoring && importType == "cherry") {
+                            CircularWavyProgressIndicator(modifier = Modifier.size(24.dp))
+                        } else {
+                            Icon(HugeIcons.FileImport, null)
+                        }
+                    },
+                )
+
+                item(
+                    onClick = if (!isRestoring) {
+                        {
+                            importType = "json"
+                            openDocumentLauncher.launch(arrayOf("application/json"))
+                        }
+                    } else null,
+                    headlineContent = { Text(stringResource(R.string.backup_page_import_from_local_json)) },
+                    supportingContent = { Text(stringResource(R.string.backup_page_import_local_json_desc)) },
+                    leadingContent = {
+                        if (isRestoring && importType == "json") {
                             CircularWavyProgressIndicator(modifier = Modifier.size(24.dp))
                         } else {
                             Icon(HugeIcons.FileImport, null)

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -178,6 +178,8 @@
   <string name="backup_page_import_chatbox_desc">导入 ChatBox 提供商配置和完整聊天记录</string>
   <string name="backup_page_import_cherry_studio_desc">导入Cherry Studio提供商配置</string>
   <string name="backup_page_import_desc">导入本地备份文件</string>
+  <string name="backup_page_import_from_local_json">从本地导入聊天记录</string>
+  <string name="backup_page_import_local_json_desc">导入本地 JSON 格式的聊天记录文件</string>
   <string name="backup_page_import_export">本地</string>
   <string name="backup_page_import_from_chatbox">从ChatBox导入</string>
   <string name="backup_page_import_from_cherry_studio">从Cherry Studio导入</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -178,6 +178,8 @@
   <string name="backup_page_import_chatbox_desc">Import ChatBox provider configurations and full chat history</string>
   <string name="backup_page_import_cherry_studio_desc">Import Cherry Studio provider configurations</string>
   <string name="backup_page_import_desc">Import local backup file</string>
+  <string name="backup_page_import_from_local_json">Import from Local File</string>
+  <string name="backup_page_import_local_json_desc">Import chat history from local JSON file</string>
   <string name="backup_page_import_export">Local</string>
   <string name="backup_page_import_from_chatbox">Import from ChatBox</string>
   <string name="backup_page_import_from_cherry_studio">Import from Cherry Studio</string>


### PR DESCRIPTION
- 新增 LocalJsonImporter，支持解析包含对话和记忆的 JSON 文件
- BackupVM 新增 restoreFromLocalJson()，自动写入 systemPrompt 并开启记忆
- ImportExportTab 新增「从本地导入聊天记录」按钮
- 使用 MD5 确定性 UUID，重复导入同一文件不产生重复对话