### PR TITLE
fix(workspace): 非交互命令 stdin 立即 EOF，避免 CLI 工具永久阻塞

### DIFF
--- a/workspace/src/main/java/me/rerere/workspace/ProotShellRunner.kt
+++ b/workspace/src/main/java/me/rerere/workspace/ProotShellRunner.kt
@@ -95,6 +95,10 @@ class ProotShellRunner(
             "TERM=xterm-256color",
             "LANG=C.UTF-8",
             "LC_ALL=C.UTF-8",
+            // 非交互执行约定, 抑制各类 CLI 的交互行为 (确认提示/分页器/颜色转义)
+            "CI=true",
+            "NO_COLOR=1",
+            "PAGER=cat",
             "/bin/bash",
             "-l",
             "-c",

--- a/workspace/src/main/java/me/rerere/workspace/WorkspaceShellRunner.kt
+++ b/workspace/src/main/java/me/rerere/workspace/WorkspaceShellRunner.kt
@@ -42,6 +42,15 @@ fun Process.readResult(timeoutMillis: Long, stdin: ByteArray? = null): Workspace
     val stdout = StreamCollector(inputStream)
     val stderr = StreamCollector(errorStream)
     val stdinWriter = stdin?.let { bytes -> StreamWriter(outputStream, bytes) }
+    if (stdinWriter == null) {
+        // 没有 stdin 输入时立即关闭管道, 让子进程读到 EOF;
+        // 否则 cat/gh/kubectl 等按 isatty 判断的工具会把这根永不写入的管道当成待输入流而永久阻塞
+        try {
+            outputStream.close()
+        } catch (_: IOException) {
+            // 子进程已提前退出导致管道关闭, 忽略
+        }
+    }
     try {
         val finished = waitFor(timeoutMillis, TimeUnit.MILLISECONDS)
         if (!finished) {

--- a/workspace/src/test/java/me/rerere/workspace/ExampleUnitTest.kt
+++ b/workspace/src/test/java/me/rerere/workspace/ExampleUnitTest.kt
@@ -118,6 +118,25 @@ class ExampleUnitTest {
     }
 
     @Test
+    fun commandWithoutStdinGetsImmediateEof() {
+        val baseDir = Files.createTempDirectory("workspace-stdin-eof-test").toFile()
+        val manager = WorkspaceManager(baseDir)
+        val root = "test-workspace"
+        manager.ensureWorkspace(root)
+
+        // 不传 stdin 时子进程的 stdin 应立即 EOF; cat 会直接退出而不是等管道输入
+        val result = manager.executeCommand(
+            root = root,
+            command = "cat",
+            timeoutMillis = 10_000,
+        )
+
+        assertFalse(result.timedOut)
+        assertEquals(0, result.exitCode)
+        assertEquals("", result.stdout)
+    }
+
+    @Test
     fun prootRunnerRequiresRootfs() {
         val baseDir = Files.createTempDirectory("workspace-proot-test").toFile()
         val manager = WorkspaceManager(


### PR DESCRIPTION
## 问题

Closes #1604

Agent 沙盒（workspace_shell / proot Ubuntu）中执行命令时，子进程的 stdin 是一根保持打开、但既不写入也永不 EOF 的管道。按 `isatty(0)` 判断工作模式的 CLI 工具（`cat`、`gh`、`ntn`、`kubectl` 等）会把它当成待输入流而**无限阻塞且无报错**。

## 根因

`Process.readResult()`（`WorkspaceShellRunner.kt`）只在调用方显式传入 `stdin` 字节时才创建 `StreamWriter`（写完会关闭管道）；绝大多数调用走 `stdin = null` 默认值，此时 `ProcessBuilder` 默认创建的 stdin 管道永不关闭。两个执行器（`HostShellRunner` / `ProotShellRunner`）都受此影响。

## 修复

- **无 stdin 时立即关闭子进程 stdin 管道**：让子进程读到即时 EOF，与 CI/subprocess 等非交互执行器行为一致。传入 `stdin` 的路径不变（`StreamWriter` 写完本来就会关闭）。
- **proot 沙盒补充非交互环境约定**：`CI=true`、`NO_COLOR=1`、`PAGER=cat`，抑制各类 CLI 的交互行为（确认提示、分页器、颜色转义）。`TERM` 保持 `xterm-256color` 未动，避免退化输出格式。

## 测试

- 新增 `commandWithoutStdinGetsImmediateEof`：不传 stdin 执行 `cat`，断言不超时、退出码 0、无输出。
- `:workspace:testDebugUnitTest` 全部 20 个测试通过。