### PR TITLE
fix(ai): 修复 Grok 生图由于 size 参数导致的 400 报错

### DIFF
--- a/ai/src/main/java/me/rerere/ai/provider/providers/OpenAIProvider.kt
+++ b/ai/src/main/java/me/rerere/ai/provider/providers/OpenAIProvider.kt
@@ -215,7 +215,11 @@ class OpenAIProvider(
                 put("model", params.model.modelId)
                 put("prompt", params.prompt)
                 put("n", params.numOfImages)
-                if (params.size.isNotBlank()) {
+                
+                val isGrok = providerSetting.baseUrl.contains("x.ai", ignoreCase = true) || 
+                    params.model.modelId.contains("grok", ignoreCase = true)
+                
+                if (params.size.isNotBlank() && !isGrok) {
                     put("size", params.size)
                 }
             }


### PR DESCRIPTION
Close #1602. 

通过判定 base_url 和 model_id 是否为 Grok，精准过滤掉不支持的 \size\ 参数，兼容官方地址和中转代理。