### PR TITLE
fix(ai): 修复工具调用后的 Token 显示并持久化全局统计

### DIFF
--- a/ai/src/main/java/me/rerere/ai/provider/ProviderManager.kt
+++ b/ai/src/main/java/me/rerere/ai/provider/ProviderManager.kt
@@ -9,7 +9,11 @@ import okhttp3.OkHttpClient
 /**
  * Provider管理器，负责注册和获取Provider实例
  */
-class ProviderManager(client: OkHttpClient, context: Context) {
+class ProviderManager(
+    client: OkHttpClient,
+    context: Context,
+    private val tokenUsageRecorder: TokenUsageRecorder = TokenUsageRecorder {},
+) {
     // 存储已注册的Provider实例
     private val providers = mutableMapOf<String, Provider<*>>()
 
@@ -26,8 +30,8 @@ class ProviderManager(client: OkHttpClient, context: Context) {
      * @param name Provider名称
      * @param provider Provider实例
      */
-    fun registerProvider(name: String, provider: Provider<*>) {
-        providers[name] = provider
+    fun <T : ProviderSetting> registerProvider(name: String, provider: Provider<T>) {
+        providers[name] = UsageTrackingProvider(provider, tokenUsageRecorder)
     }
 
     /**

--- a/ai/src/main/java/me/rerere/ai/provider/TokenUsageRecorder.kt
+++ b/ai/src/main/java/me/rerere/ai/provider/TokenUsageRecorder.kt
@@ -1,0 +1,60 @@
+package me.rerere.ai.provider
+
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import me.rerere.ai.core.TokenUsage
+import me.rerere.ai.core.merge
+import me.rerere.ai.ui.MessageChunk
+import me.rerere.ai.ui.UIMessage
+import me.rerere.common.android.Logging
+
+fun interface TokenUsageRecorder {
+    suspend fun record(usage: TokenUsage)
+}
+
+internal class UsageTrackingProvider<T : ProviderSetting>(
+    private val delegate: Provider<T>,
+    private val recorder: TokenUsageRecorder,
+) : Provider<T> by delegate {
+    override suspend fun generateText(
+        providerSetting: T,
+        messages: List<UIMessage>,
+        params: TextGenerationParams,
+    ): MessageChunk {
+        return delegate.generateText(providerSetting, messages, params).also { chunk ->
+            chunk.usage?.recordSafely()
+        }
+    }
+
+    override suspend fun streamText(
+        providerSetting: T,
+        messages: List<UIMessage>,
+        params: TextGenerationParams,
+    ): Flow<MessageChunk> = flow {
+        var requestUsage: TokenUsage? = null
+        delegate.streamText(providerSetting, messages, params).collect { chunk ->
+            chunk.usage?.let {
+                requestUsage = requestUsage.merge(it)
+            }
+            emit(chunk)
+        }
+        requestUsage?.recordSafely()
+    }
+
+    private suspend fun TokenUsage.recordSafely() {
+        if (promptTokens == 0 && completionTokens == 0 && cachedTokens == 0) return
+
+        try {
+            recorder.record(this)
+        } catch (cancellation: CancellationException) {
+            throw cancellation
+        } catch (exception: Exception) {
+            Logging.log(TAG, "Failed to record token usage: ${exception.stackTraceToString()}")
+        }
+    }
+
+    private companion object {
+        const val TAG = "UsageTrackingProvider"
+    }
+}

--- a/ai/src/main/java/me/rerere/ai/provider/TokenUsageRecorder.kt
+++ b/ai/src/main/java/me/rerere/ai/provider/TokenUsageRecorder.kt
@@ -9,6 +9,11 @@ import me.rerere.ai.ui.MessageChunk
 import me.rerere.ai.ui.UIMessage
 import me.rerere.common.android.Logging
 
+/**
+ * Application-provided sink for usage from successful text requests.
+ *
+ * The AI layer reports usage without assuming how it is stored.
+ */
 fun interface TokenUsageRecorder {
     suspend fun record(usage: TokenUsage)
 }

--- a/ai/src/test/java/me/rerere/ai/core/TokenUsageTest.kt
+++ b/ai/src/test/java/me/rerere/ai/core/TokenUsageTest.kt
@@ -1,0 +1,44 @@
+package me.rerere.ai.core
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class TokenUsageTest {
+    @Test
+    fun `merge combines fragmented usage from one request`() {
+        val usage = TokenUsage(promptTokens = 120, cachedTokens = 40)
+            .merge(TokenUsage(completionTokens = 30))
+
+        assertEquals(
+            TokenUsage(
+                promptTokens = 120,
+                completionTokens = 30,
+                cachedTokens = 40,
+                totalTokens = 150,
+            ),
+            usage,
+        )
+    }
+
+    @Test
+    fun `merge replaces cumulative snapshots instead of adding them`() {
+        val usage = TokenUsage(promptTokens = 120, completionTokens = 10)
+            .merge(TokenUsage(promptTokens = 120, completionTokens = 30))
+
+        assertEquals(120, usage.promptTokens)
+        assertEquals(30, usage.completionTokens)
+        assertEquals(150, usage.totalTokens)
+    }
+
+    @Test
+    fun `a new request accumulator does not retain previous cached usage`() {
+        val previousRequest = TokenUsage(promptTokens = 120, cachedTokens = 40)
+        val nextRequest = (null as TokenUsage?).merge(
+            TokenUsage(promptTokens = 80, completionTokens = 20)
+        )
+
+        assertEquals(40, previousRequest.cachedTokens)
+        assertEquals(0, nextRequest.cachedTokens)
+        assertEquals(100, nextRequest.totalTokens)
+    }
+}

--- a/ai/src/test/java/me/rerere/ai/provider/UsageTrackingProviderTest.kt
+++ b/ai/src/test/java/me/rerere/ai/provider/UsageTrackingProviderTest.kt
@@ -1,0 +1,152 @@
+package me.rerere.ai.provider
+
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.runBlocking
+import me.rerere.ai.core.TokenUsage
+import me.rerere.ai.ui.MessageChunk
+import me.rerere.ai.ui.UIMessage
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class UsageTrackingProviderTest {
+    private val setting = ProviderSetting.OpenAI()
+    private val params = TextGenerationParams(model = Model())
+
+    @Test
+    fun `non-streaming request is recorded once`() = runBlocking {
+        val recorded = mutableListOf<TokenUsage>()
+        val usage = TokenUsage(promptTokens = 100, completionTokens = 20, totalTokens = 120)
+        val provider = UsageTrackingProvider(
+            delegate = FakeProvider(nonStreamingChunk = chunk(usage)),
+            recorder = TokenUsageRecorder { recorded += it },
+        )
+
+        provider.generateText(setting, emptyList(), params)
+
+        assertEquals(listOf(usage), recorded)
+    }
+
+    @Test
+    fun `streaming snapshots are merged and recorded once`() = runBlocking {
+        val recorded = mutableListOf<TokenUsage>()
+        val provider = UsageTrackingProvider(
+            delegate = FakeProvider(
+                streamingChunks = flowOf(
+                    chunk(TokenUsage(promptTokens = 100, cachedTokens = 30)),
+                    chunk(TokenUsage(promptTokens = 100, completionTokens = 20)),
+                )
+            ),
+            recorder = TokenUsageRecorder { recorded += it },
+        )
+
+        provider.streamText(setting, emptyList(), params).toList()
+
+        assertEquals(
+            listOf(
+                TokenUsage(
+                    promptTokens = 100,
+                    completionTokens = 20,
+                    cachedTokens = 30,
+                    totalTokens = 120,
+                )
+            ),
+            recorded,
+        )
+    }
+
+    @Test
+    fun `empty usage and cancelled streams are not recorded`() = runBlocking {
+        val recorded = mutableListOf<TokenUsage>()
+        val emptyProvider = UsageTrackingProvider(
+            delegate = FakeProvider(nonStreamingChunk = chunk(TokenUsage())),
+            recorder = TokenUsageRecorder { recorded += it },
+        )
+        emptyProvider.generateText(setting, emptyList(), params)
+
+        val cancelledProvider = UsageTrackingProvider(
+            delegate = FakeProvider(
+                streamingChunks = flow {
+                    emit(chunk(TokenUsage(promptTokens = 100)))
+                    throw CancellationException()
+                }
+            ),
+            recorder = TokenUsageRecorder { recorded += it },
+        )
+        try {
+            cancelledProvider.streamText(setting, emptyList(), params).toList()
+        } catch (_: CancellationException) {
+            // Expected.
+        }
+
+        assertTrue(recorded.isEmpty())
+    }
+
+    @Test
+    fun `failed request is not recorded`() = runBlocking {
+        val recorded = mutableListOf<TokenUsage>()
+        val provider = UsageTrackingProvider(
+            delegate = FakeProvider(generationError = IllegalStateException("provider failed")),
+            recorder = TokenUsageRecorder { recorded += it },
+        )
+
+        try {
+            provider.generateText(setting, emptyList(), params)
+        } catch (_: IllegalStateException) {
+            // Expected.
+        }
+
+        assertTrue(recorded.isEmpty())
+    }
+
+    @Test
+    fun `recorder failure does not fail generation`() = runBlocking {
+        val expected = chunk(TokenUsage(promptTokens = 100))
+        val provider = UsageTrackingProvider(
+            delegate = FakeProvider(nonStreamingChunk = expected),
+            recorder = TokenUsageRecorder { error("database unavailable") },
+        )
+
+        val actual = provider.generateText(setting, emptyList(), params)
+
+        assertEquals(expected, actual)
+    }
+
+    private fun chunk(usage: TokenUsage?) = MessageChunk(
+        id = "test",
+        model = "test",
+        choices = emptyList(),
+        usage = usage,
+    )
+
+    private class FakeProvider(
+        private val nonStreamingChunk: MessageChunk = MessageChunk(
+            id = "test",
+            model = "test",
+            choices = emptyList(),
+        ),
+        private val streamingChunks: Flow<MessageChunk> = flowOf(),
+        private val generationError: Exception? = null,
+    ) : Provider<ProviderSetting.OpenAI> {
+        override suspend fun listModels(providerSetting: ProviderSetting.OpenAI): List<Model> = emptyList()
+
+        override suspend fun generateText(
+            providerSetting: ProviderSetting.OpenAI,
+            messages: List<UIMessage>,
+            params: TextGenerationParams,
+        ): MessageChunk {
+            generationError?.let { throw it }
+            return nonStreamingChunk
+        }
+
+        override suspend fun streamText(
+            providerSetting: ProviderSetting.OpenAI,
+            messages: List<UIMessage>,
+            params: TextGenerationParams,
+        ): Flow<MessageChunk> = streamingChunks
+    }
+}

--- a/app/schemas/me.rerere.rikkahub.data.db.AppDatabase/25.json
+++ b/app/schemas/me.rerere.rikkahub.data.db.AppDatabase/25.json
@@ -1,0 +1,599 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 25,
+    "identityHash": "ee8280b16447bb7a3bf9a83d453de476",
+    "entities": [
+      {
+        "tableName": "ConversationEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `assistant_id` TEXT NOT NULL DEFAULT '0950e2dc-9bd5-4801-afa3-aa887aa36b4e', `title` TEXT NOT NULL, `nodes` TEXT NOT NULL, `create_at` INTEGER NOT NULL, `update_at` INTEGER NOT NULL, `suggestions` TEXT NOT NULL DEFAULT '[]', `is_pinned` INTEGER NOT NULL DEFAULT 0, `custom_system_prompt` TEXT NOT NULL DEFAULT '', `mode_injection_ids` TEXT NOT NULL DEFAULT '[]', `lorebook_ids` TEXT NOT NULL DEFAULT '[]', `workspace_cwd` TEXT NOT NULL DEFAULT '', `folder_id` TEXT NOT NULL DEFAULT '', PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "assistantId",
+            "columnName": "assistant_id",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'0950e2dc-9bd5-4801-afa3-aa887aa36b4e'"
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nodes",
+            "columnName": "nodes",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createAt",
+            "columnName": "create_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updateAt",
+            "columnName": "update_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chatSuggestions",
+            "columnName": "suggestions",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'[]'"
+          },
+          {
+            "fieldPath": "isPinned",
+            "columnName": "is_pinned",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "customSystemPrompt",
+            "columnName": "custom_system_prompt",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "modeInjectionIds",
+            "columnName": "mode_injection_ids",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'[]'"
+          },
+          {
+            "fieldPath": "lorebookIds",
+            "columnName": "lorebook_ids",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'[]'"
+          },
+          {
+            "fieldPath": "workspaceCwd",
+            "columnName": "workspace_cwd",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "folderId",
+            "columnName": "folder_id",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "MemoryEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `assistant_id` TEXT NOT NULL, `content` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "assistantId",
+            "columnName": "assistant_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "GenMediaEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `path` TEXT NOT NULL, `model_id` TEXT NOT NULL, `prompt` TEXT NOT NULL, `create_at` INTEGER NOT NULL, `type` TEXT NOT NULL DEFAULT 'image_generation', `source_paths` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "path",
+            "columnName": "path",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelId",
+            "columnName": "model_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "prompt",
+            "columnName": "prompt",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createAt",
+            "columnName": "create_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'image_generation'"
+          },
+          {
+            "fieldPath": "sourcePaths",
+            "columnName": "source_paths",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "message_node",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `conversation_id` TEXT NOT NULL, `node_index` INTEGER NOT NULL, `messages` TEXT NOT NULL, `select_index` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`conversation_id`) REFERENCES `ConversationEntity`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "conversationId",
+            "columnName": "conversation_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nodeIndex",
+            "columnName": "node_index",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "messages",
+            "columnName": "messages",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "selectIndex",
+            "columnName": "select_index",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_message_node_conversation_id",
+            "unique": false,
+            "columnNames": [
+              "conversation_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_message_node_conversation_id` ON `${TABLE_NAME}` (`conversation_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "ConversationEntity",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "conversation_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "managed_files",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `folder` TEXT NOT NULL, `relative_path` TEXT NOT NULL, `display_name` TEXT NOT NULL, `mime_type` TEXT NOT NULL, `size_bytes` INTEGER NOT NULL, `created_at` INTEGER NOT NULL, `updated_at` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "folder",
+            "columnName": "folder",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "relativePath",
+            "columnName": "relative_path",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "display_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mimeType",
+            "columnName": "mime_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sizeBytes",
+            "columnName": "size_bytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_managed_files_relative_path",
+            "unique": true,
+            "columnNames": [
+              "relative_path"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_managed_files_relative_path` ON `${TABLE_NAME}` (`relative_path`)"
+          },
+          {
+            "name": "index_managed_files_folder",
+            "unique": false,
+            "columnNames": [
+              "folder"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_managed_files_folder` ON `${TABLE_NAME}` (`folder`)"
+          }
+        ]
+      },
+      {
+        "tableName": "favorites",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `type` TEXT NOT NULL, `ref_key` TEXT NOT NULL, `ref_json` TEXT NOT NULL, `snapshot_json` TEXT NOT NULL, `meta_json` TEXT, `created_at` INTEGER NOT NULL, `updated_at` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "refKey",
+            "columnName": "ref_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "refJson",
+            "columnName": "ref_json",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "snapshotJson",
+            "columnName": "snapshot_json",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "metaJson",
+            "columnName": "meta_json",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_favorites_ref_key",
+            "unique": true,
+            "columnNames": [
+              "ref_key"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_favorites_ref_key` ON `${TABLE_NAME}` (`ref_key`)"
+          },
+          {
+            "name": "index_favorites_type",
+            "unique": false,
+            "columnNames": [
+              "type"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_favorites_type` ON `${TABLE_NAME}` (`type`)"
+          },
+          {
+            "name": "index_favorites_created_at",
+            "unique": false,
+            "columnNames": [
+              "created_at"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_favorites_created_at` ON `${TABLE_NAME}` (`created_at`)"
+          }
+        ]
+      },
+      {
+        "tableName": "workspaces",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `root` TEXT NOT NULL, `shell_status` TEXT NOT NULL, `created_at` INTEGER NOT NULL, `updated_at` INTEGER NOT NULL, `last_access_at` INTEGER, `tool_approvals` TEXT NOT NULL DEFAULT '{}', PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "root",
+            "columnName": "root",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "shellStatus",
+            "columnName": "shell_status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastAccessAt",
+            "columnName": "last_access_at",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "toolApprovals",
+            "columnName": "tool_approvals",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'{}'"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_workspaces_root",
+            "unique": true,
+            "columnNames": [
+              "root"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_workspaces_root` ON `${TABLE_NAME}` (`root`)"
+          },
+          {
+            "name": "index_workspaces_updated_at",
+            "unique": false,
+            "columnNames": [
+              "updated_at"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_workspaces_updated_at` ON `${TABLE_NAME}` (`updated_at`)"
+          }
+        ]
+      },
+      {
+        "tableName": "conversation_folder",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `assistant_id` TEXT NOT NULL, `name` TEXT NOT NULL, `sort_index` INTEGER NOT NULL DEFAULT 0, `create_at` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "assistantId",
+            "columnName": "assistant_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortIndex",
+            "columnName": "sort_index",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "createAt",
+            "columnName": "create_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_conversation_folder_assistant_id",
+            "unique": false,
+            "columnNames": [
+              "assistant_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_conversation_folder_assistant_id` ON `${TABLE_NAME}` (`assistant_id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "token_usage_summary",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `prompt_tokens` INTEGER NOT NULL, `completion_tokens` INTEGER NOT NULL, `cached_tokens` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "promptTokens",
+            "columnName": "prompt_tokens",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "completionTokens",
+            "columnName": "completion_tokens",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cachedTokens",
+            "columnName": "cached_tokens",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'ee8280b16447bb7a3bf9a83d453de476')"
+    ]
+  }
+}

--- a/app/src/androidTest/java/me/rerere/rikkahub/data/db/dao/TokenUsageDAOTest.kt
+++ b/app/src/androidTest/java/me/rerere/rikkahub/data/db/dao/TokenUsageDAOTest.kt
@@ -1,0 +1,52 @@
+package me.rerere.rikkahub.data.db.dao
+
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.runBlocking
+import me.rerere.rikkahub.data.db.AppDatabase
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class TokenUsageDAOTest {
+    private lateinit var database: AppDatabase
+    private lateinit var dao: TokenUsageDAO
+
+    @Before
+    fun setUp() {
+        database = Room.inMemoryDatabaseBuilder(
+            ApplicationProvider.getApplicationContext(),
+            AppDatabase::class.java,
+        ).build()
+        dao = database.tokenUsageDao()
+    }
+
+    @After
+    fun tearDown() {
+        database.close()
+    }
+
+    @Test
+    fun addUsage_accumulatesAtomically() = runBlocking {
+        List(20) {
+            async {
+                dao.addUsage(
+                    promptTokens = 10,
+                    completionTokens = 2,
+                    cachedTokens = 3,
+                )
+            }
+        }.awaitAll()
+
+        val usage = dao.getUsage()
+        assertEquals(200L, usage.promptTokens)
+        assertEquals(40L, usage.completionTokens)
+        assertEquals(60L, usage.cachedTokens)
+    }
+}

--- a/app/src/androidTest/java/me/rerere/rikkahub/data/db/migrations/Migration_24_25_Test.kt
+++ b/app/src/androidTest/java/me/rerere/rikkahub/data/db/migrations/Migration_24_25_Test.kt
@@ -1,0 +1,109 @@
+package me.rerere.rikkahub.data.db.migrations
+
+import android.content.ContentValues
+import android.database.sqlite.SQLiteDatabase
+import androidx.room.testing.MigrationTestHelper
+import androidx.sqlite.db.framework.FrameworkSQLiteOpenHelperFactory
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import me.rerere.ai.core.MessageRole
+import me.rerere.ai.core.TokenUsage
+import me.rerere.ai.ui.UIMessage
+import me.rerere.ai.ui.UIMessagePart
+import me.rerere.rikkahub.data.db.AppDatabase
+import me.rerere.rikkahub.utils.JsonInstant
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import kotlin.uuid.Uuid
+
+@RunWith(AndroidJUnit4::class)
+class Migration_24_25_Test {
+    private val testDatabase = "migration-24-25-test"
+
+    @get:Rule
+    val helper = MigrationTestHelper(
+        InstrumentationRegistry.getInstrumentation(),
+        AppDatabase::class.java,
+        emptyList(),
+        FrameworkSQLiteOpenHelperFactory(),
+    )
+
+    @Test
+    fun migrate24To25_backfillsAndPreservesTokenUsage() {
+        val conversationId = Uuid.random().toString()
+        val messages = listOf(
+            UIMessage(
+                role = MessageRole.USER,
+                parts = listOf(UIMessagePart.Text("Question")),
+            ),
+            UIMessage(
+                role = MessageRole.ASSISTANT,
+                parts = listOf(UIMessagePart.Text("Answer")),
+                usage = TokenUsage(
+                    promptTokens = 120,
+                    completionTokens = 30,
+                    cachedTokens = 40,
+                    totalTokens = 150,
+                ),
+            ),
+        )
+
+        helper.createDatabase(testDatabase, 24).apply {
+            insert(
+                "ConversationEntity",
+                SQLiteDatabase.CONFLICT_NONE,
+                ContentValues().apply {
+                    put("id", conversationId)
+                    put("title", "Migration test")
+                    put("nodes", "[]")
+                    put("create_at", 0)
+                    put("update_at", 0)
+                },
+            )
+            insert(
+                "message_node",
+                SQLiteDatabase.CONFLICT_NONE,
+                ContentValues().apply {
+                    put("id", Uuid.random().toString())
+                    put("conversation_id", conversationId)
+                    put("node_index", 0)
+                    put("messages", JsonInstant.encodeToString(messages))
+                    put("select_index", 0)
+                },
+            )
+            close()
+        }
+
+        val db = helper.runMigrationsAndValidate(
+            testDatabase,
+            25,
+            true,
+            Migration_24_25,
+        )
+
+        assertUsage(db, prompt = 120, completion = 30, cached = 40)
+
+        db.execSQL("DELETE FROM ConversationEntity WHERE id = ?", arrayOf(conversationId))
+
+        assertUsage(db, prompt = 120, completion = 30, cached = 40)
+        db.close()
+    }
+
+    private fun assertUsage(
+        db: androidx.sqlite.db.SupportSQLiteDatabase,
+        prompt: Long,
+        completion: Long,
+        cached: Long,
+    ) {
+        db.query(
+            "SELECT prompt_tokens, completion_tokens, cached_tokens FROM token_usage_summary WHERE id = 0"
+        ).use { cursor ->
+            cursor.moveToFirst()
+            assertEquals(prompt, cursor.getLong(0))
+            assertEquals(completion, cursor.getLong(1))
+            assertEquals(cached, cursor.getLong(2))
+        }
+    }
+}

--- a/app/src/main/java/me/rerere/rikkahub/data/ai/GenerationHandler.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/ai/GenerationHandler.kt
@@ -17,6 +17,7 @@ import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 import me.rerere.ai.core.MessageRole
 import me.rerere.ai.core.ReasoningLevel
+import me.rerere.ai.core.TokenUsage
 import me.rerere.ai.core.Tool
 import me.rerere.ai.core.merge
 import me.rerere.ai.provider.CustomBody
@@ -415,40 +416,35 @@ class GenerationHandler(
                 addAll(model.customBodies)
             }
         )
-        if (stream) {
+        val chunks = if (stream) {
             providerImpl.streamText(
                 providerSetting = provider,
                 messages = internalMessages,
                 params = params
-            ).collect {
-                messages = messages.handleMessageChunk(chunk = it, model = model)
-                it.usage?.let { usage ->
-                    messages = messages.mapIndexed { index, message ->
-                        if (index == messages.lastIndex) {
-                            message.copy(usage = message.usage.merge(usage))
-                        } else {
-                            message
-                        }
-                    }
-                }
-                onUpdateMessages(messages)
-            }
-        } else {
-            val chunk = providerImpl.generateText(
-                providerSetting = provider,
-                messages = internalMessages,
-                params = params,
             )
+        } else {
+            flow {
+                emit(
+                    providerImpl.generateText(
+                        providerSetting = provider,
+                        messages = internalMessages,
+                        params = params,
+                    )
+                )
+            }
+        }
+
+        var requestUsage: TokenUsage? = null
+        chunks.collect { chunk ->
             messages = messages.handleMessageChunk(chunk = chunk, model = model)
-            chunk.usage?.let { usage ->
-                messages = messages.mapIndexed { index, message ->
-                    if (index == messages.lastIndex) {
-                        message.copy(
-                            usage = message.usage.merge(usage)
-                        )
-                    } else {
-                        message
-                    }
+            chunk.usage?.let {
+                requestUsage = requestUsage.merge(it)
+            }
+            messages = messages.mapIndexed { index, message ->
+                if (index == messages.lastIndex) {
+                    message.copy(usage = requestUsage)
+                } else {
+                    message
                 }
             }
             onUpdateMessages(messages)

--- a/app/src/main/java/me/rerere/rikkahub/data/db/AppDatabase.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/db/AppDatabase.kt
@@ -13,6 +13,7 @@ import me.rerere.rikkahub.data.db.dao.GenMediaDAO
 import me.rerere.rikkahub.data.db.dao.ManagedFileDAO
 import me.rerere.rikkahub.data.db.dao.MemoryDAO
 import me.rerere.rikkahub.data.db.dao.MessageNodeDAO
+import me.rerere.rikkahub.data.db.dao.TokenUsageDAO
 import me.rerere.rikkahub.data.db.dao.WorkspaceDAO
 import me.rerere.rikkahub.data.db.entity.ConversationEntity
 import me.rerere.rikkahub.data.db.entity.FavoriteEntity
@@ -21,6 +22,7 @@ import me.rerere.rikkahub.data.db.entity.GenMediaEntity
 import me.rerere.rikkahub.data.db.entity.ManagedFileEntity
 import me.rerere.rikkahub.data.db.entity.MemoryEntity
 import me.rerere.rikkahub.data.db.entity.MessageNodeEntity
+import me.rerere.rikkahub.data.db.entity.TokenUsageSummaryEntity
 import me.rerere.rikkahub.data.db.entity.WorkspaceEntity
 import me.rerere.rikkahub.data.db.migrations.Migration_16_17
 import me.rerere.rikkahub.data.db.migrations.Migration_22_23
@@ -37,8 +39,9 @@ import me.rerere.rikkahub.utils.JsonInstant
         FavoriteEntity::class,
         WorkspaceEntity::class,
         FolderEntity::class,
+        TokenUsageSummaryEntity::class,
     ],
-    version = 24,
+    version = 25,
     autoMigrations = [
         AutoMigration(from = 1, to = 2),
         AutoMigration(from = 2, to = 3),
@@ -77,6 +80,8 @@ abstract class AppDatabase : RoomDatabase() {
     abstract fun workspaceDao(): WorkspaceDAO
 
     abstract fun folderDao(): FolderDAO
+
+    abstract fun tokenUsageDao(): TokenUsageDAO
 }
 
 object TokenUsageConverter {

--- a/app/src/main/java/me/rerere/rikkahub/data/db/RoomTokenUsageRecorder.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/db/RoomTokenUsageRecorder.kt
@@ -1,0 +1,17 @@
+package me.rerere.rikkahub.data.db
+
+import me.rerere.ai.core.TokenUsage
+import me.rerere.ai.provider.TokenUsageRecorder
+import me.rerere.rikkahub.data.db.dao.TokenUsageDAO
+
+class RoomTokenUsageRecorder(
+    private val tokenUsageDAO: TokenUsageDAO,
+) : TokenUsageRecorder {
+    override suspend fun record(usage: TokenUsage) {
+        tokenUsageDAO.addUsage(
+            promptTokens = usage.promptTokens.toLong(),
+            completionTokens = usage.completionTokens.toLong(),
+            cachedTokens = usage.cachedTokens.toLong(),
+        )
+    }
+}

--- a/app/src/main/java/me/rerere/rikkahub/data/db/dao/MessageNodeDAO.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/db/dao/MessageNodeDAO.kt
@@ -42,31 +42,19 @@ interface MessageNodeDAO {
 
     // 使用 @RawQuery 绕过 Room 编译期校验，以便使用 json_each() 虚拟表
     @RawQuery
-    suspend fun getTokenStatsRaw(query: SupportSQLiteQuery): MessageTokenStats
+    suspend fun getMessageCountRaw(query: SupportSQLiteQuery): Int
 
     @RawQuery
     suspend fun getMessageCountPerDayRaw(query: SupportSQLiteQuery): List<MessageDayCount>
 }
 
-data class MessageTokenStats(
-    val totalMessages: Int = 0,
-    val promptTokens: Long = 0,
-    val completionTokens: Long = 0,
-    val cachedTokens: Long = 0,
-)
-
 data class MessageDayCount(val day: String, val count: Int)
 
-// SQLite json_each() 展开 messages JSON 数组，json_extract() 提取 Token 字段并聚合
-private val TOKEN_STATS_SQL = SimpleSQLiteQuery(
-    "SELECT COUNT(*) AS totalMessages, " +
-        "COALESCE(SUM(CAST(json_extract(j.value, '$.usage.promptTokens') AS INTEGER)), 0) AS promptTokens, " +
-        "COALESCE(SUM(CAST(json_extract(j.value, '$.usage.completionTokens') AS INTEGER)), 0) AS completionTokens, " +
-        "COALESCE(SUM(CAST(json_extract(j.value, '$.usage.cachedTokens') AS INTEGER)), 0) AS cachedTokens " +
-        "FROM message_node mn, json_each(mn.messages) j"
+private val MESSAGE_COUNT_SQL = SimpleSQLiteQuery(
+    "SELECT COUNT(*) FROM message_node mn, json_each(mn.messages) j"
 )
 
-suspend fun MessageNodeDAO.getTokenStats(): MessageTokenStats = getTokenStatsRaw(TOKEN_STATS_SQL)
+suspend fun MessageNodeDAO.getMessageCount(): Int = getMessageCountRaw(MESSAGE_COUNT_SQL)
 
 // 按用户消息的 createdAt 字段（LocalDateTime ISO 字符串前10位即日期）统计每日消息数
 suspend fun MessageNodeDAO.getMessageCountPerDay(startDate: String): List<MessageDayCount> =
@@ -81,4 +69,3 @@ suspend fun MessageNodeDAO.getMessageCountPerDay(startDate: String): List<Messag
             arrayOf(startDate)
         )
     )
-

--- a/app/src/main/java/me/rerere/rikkahub/data/db/dao/TokenUsageDAO.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/db/dao/TokenUsageDAO.kt
@@ -1,0 +1,40 @@
+package me.rerere.rikkahub.data.db.dao
+
+import androidx.room.Dao
+import androidx.room.Query
+
+@Dao
+interface TokenUsageDAO {
+    @Query(
+        """
+        INSERT INTO token_usage_summary (id, prompt_tokens, completion_tokens, cached_tokens)
+        VALUES (0, :promptTokens, :completionTokens, :cachedTokens)
+        ON CONFLICT(id) DO UPDATE SET
+            prompt_tokens = prompt_tokens + excluded.prompt_tokens,
+            completion_tokens = completion_tokens + excluded.completion_tokens,
+            cached_tokens = cached_tokens + excluded.cached_tokens
+        """
+    )
+    suspend fun addUsage(
+        promptTokens: Long,
+        completionTokens: Long,
+        cachedTokens: Long,
+    )
+
+    @Query(
+        """
+        SELECT
+            COALESCE(SUM(prompt_tokens), 0) AS promptTokens,
+            COALESCE(SUM(completion_tokens), 0) AS completionTokens,
+            COALESCE(SUM(cached_tokens), 0) AS cachedTokens
+        FROM token_usage_summary
+        """
+    )
+    suspend fun getUsage(): TokenUsageTotals
+}
+
+data class TokenUsageTotals(
+    val promptTokens: Long = 0,
+    val completionTokens: Long = 0,
+    val cachedTokens: Long = 0,
+)

--- a/app/src/main/java/me/rerere/rikkahub/data/db/entity/TokenUsageSummaryEntity.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/db/entity/TokenUsageSummaryEntity.kt
@@ -1,0 +1,17 @@
+package me.rerere.rikkahub.data.db.entity
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "token_usage_summary")
+data class TokenUsageSummaryEntity(
+    @PrimaryKey
+    val id: Int = 0,
+    @ColumnInfo("prompt_tokens")
+    val promptTokens: Long = 0,
+    @ColumnInfo("completion_tokens")
+    val completionTokens: Long = 0,
+    @ColumnInfo("cached_tokens")
+    val cachedTokens: Long = 0,
+)

--- a/app/src/main/java/me/rerere/rikkahub/data/db/migrations/Migration_24_25.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/db/migrations/Migration_24_25.kt
@@ -1,31 +1,48 @@
 package me.rerere.rikkahub.data.db.migrations
 
+import android.util.Log
 import androidx.room.migration.Migration
 import androidx.sqlite.db.SupportSQLiteDatabase
+import me.rerere.rikkahub.data.db.DatabaseMigrationTracker
 
-object Migration_24_25 : Migration(24, 25) {
+private const val TAG = "Migration_24_25"
+
+val Migration_24_25 = object : Migration(24, 25) {
     override fun migrate(db: SupportSQLiteDatabase) {
-        db.execSQL(
-            """
-            CREATE TABLE IF NOT EXISTS token_usage_summary (
-                id INTEGER NOT NULL,
-                prompt_tokens INTEGER NOT NULL,
-                completion_tokens INTEGER NOT NULL,
-                cached_tokens INTEGER NOT NULL,
-                PRIMARY KEY(id)
-            )
-            """.trimIndent()
-        )
-        db.execSQL(
-            """
-            INSERT INTO token_usage_summary (id, prompt_tokens, completion_tokens, cached_tokens)
-            SELECT
-                0,
-                COALESCE(SUM(CAST(json_extract(j.value, '$.usage.promptTokens') AS INTEGER)), 0),
-                COALESCE(SUM(CAST(json_extract(j.value, '$.usage.completionTokens') AS INTEGER)), 0),
-                COALESCE(SUM(CAST(json_extract(j.value, '$.usage.cachedTokens') AS INTEGER)), 0)
-            FROM message_node mn, json_each(mn.messages) j
-            """.trimIndent()
-        )
+        Log.i(TAG, "migrate: start migrate from 24 to 25 (persisting token usage)")
+        DatabaseMigrationTracker.onMigrationStart(24, 25)
+        try {
+            db.beginTransaction()
+            try {
+                db.execSQL(
+                    """
+                    CREATE TABLE IF NOT EXISTS token_usage_summary (
+                        id INTEGER NOT NULL,
+                        prompt_tokens INTEGER NOT NULL,
+                        completion_tokens INTEGER NOT NULL,
+                        cached_tokens INTEGER NOT NULL,
+                        PRIMARY KEY(id)
+                    )
+                    """.trimIndent()
+                )
+                db.execSQL(
+                    """
+                    INSERT INTO token_usage_summary (id, prompt_tokens, completion_tokens, cached_tokens)
+                    SELECT
+                        0,
+                        COALESCE(SUM(CAST(json_extract(j.value, '$.usage.promptTokens') AS INTEGER)), 0),
+                        COALESCE(SUM(CAST(json_extract(j.value, '$.usage.completionTokens') AS INTEGER)), 0),
+                        COALESCE(SUM(CAST(json_extract(j.value, '$.usage.cachedTokens') AS INTEGER)), 0)
+                    FROM message_node mn, json_each(mn.messages) j
+                    """.trimIndent()
+                )
+                db.setTransactionSuccessful()
+                Log.i(TAG, "migrate: migrate from 24 to 25 success")
+            } finally {
+                db.endTransaction()
+            }
+        } finally {
+            DatabaseMigrationTracker.onMigrationEnd()
+        }
     }
 }

--- a/app/src/main/java/me/rerere/rikkahub/data/db/migrations/Migration_24_25.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/db/migrations/Migration_24_25.kt
@@ -1,0 +1,31 @@
+package me.rerere.rikkahub.data.db.migrations
+
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
+
+object Migration_24_25 : Migration(24, 25) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL(
+            """
+            CREATE TABLE IF NOT EXISTS token_usage_summary (
+                id INTEGER NOT NULL,
+                prompt_tokens INTEGER NOT NULL,
+                completion_tokens INTEGER NOT NULL,
+                cached_tokens INTEGER NOT NULL,
+                PRIMARY KEY(id)
+            )
+            """.trimIndent()
+        )
+        db.execSQL(
+            """
+            INSERT INTO token_usage_summary (id, prompt_tokens, completion_tokens, cached_tokens)
+            SELECT
+                0,
+                COALESCE(SUM(CAST(json_extract(j.value, '$.usage.promptTokens') AS INTEGER)), 0),
+                COALESCE(SUM(CAST(json_extract(j.value, '$.usage.completionTokens') AS INTEGER)), 0),
+                COALESCE(SUM(CAST(json_extract(j.value, '$.usage.cachedTokens') AS INTEGER)), 0)
+            FROM message_node mn, json_each(mn.messages) j
+            """.trimIndent()
+        )
+    }
+}

--- a/app/src/main/java/me/rerere/rikkahub/di/DataSourceModule.kt
+++ b/app/src/main/java/me/rerere/rikkahub/di/DataSourceModule.kt
@@ -12,6 +12,7 @@ import io.requery.android.database.sqlite.RequerySQLiteOpenHelperFactory
 import io.requery.android.database.sqlite.SQLiteCustomExtension
 import kotlinx.serialization.json.Json
 import me.rerere.ai.provider.ProviderManager
+import me.rerere.ai.provider.TokenUsageRecorder
 import me.rerere.common.http.AcceptLanguageBuilder
 import me.rerere.rikkahub.BuildConfig
 import me.rerere.rikkahub.data.ai.AIRequestInterceptor
@@ -23,6 +24,7 @@ import me.rerere.rikkahub.data.api.RikkaHubAPI
 import me.rerere.rikkahub.data.api.SponsorAPI
 import me.rerere.rikkahub.data.datastore.SettingsStore
 import me.rerere.rikkahub.data.db.AppDatabase
+import me.rerere.rikkahub.data.db.RoomTokenUsageRecorder
 import me.rerere.rikkahub.data.db.fts.MessageFtsManager
 import me.rerere.rikkahub.data.db.fts.SimpleDictManager
 import me.rerere.rikkahub.data.db.migrations.Migration_6_7
@@ -30,6 +32,7 @@ import me.rerere.rikkahub.data.db.migrations.Migration_11_12
 import me.rerere.rikkahub.data.db.migrations.Migration_13_14
 import me.rerere.rikkahub.data.db.migrations.Migration_14_15
 import me.rerere.rikkahub.data.db.migrations.Migration_15_16
+import me.rerere.rikkahub.data.db.migrations.Migration_24_25
 import me.rerere.rikkahub.data.ai.mcp.McpManager
 import me.rerere.rikkahub.data.sync.webdav.WebDavSync
 import me.rerere.search.SearchService
@@ -52,7 +55,14 @@ val dataSourceModule = module {
         val context: Context = get()
         Room.databaseBuilder(context, AppDatabase::class.java, "rikka_hub")
             .setJournalMode(RoomDatabase.JournalMode.WRITE_AHEAD_LOGGING)
-            .addMigrations(Migration_6_7, Migration_11_12, Migration_13_14, Migration_14_15, Migration_15_16)
+            .addMigrations(
+                Migration_6_7,
+                Migration_11_12,
+                Migration_13_14,
+                Migration_14_15,
+                Migration_15_16,
+                Migration_24_25,
+            )
             .addCallback(object : RoomDatabase.Callback() {
                 override fun onOpen(db: SupportSQLiteDatabase) {
                     val dictDir = SimpleDictManager.extractDict(context)
@@ -147,6 +157,14 @@ val dataSourceModule = module {
     }
 
     single {
+        get<AppDatabase>().tokenUsageDao()
+    }
+
+    single<TokenUsageRecorder> {
+        RoomTokenUsageRecorder(tokenUsageDAO = get())
+    }
+
+    single {
         MessageFtsManager(get())
     }
 
@@ -212,7 +230,11 @@ val dataSourceModule = module {
     }
 
     single {
-        ProviderManager(client = get(), context = get())
+        ProviderManager(
+            client = get(),
+            context = get(),
+            tokenUsageRecorder = get(),
+        )
     }
 
     single {

--- a/app/src/main/java/me/rerere/rikkahub/ui/components/message/ChatMessage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/message/ChatMessage.kt
@@ -212,10 +212,11 @@ fun ChatMessage(
             assistant = assistant,
         )
 
-        if (shouldShowTokenUsage(message, loading)) {
-            ProvideTextStyle(textStyle) {
-                ChatMessageNerdLine(message = message)
-            }
+        ProvideTextStyle(textStyle) {
+            ChatMessageNerdLine(
+                message = message,
+                loading = loading,
+            )
         }
 
     }
@@ -261,12 +262,6 @@ fun ChatMessage(
             }
         )
     }
-}
-
-internal fun shouldShowTokenUsage(message: UIMessage, loading: Boolean): Boolean {
-    return !loading &&
-        message.usage != null &&
-        message.getTools().all { it.isExecuted }
 }
 
 @OptIn(FlowPreview::class)

--- a/app/src/main/java/me/rerere/rikkahub/ui/components/message/ChatMessage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/message/ChatMessage.kt
@@ -212,8 +212,10 @@ fun ChatMessage(
             assistant = assistant,
         )
 
-        ProvideTextStyle(textStyle) {
-            ChatMessageNerdLine(message = message)
+        if (shouldShowTokenUsage(message, loading)) {
+            ProvideTextStyle(textStyle) {
+                ChatMessageNerdLine(message = message)
+            }
         }
 
     }
@@ -259,6 +261,12 @@ fun ChatMessage(
             }
         )
     }
+}
+
+internal fun shouldShowTokenUsage(message: UIMessage, loading: Boolean): Boolean {
+    return !loading &&
+        message.usage != null &&
+        message.getTools().all { it.isExecuted }
 }
 
 @OptIn(FlowPreview::class)

--- a/app/src/main/java/me/rerere/rikkahub/ui/components/message/ChatMessageNerdLine.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/message/ChatMessageNerdLine.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import kotlinx.datetime.toJavaLocalDateTime
+import me.rerere.ai.core.TokenUsage
 import me.rerere.ai.ui.UIMessage
 import me.rerere.hugeicons.HugeIcons
 import me.rerere.hugeicons.stroke.Clock02
@@ -34,6 +35,7 @@ import java.time.Duration
 @Composable
 fun ChatMessageNerdLine(
     message: UIMessage,
+    loading: Boolean,
     modifier: Modifier = Modifier,
     color: Color = MaterialTheme.colorScheme.secondary.copy(alpha = 0.5f),
 ) {
@@ -46,7 +48,7 @@ fun ChatMessageNerdLine(
                 itemVerticalAlignment = Alignment.CenterVertically,
                 modifier = modifier.padding(horizontal = 4.dp),
             ) {
-                val usage = message.usage
+                val usage = tokenUsageToDisplay(message, loading)
                 if (settings.showTokenUsage && usage != null) {
                     // Input tokens
                     StatsItem(
@@ -63,7 +65,7 @@ fun ChatMessageNerdLine(
                             // Cached tokens
                             if (usage.cachedTokens > 0) {
                                 Text(
-                                    text = "(${message.usage?.cachedTokens?.formatNumber() ?: "0"} cached)"
+                                    text = "(${usage.cachedTokens.formatNumber()} cached)"
                                 )
                             }
                         }
@@ -118,6 +120,12 @@ fun ChatMessageNerdLine(
                 }
             }
         }
+    }
+}
+
+internal fun tokenUsageToDisplay(message: UIMessage, loading: Boolean): TokenUsage? {
+    return message.usage?.takeIf {
+        !loading && message.getTools().all { tool -> tool.isExecuted }
     }
 }
 

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/stats/StatsVM.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/stats/StatsVM.kt
@@ -10,8 +10,9 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import me.rerere.rikkahub.data.db.dao.ConversationDAO
 import me.rerere.rikkahub.data.db.dao.MessageNodeDAO
+import me.rerere.rikkahub.data.db.dao.TokenUsageDAO
 import me.rerere.rikkahub.data.db.dao.getMessageCountPerDay
-import me.rerere.rikkahub.data.db.dao.getTokenStats
+import me.rerere.rikkahub.data.db.dao.getMessageCount
 import me.rerere.rikkahub.data.datastore.SettingsStore
 import java.time.DayOfWeek
 import java.time.LocalDate
@@ -31,6 +32,7 @@ data class AppStats(
 class StatsVM(
     private val conversationDAO: ConversationDAO,
     private val messageNodeDAO: MessageNodeDAO,
+    private val tokenUsageDAO: TokenUsageDAO,
     private val settingsStore: SettingsStore,
 ) : ViewModel() {
 
@@ -64,18 +66,18 @@ class StatsVM(
 
         val totalConversations = conversationDAO.countAll()
 
-        // json_each() + json_extract() 在 SQLite 侧聚合，不再加载完整 JSON 到 Kotlin
-        val tokenStats = messageNodeDAO.getTokenStats()
+        val totalMessages = messageNodeDAO.getMessageCount()
+        val tokenUsage = tokenUsageDAO.getUsage()
 
         val launchCount = settingsStore.settingsFlow.value.launchCount
 
         _stats.value = AppStats(
             isLoading = false,
             totalConversations = totalConversations,
-            totalMessages = tokenStats.totalMessages,
-            totalPromptTokens = tokenStats.promptTokens,
-            totalCompletionTokens = tokenStats.completionTokens,
-            totalCachedTokens = tokenStats.cachedTokens,
+            totalMessages = totalMessages,
+            totalPromptTokens = tokenUsage.promptTokens,
+            totalCompletionTokens = tokenUsage.completionTokens,
+            totalCachedTokens = tokenUsage.cachedTokens,
             conversationsPerDay = conversationsPerDay,
             launchCount = launchCount,
         )

--- a/app/src/test/java/me/rerere/rikkahub/ui/components/message/ChatMessageTokenUsageTest.kt
+++ b/app/src/test/java/me/rerere/rikkahub/ui/components/message/ChatMessageTokenUsageTest.kt
@@ -1,0 +1,58 @@
+package me.rerere.rikkahub.ui.components.message
+
+import me.rerere.ai.core.MessageRole
+import me.rerere.ai.core.TokenUsage
+import me.rerere.ai.ui.UIMessage
+import me.rerere.ai.ui.UIMessagePart
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ChatMessageTokenUsageTest {
+    @Test
+    fun `usage is shown only after generation and tools finish`() {
+        val message = UIMessage(
+            role = MessageRole.ASSISTANT,
+            parts = listOf(UIMessagePart.Text("done")),
+            usage = TokenUsage(promptTokens = 100),
+        )
+
+        assertFalse(shouldShowTokenUsage(message, loading = true))
+        assertTrue(shouldShowTokenUsage(message, loading = false))
+    }
+
+    @Test
+    fun `usage is hidden for unresolved tools`() {
+        val message = UIMessage(
+            role = MessageRole.ASSISTANT,
+            parts = listOf(
+                UIMessagePart.Tool(
+                    toolCallId = "tool-1",
+                    toolName = "search",
+                    input = "{}",
+                )
+            ),
+            usage = TokenUsage(promptTokens = 100),
+        )
+
+        assertFalse(shouldShowTokenUsage(message, loading = false))
+    }
+
+    @Test
+    fun `usage is shown after all tools execute`() {
+        val message = UIMessage(
+            role = MessageRole.ASSISTANT,
+            parts = listOf(
+                UIMessagePart.Tool(
+                    toolCallId = "tool-1",
+                    toolName = "search",
+                    input = "{}",
+                    output = listOf(UIMessagePart.Text("result")),
+                )
+            ),
+            usage = TokenUsage(promptTokens = 100),
+        )
+
+        assertTrue(shouldShowTokenUsage(message, loading = false))
+    }
+}

--- a/app/src/test/java/me/rerere/rikkahub/ui/components/message/ChatMessageTokenUsageTest.kt
+++ b/app/src/test/java/me/rerere/rikkahub/ui/components/message/ChatMessageTokenUsageTest.kt
@@ -4,8 +4,8 @@ import me.rerere.ai.core.MessageRole
 import me.rerere.ai.core.TokenUsage
 import me.rerere.ai.ui.UIMessage
 import me.rerere.ai.ui.UIMessagePart
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Test
 
 class ChatMessageTokenUsageTest {
@@ -17,8 +17,18 @@ class ChatMessageTokenUsageTest {
             usage = TokenUsage(promptTokens = 100),
         )
 
-        assertFalse(shouldShowTokenUsage(message, loading = true))
-        assertTrue(shouldShowTokenUsage(message, loading = false))
+        assertNull(tokenUsageToDisplay(message, loading = true))
+        assertEquals(message.usage, tokenUsageToDisplay(message, loading = false))
+    }
+
+    @Test
+    fun `usage is hidden when unavailable`() {
+        val message = UIMessage(
+            role = MessageRole.ASSISTANT,
+            parts = listOf(UIMessagePart.Text("done")),
+        )
+
+        assertNull(tokenUsageToDisplay(message, loading = false))
     }
 
     @Test
@@ -35,7 +45,7 @@ class ChatMessageTokenUsageTest {
             usage = TokenUsage(promptTokens = 100),
         )
 
-        assertFalse(shouldShowTokenUsage(message, loading = false))
+        assertNull(tokenUsageToDisplay(message, loading = false))
     }
 
     @Test
@@ -53,6 +63,6 @@ class ChatMessageTokenUsageTest {
             usage = TokenUsage(promptTokens = 100),
         )
 
-        assertTrue(shouldShowTokenUsage(message, loading = false))
+        assertEquals(message.usage, tokenUsageToDisplay(message, loading = false))
     }
 }

--- a/docs/references/chat-generation-pipeline.md
+++ b/docs/references/chat-generation-pipeline.md
@@ -77,6 +77,15 @@ onSuccess
     └── generateSuggestion()（异步，使用 suggestionModel）
 ```
 
+### Token Usage 语义
+
+- 同一次 Provider 请求的流式 usage 是快照：按字段更新，不能把每个 chunk 相加。
+- 每次工具 Step 都创建独立的请求级 usage；聊天消息只保留最后一次请求的统计。
+- 生成中或存在未执行 Tool 时不展示消息统计，工具链完成后再显示最后一轮结果。
+- `ProviderManager` 对每个正常完成且返回 usage 的文本请求记录一次全局累计；该累计独立于会话，
+  删除或压缩消息不会减少历史消耗。
+- `cachedTokens` 是 `promptTokens` 的子集，计算总 Token 时不重复相加。
+
 ---
 
 ## 阶段一：用户消息预处理


### PR DESCRIPTION
Closes #1030 
Closes #1392


## 修复工具调用时的 Token 显示

统一了 GenerationHandler 中流式和非流式请求的 Flow 封装，消除了重复的合并逻辑。
在 ChatMessageNerdLine 中做了拦截，Token 用量现在只会在模型生成完全结束、且所有工具调用执行完毕后才会显示，解决了执行期间数字闪烁跳动的问题。


## 持久化全局 Token 统计

引入了 token_usage_summary 单行表，用来持久化记录应用的全局 Token 消耗。
在 ProviderManager 层面添加了 UsageTrackingProvider，将所有底层 Provider 的调用（包括聊天、自动标题、建议生成、OCR 等全量 API 路径）无缝记录到统计表中。
改变了原本每次进统计页都要通过 json_each 实时遍历解析所有消息历史的做法。现在直接读取新表，不仅大幅提升了加载速度 ，也保证了删除对话或压缩历史记录后，真实的 token统计不会丢失。


## 其他

新增 Migration_24_25，自动回填现有用户的历史统计数据。
补充了单元测试。
更新了文档中有关 Token Usage 快照的语义说明