### PR TITLE
fix(storage): 补全 Android 9 图片保存权限

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,6 +5,9 @@
   <uses-permission android:name="android.permission.INTERNET" />
   <uses-permission android:name="android.permission.CAMERA" />
   <uses-permission android:name="android.permission.RECORD_AUDIO" />
+  <uses-permission
+    android:name="android.permission.WRITE_EXTERNAL_STORAGE"
+    android:maxSdkVersion="28" />
   <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
   <uses-permission android:name="android.permission.POST_PROMOTED_NOTIFICATIONS" />
   <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />


### PR DESCRIPTION
Closes #1142

代码里原本就写了动态请求 `WRITE_EXTERNAL_STORAGE` 的逻辑，但是 `AndroidManifest.xml` 里漏了声明，导致在 Android 9 (API 28) 及以下设备保存图片时会直接静默失败。

本PR在 Manifest 补上了声明，同时加上了 `android:maxSdkVersion="28"`。这样 Android 10+ 的机器（已经原生支持 MediaStore）就不会被索要多余的存储权限了。