### PR TITLE
fix(ai): 合并错序的 Claude thinking 签名

### DIFF
--- a/ai/src/main/java/me/rerere/ai/provider/providers/ClaudeProvider.kt
+++ b/ai/src/main/java/me/rerere/ai/provider/providers/ClaudeProvider.kt
@@ -197,7 +197,7 @@ class ClaudeProvider(private val client: OkHttpClient, context: Context? = null)
                     if (deltaObj != null) {
                         add(deltaObj)
                     }
-                })
+                }, contentBlockIndex = dataJson["index"]?.jsonPrimitive?.intOrNull)
                 val tokenUsage = parseTokenUsage(dataJson)
                 val messageChunk = MessageChunk(
                     id = id ?: "",
@@ -517,7 +517,10 @@ class ClaudeProvider(private val client: OkHttpClient, context: Context? = null)
         }
     }
 
-    private fun parseMessage(content: JsonArray): UIMessage {
+    private fun parseMessage(
+        content: JsonArray,
+        contentBlockIndex: Int? = null,
+    ): UIMessage {
         val parts = mutableListOf<UIMessagePart>()
 
         content.forEach { contentBlock ->
@@ -535,14 +538,18 @@ class ClaudeProvider(private val client: OkHttpClient, context: Context? = null)
                 "thinking", "thinking_delta", "signature_delta" -> {
                     val thinking = block["thinking"]?.jsonPrimitive?.contentOrNull ?: ""
                     val signature = block["signature"]?.jsonPrimitive?.contentOrNull
-                    if (thinking.isNotEmpty() || signature != null) {
+                    if (thinking.isNotEmpty() || signature != null || contentBlockIndex != null) {
                         val reasoning = UIMessagePart.Reasoning(
                             reasoning = thinking,
                             createdAt = Clock.System.now(),
                             finishedAt = null
                         )
-                        if (signature != null) {
-                            reasoning.metadata = ClaudeReasoningMetadata(signature = signature).toMetadata()
+                        val metadata = ClaudeReasoningMetadata(
+                            signature = signature,
+                            contentBlockIndex = contentBlockIndex,
+                        ).toMetadata()
+                        if (metadata.isNotEmpty()) {
+                            reasoning.metadata = metadata
                         }
                         parts.add(reasoning)
                     }

--- a/ai/src/main/java/me/rerere/ai/ui/Message.kt
+++ b/ai/src/main/java/me/rerere/ai/ui/Message.kt
@@ -34,6 +34,26 @@ data class UIMessage(
         val choice = chunk.choices.getOrNull(0)
         val message = choice?.delta ?: choice?.message
         return message?.let { delta ->
+            fun mergeMetadata(existing: JsonObject?, incoming: JsonObject?): JsonObject? = when {
+                existing == null -> incoming
+                incoming == null -> existing
+                else -> JsonObject(existing + incoming)
+            }
+
+            fun List<UIMessagePart>.reasoningTargetIndex(deltaPart: UIMessagePart.Reasoning): Int {
+                val metadata = deltaPart.metadataAs<ClaudeReasoningMetadata>()
+                metadata?.contentBlockIndex?.let { contentBlockIndex ->
+                    return indexOfLast { part ->
+                        part is UIMessagePart.Reasoning &&
+                            part.metadataAs<ClaudeReasoningMetadata>()?.contentBlockIndex == contentBlockIndex
+                    }
+                }
+                if (deltaPart.reasoning.isEmpty() && !metadata?.signature.isNullOrBlank()) {
+                    return indexOfLast { it is UIMessagePart.Reasoning }
+                }
+                return if (lastOrNull() is UIMessagePart.Reasoning) lastIndex else -1
+            }
+
             // Handle Parts
             var newParts = delta.parts.fold(parts) { acc, deltaPart ->
                 when (deltaPart) {
@@ -75,16 +95,29 @@ data class UIMessage(
                         if (deltaPart.reasoning.isEmpty() && deltaPart.metadata == null) {
                             acc
                         } else {
-                            val lastPart = acc.lastOrNull()
-                            if (lastPart is UIMessagePart.Reasoning) {
-                                // Append to the last Reasoning part
-                                acc.dropLast(1) + UIMessagePart.Reasoning(
-                                    reasoning = lastPart.reasoning + deltaPart.reasoning,
-                                    createdAt = lastPart.createdAt,
-                                    finishedAt = null,
-                                ).also {
-                                    it.metadata = deltaPart.metadata ?: lastPart.metadata
+                            val targetIndex = acc.reasoningTargetIndex(deltaPart)
+                            if (targetIndex >= 0) {
+                                acc.mapIndexed { index, part ->
+                                    if (index == targetIndex) {
+                                        val reasoningPart = part as UIMessagePart.Reasoning
+                                        reasoningPart.copy(
+                                            reasoning = reasoningPart.reasoning + deltaPart.reasoning,
+                                            finishedAt = if (deltaPart.reasoning.isEmpty()) {
+                                                reasoningPart.finishedAt
+                                            } else {
+                                                null
+                                            },
+                                            metadata = mergeMetadata(reasoningPart.metadata, deltaPart.metadata),
+                                        )
+                                    } else {
+                                        part
+                                    }
                                 }
+                            } else if (
+                                deltaPart.reasoning.isEmpty() &&
+                                !deltaPart.metadataAs<ClaudeReasoningMetadata>()?.signature.isNullOrBlank()
+                            ) {
+                                acc
                             } else {
                                 // Create new Reasoning part
                                 acc + deltaPart

--- a/ai/src/main/java/me/rerere/ai/ui/MessageMetadata.kt
+++ b/ai/src/main/java/me/rerere/ai/ui/MessageMetadata.kt
@@ -26,6 +26,8 @@ sealed interface PartMetadata
 @Serializable
 data class ClaudeReasoningMetadata(
     val signature: String? = null,
+    @SerialName("content_block_index")
+    val contentBlockIndex: Int? = null,
 ) : PartMetadata
 
 /**

--- a/ai/src/test/java/me/rerere/ai/provider/providers/ClaudeProviderMessageTest.kt
+++ b/ai/src/test/java/me/rerere/ai/provider/providers/ClaudeProviderMessageTest.kt
@@ -1,9 +1,11 @@
 package me.rerere.ai.provider.providers
 
 import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
 import me.rerere.ai.core.MessageRole
 import me.rerere.ai.provider.ClaudePromptCacheTtl
 import me.rerere.ai.ui.UIMessage
@@ -186,6 +188,35 @@ class ClaudeProviderMessageTest {
         }?.jsonObject
         assertEquals("Let me think about this...",
             thinkingBlock?.get("thinking")?.jsonPrimitive?.content)
+    }
+
+    @Test
+    fun `thinking block should replay its signature`() {
+        val assistantMessage = UIMessage(
+            role = MessageRole.ASSISTANT,
+            parts = listOf(
+                UIMessagePart.Reasoning(
+                    reasoning = "Let me think about this...",
+                    metadata = buildJsonObject {
+                        put("signature", "anthropic-signature")
+                        put("content_block_index", 0)
+                    },
+                ),
+                UIMessagePart.Text("Here is my response"),
+            ),
+        )
+
+        val result = invokeBuildMessages(listOf(UIMessage.user("Question"), assistantMessage))
+        val thinkingBlock = result
+            .first { it.jsonObject["role"]?.jsonPrimitive?.content == "assistant" }
+            .jsonObject["content"]!!
+            .jsonArray
+            .first { it.jsonObject["type"]?.jsonPrimitive?.content == "thinking" }
+            .jsonObject
+
+        assertEquals("Let me think about this...", thinkingBlock["thinking"]?.jsonPrimitive?.content)
+        assertEquals("anthropic-signature", thinkingBlock["signature"]?.jsonPrimitive?.content)
+        assertTrue("Internal stream index must not be replayed", "content_block_index" !in thinkingBlock)
     }
 
     @Test

--- a/ai/src/test/java/me/rerere/ai/ui/MessageTest.kt
+++ b/ai/src/test/java/me/rerere/ai/ui/MessageTest.kt
@@ -233,6 +233,143 @@ class MessageTest {
         assertTrue(message.isValidToUpload())
     }
 
+    @Test
+    fun `handleMessageChunk should merge delayed Claude signature by content block index`() {
+        val messages = listOf(
+            UIMessage(
+                role = MessageRole.ASSISTANT,
+                parts = listOf(
+                    UIMessagePart.Reasoning(
+                        reasoning = "thinking",
+                        metadata = ClaudeReasoningMetadata(contentBlockIndex = 0).toMetadata(),
+                    ),
+                    UIMessagePart.Text("visible text"),
+                ),
+            )
+        )
+        val chunk = MessageChunk(
+            id = "chunk-1",
+            model = "claude-test",
+            choices = listOf(
+                UIMessageChoice(
+                    index = 0,
+                    delta = UIMessage(
+                        role = MessageRole.ASSISTANT,
+                        parts = listOf(
+                            UIMessagePart.Reasoning(
+                                reasoning = "",
+                                finishedAt = null,
+                                metadata = ClaudeReasoningMetadata(
+                                    signature = "sig-1",
+                                    contentBlockIndex = 0,
+                                ).toMetadata(),
+                            )
+                        ),
+                    ),
+                    message = null,
+                    finishReason = null,
+                )
+            ),
+        )
+
+        val parts = messages.handleMessageChunk(chunk).single().parts
+
+        assertEquals(2, parts.size)
+        assertTrue(parts[0] is UIMessagePart.Reasoning)
+        assertTrue(parts[1] is UIMessagePart.Text)
+        val reasoning = parts[0] as UIMessagePart.Reasoning
+        assertEquals("thinking", reasoning.reasoning)
+        assertEquals("sig-1", reasoning.metadataAs<ClaudeReasoningMetadata>()?.signature)
+    }
+
+    @Test
+    fun `handleMessageChunk should attach Claude signature to matching reasoning block`() {
+        val messages = listOf(
+            UIMessage(
+                role = MessageRole.ASSISTANT,
+                parts = listOf(
+                    UIMessagePart.Reasoning(
+                        reasoning = "first",
+                        metadata = ClaudeReasoningMetadata(contentBlockIndex = 0).toMetadata(),
+                    ),
+                    UIMessagePart.Text("between"),
+                    UIMessagePart.Reasoning(
+                        reasoning = "second",
+                        metadata = ClaudeReasoningMetadata(contentBlockIndex = 2).toMetadata(),
+                    ),
+                ),
+            )
+        )
+        val chunk = MessageChunk(
+            id = "chunk-2",
+            model = "claude-test",
+            choices = listOf(
+                UIMessageChoice(
+                    index = 0,
+                    delta = UIMessage(
+                        role = MessageRole.ASSISTANT,
+                        parts = listOf(
+                            UIMessagePart.Reasoning(
+                                reasoning = "",
+                                finishedAt = null,
+                                metadata = ClaudeReasoningMetadata(
+                                    signature = "sig-first",
+                                    contentBlockIndex = 0,
+                                ).toMetadata(),
+                            )
+                        ),
+                    ),
+                    message = null,
+                    finishReason = null,
+                )
+            ),
+        )
+
+        val reasoning = messages.handleMessageChunk(chunk)
+            .single()
+            .parts
+            .filterIsInstance<UIMessagePart.Reasoning>()
+
+        assertEquals("sig-first", reasoning[0].metadataAs<ClaudeReasoningMetadata>()?.signature)
+        assertEquals(null, reasoning[1].metadataAs<ClaudeReasoningMetadata>()?.signature)
+    }
+
+    @Test
+    fun `handleMessageChunk should ignore orphan Claude signature`() {
+        val messages = listOf(
+            UIMessage(
+                role = MessageRole.ASSISTANT,
+                parts = listOf(UIMessagePart.Text("visible text")),
+            )
+        )
+        val chunk = MessageChunk(
+            id = "chunk-3",
+            model = "claude-test",
+            choices = listOf(
+                UIMessageChoice(
+                    index = 0,
+                    delta = UIMessage(
+                        role = MessageRole.ASSISTANT,
+                        parts = listOf(
+                            UIMessagePart.Reasoning(
+                                reasoning = "",
+                                finishedAt = null,
+                                metadata = ClaudeReasoningMetadata(signature = "orphan").toMetadata(),
+                            )
+                        ),
+                    ),
+                    message = null,
+                    finishReason = null,
+                )
+            ),
+        )
+
+        val parts = messages.handleMessageChunk(chunk).single().parts
+
+        assertEquals(1, parts.size)
+        assertTrue(parts.single() is UIMessagePart.Text)
+    }
+
     // ==================== migrateToolMessages Tests ====================
 
     @Test


### PR DESCRIPTION
oh-my-anthropic-fxxk-u

Closes #1075 (修复 OpenRouter 转发导致的 Claude thinking 签名分离与 UI 异常)

在使用 OpenRouter 等第三方网关请求 Claude 模型时，受限于上游的流处理机制，`signature` 块（甚至部分 `thinking` 块）经常会在后续的 `text` 文本块到达后才姗姗来迟。
旧版消息拼接逻辑过于依赖顺序，只会简单追加到 `lastPart`。一旦中间穿插了文本块，迟来的签名就会被误认为是一个全新的思考块，导致 UI 渲染出孤立的、没有内容的 thinking 气泡。

本 PR 彻底重构了流合并逻辑，大幅提升了极端网络下的鲁棒性：
1. **绝对索引合并**: 在 `ClaudeReasoningMetadata` 中引入 `content_block_index`。通过解析原始流的 `index`，精确将 signature 合并回它真正所属的思考块，无视乱序。
2. **防污染设计**: 索引元数据仅参与本地 UI 拼接。在构建下一步上下文发送给 API 时，`content_block_index` 会被自然剥离，保证历史消息严格遵循 Anthropic API 规范。
3. **安全降级**: 针对不携带 index 的异常流，平滑降级为追加到最后的 thinking 块；遇到无法归属的游离 signature 则安全丢弃，杜绝 UI 渲染崩溃。