### PR TITLE
fix(workspace): 支持读取 HEIC/HEIF/AVIF/ICO 图片

### DIFF
--- a/app/src/main/java/me/rerere/rikkahub/data/ai/tools/WorkspaceTools.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/ai/tools/WorkspaceTools.kt
@@ -52,7 +52,9 @@ suspend fun createWorkspaceTools(
     )
 }
 
-private val IMAGE_EXTENSIONS = setOf("png", "jpg", "jpeg", "gif", "webp", "bmp", "svg")
+private val IMAGE_EXTENSIONS = setOf(
+    "png", "jpg", "jpeg", "gif", "webp", "bmp", "svg", "heic", "heif", "avif", "ico",
+)
 
 private fun String.isImagePath(): Boolean =
     substringAfterLast('.', "").lowercase() in IMAGE_EXTENSIONS
@@ -66,7 +68,7 @@ private fun createReadFileTool(
     description = """
         Read a file using the assistant's bound workspace Rootfs. Paths must be absolute inside Rootfs.
         Use /workspace for the workspace files area.
-        Supports UTF-8 text files and image files (png, jpg, jpeg, gif, webp, bmp).
+        Supports UTF-8 text files and image files (png, jpg, jpeg, gif, webp, bmp, svg, heic, heif, avif, ico).
     """.trimIndent().replace("\n", " "),
     parameters = {
         InputSchema.Obj(


### PR DESCRIPTION
Closes #1118 

 `WorkspaceTools` 中的 `IMAGE_EXTENSIONS` 扩展名白名单遗漏了 `heic`, `heif` 以及现代网页开发中常见的 `avif`, `ico`。

本 PR 把这些格式补进图片白名单。