### PR TITLE
fix(ai): 月之暗面 K2.5+/K3 未过滤 temperature 报错的问题

### DIFF
--- a/ai/src/main/java/me/rerere/ai/provider/providers/openai/ChatCompletionsAPI.kt
+++ b/ai/src/main/java/me/rerere/ai/provider/providers/openai/ChatCompletionsAPI.kt
@@ -454,7 +454,13 @@ class ChatCompletionsAPI(
     }
 
     private fun isModelAllowTemperature(model: Model): Boolean {
-        return !ModelRegistry.OPENAI_O_MODELS.match(model.modelId) && !ModelRegistry.GPT_5.match(model.modelId)
+        val isMoonshotRestricted = ModelRegistry.KIMI_K2_5.match(model.modelId) ||
+                ModelRegistry.KIMI_K2_6.match(model.modelId) ||
+                ModelRegistry.KIMI_K3.match(model.modelId) ||
+                ModelRegistry.KIMI_K3_ALIAS.match(model.modelId)
+        return !ModelRegistry.OPENAI_O_MODELS.match(model.modelId) && 
+               !ModelRegistry.GPT_5.match(model.modelId) && 
+               !isMoonshotRestricted
     }
 
     private fun buildMessages(

--- a/ai/src/main/java/me/rerere/ai/registry/ModelRegistry.kt
+++ b/ai/src/main/java/me/rerere/ai/registry/ModelRegistry.kt
@@ -367,7 +367,7 @@ object ModelRegistry {
         toolReasoningAbility()
     }
 
-    private val KIMI_K2_5 = defineModel {
+    val KIMI_K2_5 = defineModel {
         tokens("kimi", "k", "2", "5")
         visionInput()
         toolReasoningAbility()
@@ -379,14 +379,14 @@ object ModelRegistry {
         toolReasoningAbility()
     }
 
-    private val KIMI_K3 = defineModel {
+    val KIMI_K3 = defineModel {
         tokens("kimi", "k", "3")
         visionInput()
         toolReasoningAbility()
     }
 
     // 兼容不带 kimi 前缀的裸 id "k3"
-    private val KIMI_K3_ALIAS = defineModel {
+    val KIMI_K3_ALIAS = defineModel {
         exact("k3")
         visionInput()
         toolReasoningAbility()


### PR DESCRIPTION
Closes #1574

根据官方文档，K3、K2.7-code 以及开启了思考模式的模型参数是强制锁死的，传入其他温度会报 400 错误。此 PR 添加了对应的过滤逻辑。

#1585 也有修这玩意，但#1585 疑似太重了...