### PR TITLE
fix(ui): 修复同名 Skill 导致的 LazyColumn 崩溃问题

### DIFF
--- a/app/src/main/java/me/rerere/rikkahub/ui/components/ai/ExtensionContent.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/ai/ExtensionContent.kt
@@ -121,7 +121,7 @@ fun SkillsContent(
         modifier = modifier.fillMaxSize(),
         verticalArrangement = Arrangement.spacedBy(4.dp)
     ) {
-        items(skills, key = { it.name }) { skill ->
+        items(skills, key = { it.skillDir.absolutePath }) { skill ->
             ListItem(
                 headlineContent = { Text(skill.name) },
                 supportingContent = if (skill.description.isNotBlank()) {

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/extensions/skills/SkillsPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/extensions/skills/SkillsPage.kt
@@ -150,7 +150,7 @@ fun SkillsPage() {
                 }
             }
 
-            items(skills, key = { it.name }) { skill ->
+            items(skills, key = { it.skillDir.absolutePath }) { skill ->
                 SkillCard(
                     skill = skill,
                     onClick = { navController.navigate(Screen.SkillDetail(skill.name)) },


### PR DESCRIPTION
Closes #1548

当存在同名 Skill 时，LazyColumn 会因为 `key = { it.name }` 抛出 `java.lang.IllegalArgumentException: Key was already used` 导致崩溃。此 PR 将 key 替换为全局唯一的目录绝对路径，杜绝了崩溃隐患。