### PR TITLE
fix: use absolute path as key for skills list to prevent crash

### DIFF
--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/extensions/skills/SkillsPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/extensions/skills/SkillsPage.kt
@@ -150,7 +150,7 @@ fun SkillsPage() {
                 }
             }
 
-            items(skills, key = { it.name }) { skill ->
+            items(skills, key = { it.skillDir.absolutePath }) { skill ->
                 SkillCard(
                     skill = skill,
                     onClick = { navController.navigate(Screen.SkillDetail(skill.name)) },


### PR DESCRIPTION
Resolves #1548. When there are duplicate skill names, using just the name as the LazyColumn key causes a crash. Using the absolute path of the skill directory prevents this.