### PR TITLE
fix(search): Brave 搜索结果缺少 type 字段导致解析崩溃

### DIFF
--- a/search/src/main/java/me/rerere/search/BraveSearchService.kt
+++ b/search/src/main/java/me/rerere/search/BraveSearchService.kt
@@ -112,7 +112,7 @@ object BraveSearchService : SearchService<SearchServiceOptions.BraveOptions> {
 
     @Serializable
     data class WebResult(
-        val type: String,
+        val type: String? = null,
         val title: String,
         val url: String,
         val description: String? = null,


### PR DESCRIPTION
Closes #1368

Brave API 返回的 WebResult 有时不包含 type 字段，但数据类中声明为非空 String，导致 kotlinx.serialization 抛出 MissingFieldException。外层的 BraveSearchResponse.type 和 WebResults.type 已经修过了，但最内层的 WebResult.type 漏了，补上。