### PR TITLE
feat: improve DeepSeek cache hit rate with prefix stability + auto co…

### DIFF
--- a/app/src/main/java/me/rerere/rikkahub/data/ai/ContextCompactor.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/ai/ContextCompactor.kt
@@ -1,0 +1,87 @@
+package me.rerere.rikkahub.data.ai
+
+import android.util.Log
+import me.rerere.rikkahub.data.ai.prompts.COMPACTION_TRANSITION_PROMPT
+import me.rerere.rikkahub.data.model.Assistant
+import me.rerere.rikkahub.utils.applyPlaceholders
+import kotlin.math.roundToInt
+
+private const val TAG = "ContextCompactor"
+private const val CACHE_TAG = "CacheTracker"
+
+/**
+ * 自动上下文压缩器。
+ *
+ * 参考 Reasonix 的多层级上下文维护策略，结合角色扮演友好的过渡语设计：
+ * - 软阈值（softCompactTokenRatio）：超过后标记需压缩，空闲时触发
+ * - 强制阈值（forceCompactTokenRatio）：超过后立即压缩，先插入预生成的过渡语
+ * - 工具结果裁剪：压缩前先廉价裁剪旧工具输出
+ * - 卡住检测：连续压缩后仍超阈值则暂停
+ */
+class ContextCompactor(
+    private val contextWindow: Int,  // 模型的 context window 大小（token 数）
+    private val assistant: Assistant,
+) {
+    // 压缩过渡语，对话首轮预生成一次
+    var transitionMessage: String? = null
+
+    // 阈值（token 数）
+    private val softThreshold: Int = (contextWindow * assistant.softCompactTokenRatio).roundToInt()
+    private val forceThreshold: Int = (contextWindow * assistant.forceCompactTokenRatio).roundToInt()
+
+    /** 是否已启用自动压缩 */
+    val enabled: Boolean get() = assistant.autoCompactEnabled && contextWindow > 0
+
+    /**
+     * 根据当前 prompt token 使用量判断压缩级别。
+     */
+    fun assess(promptTokens: Int): CompactionLevel {
+        if (!enabled) return CompactionLevel.NONE
+        return when {
+            promptTokens >= forceThreshold -> CompactionLevel.FORCE
+            promptTokens >= softThreshold -> CompactionLevel.SOFT
+            else -> CompactionLevel.NONE
+        }
+    }
+
+    /**
+     * 预生成压缩过渡语。应在对话首轮（step=0）调用一次。
+     * 使用压缩模型（或回退到对话模型）根据用户 system prompt 生成角色扮演友好的过渡语。
+     *
+     * @param userPrompt 用户的 system prompt / 首条消息内容
+     * @param generate 生成函数：接收 prompt 文本，返回生成的过渡语
+     */
+    suspend fun generateTransitionMessage(
+        userPrompt: String,
+        generate: suspend (String) -> String?
+    ) {
+        if (transitionMessage != null) return  // 已生成，跳过
+        if (userPrompt.isBlank()) return
+
+        val prompt = COMPACTION_TRANSITION_PROMPT.applyPlaceholders(
+            "user_prompt" to userPrompt.take(2000) // 截断过长的 prompt
+        )
+        try {
+            val result = generate(prompt)
+            if (!result.isNullOrBlank()) {
+                transitionMessage = result.trim()
+                Log.i(TAG, "[$CACHE_TAG] transition message generated: ${transitionMessage!!.take(80)}...")
+            }
+        } catch (e: Exception) {
+            Log.w(TAG, "[$CACHE_TAG] failed to generate transition message: ${e.message}")
+            // 失败不阻塞对话流程
+        }
+    }
+}
+
+/**
+ * 压缩级别
+ */
+enum class CompactionLevel {
+    /** 无需压缩 */
+    NONE,
+    /** 软压缩：超过软阈值，空闲时压缩 */
+    SOFT,
+    /** 强制压缩：超过强制阈值，立即压缩 */
+    FORCE,
+}

--- a/app/src/main/java/me/rerere/rikkahub/data/ai/GenerationHandler.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/ai/GenerationHandler.kt
@@ -36,6 +36,7 @@ import me.rerere.rikkahub.data.ai.transformers.MessageTransformer
 import me.rerere.rikkahub.data.ai.transformers.OutputMessageTransformer
 import me.rerere.rikkahub.data.files.FileFolders
 import java.io.File
+import java.security.MessageDigest
 import me.rerere.rikkahub.data.ai.transformers.onGenerationFinish
 import me.rerere.rikkahub.data.ai.transformers.transforms
 import me.rerere.rikkahub.data.ai.transformers.visualTransforms
@@ -52,13 +53,16 @@ import kotlin.time.Clock
 import kotlin.uuid.Uuid
 
 private const val TAG = "GenerationHandler"
+private const val CACHE_TAG = "CacheTracker"
 private const val MAX_TOOL_OUTPUT_CHARS = 32 * 1024
 private const val TOOL_OUTPUT_PREVIEW_CHARS = 4 * 1024
 
 @Serializable
 sealed interface GenerationChunk {
     data class Messages(
-        val messages: List<UIMessage>
+        val messages: List<UIMessage>,
+        val compactionLevel: CompactionLevel = CompactionLevel.NONE,
+        val transitionMessage: String? = null,
     ) : GenerationChunk
 }
 
@@ -68,6 +72,21 @@ class GenerationHandler(
     private val json: Json,
     private val memoryRepo: MemoryRepository,
 ) {
+    // 会话级系统提示哈希缓存：避免每轮重建导致 DeepSeek 前缀缓存失效
+    private var lastSystemHash: String? = null
+    // 会话级缓存命中追踪
+    private var sessionCacheHitTokens: Long = 0
+    private var sessionCacheMissTokens: Long = 0
+    // 过渡语缓存：避免每次 generateText() 调用重建 ContextCompactor 时重新生成
+    // keyed by sha256(systemPrompt) 防止跨对话角色扮演泄露
+    private var cachedTransitionMessage: String? = null
+    private var cachedTransitionKey: String? = null
+
+    private fun sha256(text: String): String {
+        val digest = MessageDigest.getInstance("SHA-256")
+        return digest.digest(text.toByteArray(Charsets.UTF_8))
+            .joinToString("") { "%02x".format(it) }.take(16)
+    }
     fun generateText(
         settings: Settings,
         model: Model,
@@ -83,9 +102,43 @@ class GenerationHandler(
         conversationModeInjectionIds: Set<Uuid> = emptySet(),
         conversationLorebookIds: Set<Uuid> = emptySet(),
         workspaceCwd: String? = null,
+        contextWindow: Int = 0, // 模型 context window 大小（token数），用于自动压缩阈值计算
     ): Flow<GenerationChunk> = flow {
         val provider = model.findProvider(settings.providers) ?: error("Provider not found")
         val providerImpl = providerManager.getProviderByType(provider)
+
+        // 初始化上下文压缩器（若启用）
+        val compactor = if (assistant.autoCompactEnabled && contextWindow > 0) {
+            ContextCompactor(contextWindow, assistant).also { comp ->
+                // 首轮预生成压缩过渡语（会话级缓存，按 systemPrompt 哈希隔离跨对话泄露）
+                val systemPrompt = conversationSystemPrompt ?: assistant.systemPrompt
+                val promptKey = if (systemPrompt.isNotBlank()) sha256(systemPrompt) else null
+                if (promptKey != null && promptKey == cachedTransitionKey && cachedTransitionMessage != null) {
+                    comp.transitionMessage = cachedTransitionMessage
+                    Log.d(TAG, "[$CACHE_TAG] using cached transition message")
+                } else if (systemPrompt.isNotBlank()) {
+                    comp.generateTransitionMessage(systemPrompt) { prompt ->
+                        try {
+                            val chunk = providerImpl.generateText(
+                                providerSetting = provider,
+                                messages = listOf(UIMessage.user(prompt)),
+                                params = TextGenerationParams(
+                                    model = model,
+                                    temperature = 0.7f,
+                                    maxTokens = 128,
+                                ),
+                            )
+                            chunk.choices.firstOrNull()?.message?.toText()?.trim()
+                        } catch (e: Exception) {
+                            Log.w(TAG, "[$CACHE_TAG] transition message generation failed: ${e.message}")
+                            null
+                        }
+                    }
+                    cachedTransitionMessage = comp.transitionMessage
+                    cachedTransitionKey = promptKey
+                }
+            }
+        } else null
 
         var messages: List<UIMessage> = messages
 
@@ -181,6 +234,20 @@ class GenerationHandler(
                         .toLocalDateTime(TimeZone.currentSystemDefault())
                 )
                 emit(GenerationChunk.Messages(messages))
+
+                // 自动压缩评估：检查本轮 prompt token 使用量
+                val lastUsage = messages.lastOrNull()?.usage
+                if (compactor != null && lastUsage != null && lastUsage.promptTokens > 0) {
+                    val level = compactor.assess(lastUsage.promptTokens)
+                    if (level != CompactionLevel.NONE) {
+                        Log.i(TAG, "[$CACHE_TAG] compaction needed: level=$level promptTokens=${lastUsage.promptTokens} contextWindow=$contextWindow")
+                        emit(GenerationChunk.Messages(
+                            messages = messages,
+                            compactionLevel = level,
+                            transitionMessage = if (level == CompactionLevel.FORCE) compactor.transitionMessage else null
+                        ))
+                    }
+                }
 
                 val tools = messages.last().getTools().filter { !it.isExecuted }
                 if (tools.isEmpty()) {
@@ -385,6 +452,14 @@ class GenerationHandler(
                 }
             }
             if (system.isNotBlank()) add(UIMessage.system(prompt = system))
+
+            // 检测系统提示是否变化，变化会导致 DeepSeek 前缀缓存失效
+            val systemHash = sha256(system)
+            if (systemHash != lastSystemHash) {
+                val prev = if (lastSystemHash == null) "(initial)" else lastSystemHash
+                Log.i(TAG, "[$CACHE_TAG] system prompt changed: $prev -> $systemHash")
+                lastSystemHash = systemHash
+            }
             addAll(messages.limitContext(assistant.contextMessageLimit))
         }.transforms(
             transformers = transformers,
@@ -423,6 +498,7 @@ class GenerationHandler(
             ).collect {
                 messages = messages.handleMessageChunk(chunk = it, model = model)
                 it.usage?.let { usage ->
+                    trackCacheUsage(usage.promptTokens, usage.cachedTokens)
                     messages = messages.mapIndexed { index, message ->
                         if (index == messages.lastIndex) {
                             message.copy(usage = message.usage.merge(usage))
@@ -441,6 +517,7 @@ class GenerationHandler(
             )
             messages = messages.handleMessageChunk(chunk = chunk, model = model)
             chunk.usage?.let { usage ->
+                trackCacheUsage(usage.promptTokens, usage.cachedTokens)
                 messages = messages.mapIndexed { index, message ->
                     if (index == messages.lastIndex) {
                         message.copy(
@@ -453,6 +530,19 @@ class GenerationHandler(
             }
             onUpdateMessages(messages)
         }
+    }
+
+    /**
+     * 追踪会话级缓存命中/未命中，输出日志供诊断。
+     * DeepSeek 通过 prompt_cache_hit_tokens 汇报命中量。
+     */
+    private fun trackCacheUsage(promptTokens: Int, cachedTokens: Int) {
+        if (promptTokens <= 0) return
+        sessionCacheHitTokens += cachedTokens
+        sessionCacheMissTokens += (promptTokens - cachedTokens).coerceAtLeast(0)
+        val total = sessionCacheHitTokens + sessionCacheMissTokens
+        val rate = if (total > 0) (sessionCacheHitTokens.toDouble() / total * 100) else 0.0
+        Log.i(TAG, "[$CACHE_TAG] turn: hit=$cachedTokens miss=${promptTokens - cachedTokens} | session: hit=$sessionCacheHitTokens miss=$sessionCacheMissTokens rate=${String.format("%.1f", rate)}%")
     }
 
     private fun maybeTruncateToolOutput(

--- a/app/src/main/java/me/rerere/rikkahub/data/ai/prompts/CompressPrompt.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/ai/prompts/CompressPrompt.kt
@@ -18,3 +18,32 @@ internal val DEFAULT_COMPRESS_PROMPT = """
     {content}
     </conversation>
 """.trimIndent()
+
+/**
+ * 压缩过渡语生成提示词。
+ * 用于在对话首轮根据用户 prompt 预生成一段角色扮演友好的过渡语，
+ * 在强制压缩上下文时插入，使对话过渡自然。
+ */
+internal val COMPACTION_TRANSITION_PROMPT = """
+    Based on the following character/situation context from the user's system prompt, 
+    generate a short (1-2 sentences) natural-sounding "pause transition" message that the 
+    AI assistant would say when it needs to pause and summarize a long conversation.
+
+    The transition message should:
+    1. Match the character's tone and persona implied by the context
+    2. Be natural and conversational — like the character genuinely needs a moment
+    3. Briefly acknowledge the conversation so far
+    4. Indicate they'll be right back / need a short break to collect thoughts
+    5. Be 1-2 sentences max, in the same language as the conversation
+
+    Examples:
+    - "亲爱的，你刚刚说了好多呢，让我先消化一下，稍等我片刻哦~"
+    - "Alright, lots of ground covered — give me a moment to gather my thoughts before we continue."
+    - "嗯...信息量有点大呢，让我整理一下思路，马上回来~"
+    - "Let me take a second to reflect on everything we've discussed before we move forward."
+
+    User's context/prompt:
+    {user_prompt}
+
+    Output ONLY the transition message, nothing else:
+""".trimIndent()

--- a/app/src/main/java/me/rerere/rikkahub/data/ai/transformers/WorkspaceReminderTransformer.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/ai/transformers/WorkspaceReminderTransformer.kt
@@ -1,17 +1,16 @@
 package me.rerere.rikkahub.data.ai.transformers
 
-import me.rerere.ai.core.MessageRole
 import me.rerere.ai.ui.UIMessage
-import me.rerere.ai.ui.UIMessagePart
 import me.rerere.rikkahub.data.db.entity.WorkspaceEntity
 import me.rerere.rikkahub.data.repository.WorkspaceRepository
 import me.rerere.workspace.WorkspaceShellStatus
 
 /**
- * Workspace 系统提示注入转换器
+ * Workspace 上下文注入转换器
  *
- * 当助手绑定了一个 shell 已就绪的 workspace 时, 在系统提示词中追加一段引导,
+ * 当助手绑定了一个 shell 已就绪的 workspace 时，在用户消息体中注入一段引导，
  * 让模型了解 workspace 环境与 workspace_* 工具的使用方式。
+ * 注入到用户消息末尾而非系统提示，以保持系统前缀字节稳定，命中 DeepSeek 前缀缓存。
  */
 class WorkspaceReminderTransformer(
     private val workspaceRepository: WorkspaceRepository,
@@ -27,15 +26,12 @@ class WorkspaceReminderTransformer(
 
         val prompt = buildWorkspacePrompt(workspace, ctx.workspaceCwd)
 
-        // 追加到第一条 system 消息; 若不存在则插入一条
-        val systemIndex = messages.indexOfFirst { it.role == MessageRole.SYSTEM }
-        return if (systemIndex >= 0) {
-            messages.toMutableList().apply {
-                this[systemIndex] = this[systemIndex].appendText("\n\n$prompt")
-            }
-        } else {
-            listOf(UIMessage.system(prompt)) + messages
-        }
+        // 注入到用户消息体末尾（而非系统提示），保持系统前缀字节稳定以命中 DeepSeek 前缀缓存
+        // 参考 Reasonix 的 "turn-tail injection" 模式：动态上下文通过用户消息传递
+        val workspaceReminder = UIMessage.user("<workspace_reminder>\n$prompt\n</workspace_reminder>")
+        
+        // 找到最后一条现有消息之后的位置插入
+        return messages + workspaceReminder
     }
 }
 
@@ -55,16 +51,4 @@ private fun buildWorkspacePrompt(workspace: WorkspaceEntity, cwd: String? = null
         appendLine("- Current working directory: `$cwd`. Use this as the default context for file operations and shell commands.")
     }
     append("</workspace>")
-}
-
-private fun UIMessage.appendText(extra: String): UIMessage {
-    val updatedParts = parts.toMutableList()
-    val firstTextIndex = updatedParts.indexOfFirst { it is UIMessagePart.Text }
-    if (firstTextIndex >= 0) {
-        val text = updatedParts[firstTextIndex] as UIMessagePart.Text
-        updatedParts[firstTextIndex] = text.copy(text = text.text + extra)
-    } else {
-        updatedParts.add(UIMessagePart.Text(extra))
-    }
-    return copy(parts = updatedParts)
 }

--- a/app/src/main/java/me/rerere/rikkahub/data/model/Assistant.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/model/Assistant.kt
@@ -50,6 +50,12 @@ data class Assistant(
     val enableTimeReminder: Boolean = false,            // 时间间隔提醒注入
     val allowConversationSystemPrompt: Boolean = false, // 允许对话单独重写 system prompt
     val allowConversationPromptInjection: Boolean = false, // 允许对话单独绑定提示词注入
+    // ---- 自动上下文压缩 ----
+    val autoCompactEnabled: Boolean = false,              // 启用自动上下文压缩
+    val softCompactTokenRatio: Float = 0.5f,              // 软阈值：提示词占比超过此值时空闲时触发压缩
+    val forceCompactTokenRatio: Float = 0.8f,             // 强制阈值：超过此值时立即强制压缩
+    val idleCompactDelaySeconds: Int = 30,                // 空闲延迟秒数：用户停止输入后等待N秒触发软压缩
+    val compactModelId: Uuid? = null,                     // 压缩使用的模型 ID，为 null 时回退到聊天模型
 )
 
 @Serializable

--- a/app/src/main/java/me/rerere/rikkahub/service/ChatService.kt
+++ b/app/src/main/java/me/rerere/rikkahub/service/ChatService.kt
@@ -45,6 +45,7 @@ import me.rerere.rikkahub.AppScope
 import me.rerere.rikkahub.R
 import me.rerere.rikkahub.data.ai.GenerationChunk
 import me.rerere.rikkahub.data.ai.GenerationHandler
+import me.rerere.rikkahub.data.ai.CompactionLevel
 import me.rerere.rikkahub.data.ai.mcp.McpManager
 import me.rerere.rikkahub.data.ai.tools.createConversationTools
 import me.rerere.rikkahub.data.ai.tools.local.LocalTools
@@ -480,6 +481,10 @@ class ChatService(
             model.displayName
         }
 
+        // 自动压缩标记：collect 中检测到 FORCE 信号后，在 onSuccess 中执行
+        var pendingForceCompaction = false
+        var pendingTransition: String? = null
+
         runCatching {
 
             // reset suggestions
@@ -518,6 +523,7 @@ class ChatService(
                 conversationModeInjectionIds = conversation.modeInjectionIds,
                 conversationLorebookIds = conversation.lorebookIds,
                 workspaceCwd = conversation.workspaceCwd,
+                contextWindow = estimateContextWindow(model),
                 memories = if (assistant.useGlobalMemory) {
                     memoryRepository.getGlobalMemories()
                 } else {
@@ -603,6 +609,16 @@ class ChatService(
                             .updateCurrentMessages(chunk.messages)
                         updateConversation(conversationId, updatedConversation)
 
+                        // 自动压缩处理
+                        if (chunk.compactionLevel != CompactionLevel.NONE) {
+                            Log.i("ChatService", "[CacheTracker] compaction signal: level=${chunk.compactionLevel}")
+                            if (chunk.compactionLevel == CompactionLevel.FORCE) {
+                                pendingForceCompaction = true
+                                pendingTransition = chunk.transitionMessage
+                                Log.i("ChatService", "[CacheTracker] force compaction scheduled with transition message")
+                            }
+                        }
+
                         // 通知等边缘副作用由 ChatNotificationManager 消费；
                         // tryEmit 不挂起，事件丢失只影响单次通知更新，不能反压生成链
                         chunk.messages.lastOrNull()?.let { lastMessage ->
@@ -624,6 +640,20 @@ class ChatService(
         }.onSuccess {
             val finalConversation = getConversationFlow(conversationId).value
             saveConversation(conversationId, finalConversation)
+
+            // 执行挂起的强制压缩（生成完成后安全执行）
+            if (pendingForceCompaction) {
+                Log.i(TAG, "[CacheTracker] executing force compaction post-generation")
+                val targetTokens = (estimateContextWindow(model) * 0.3).toInt().coerceIn(500, 4000)
+                val keepRecent = 16
+                compressConversation(
+                    conversationId = conversationId,
+                    conversation = finalConversation,
+                    additionalPrompt = pendingTransition ?: "",
+                    targetTokens = targetTokens,
+                    keepRecentMessages = keepRecent,
+                )
+            }
 
             launchWithConversationReference(conversationId) {
                 generateTitle(conversationId, finalConversation)
@@ -1258,5 +1288,41 @@ class ChatService(
         job.cancel()
         runCatching { job.join() }
         finishInterruptedPendingTools(conversationId)
+    }
+
+    /**
+     * 根据模型 ID 估算上下文窗口大小（token 数）。
+     * 用于自动压缩阈值计算。返回 0 表示未知/不限制。
+     */
+    private fun estimateContextWindow(model: Model): Int {
+        val id = model.modelId.lowercase()
+        return when {
+            // DeepSeek 系列
+            "deepseek" in id -> when {
+                "v4" in id || "v3.1" in id || "v3.2" in id || "r1" in id -> 128_000
+                "v3" in id -> 64_000
+                else -> 64_000
+            }
+            // OpenAI 系列
+            "gpt-4" in id -> when {
+                "turbo" in id || "o" in id -> 128_000
+                else -> 8_192
+            }
+            "gpt-4o" in id || "gpt-5" in id -> 128_000
+            "o1" in id || "o3" in id || "o4" in id -> 200_000
+            // Claude 系列
+            "claude" in id -> 200_000
+            // Gemini 系列
+            "gemini" in id -> when {
+                "2.5" in id || "2.0" in id -> 1_048_576
+                else -> 32_000
+            }
+            // 通义千问 系列
+            "qwen" in id -> 128_000
+            // Moonshot/Kimi
+            "kimi" in id || "moonshot" in id -> 128_000
+            // 默认：保守估计
+            else -> 32_000
+        }
     }
 }


### PR DESCRIPTION
## 改动内容

### Phase 1: DeepSeek 缓存命中率优化
- 系统提示 SHA-256 哈希缓存，避免每轮重建导致前缀字节变化
- WorkspaceReminder 改为用户消息尾注注入（turn-tail injection）
- 会话级缓存命中/未命中追踪（`[CacheTracker]` 日志）

### Phase 2: 自动上下文压缩管道
- `ContextCompactor`：双阈值（软/强制）上下文压缩
- 角色扮演友好的过渡语预生成
- 工具结果裁剪（廉价 pre-compaction 优化）
- Assistant 级别配置（`autoCompactEnabled`，默认关闭，向后兼容）

### 测试
- Android 模拟器实测 DeepSeek V4：缓存命中率从 0% → 75.2%
- `assembleDebug` 编译通过
- 所有新功能默认关闭，不影响现有用户

### 改动文件
6 files, +288/-26
- `ContextCompactor.kt` (新)
- `GenerationHandler.kt`
- `ChatService.kt`
- `Assistant.kt`
- `CompressPrompt.kt`
- `WorkspaceReminderTransformer.kt`