### PR TITLE
feat(ai): local ML Kit OCR as primary path with AI fallback

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -232,6 +232,8 @@ dependencies {
     // quickie (qrcode scanner)
     implementation(libs.quickie.bundled)
     implementation(libs.barcode.scanning)
+    implementation(libs.text.recognition.chinese)
+    implementation(libs.text.recognition)
     implementation(libs.androidx.camera.core)
 
     // Room

--- a/app/src/main/java/me/rerere/rikkahub/data/ai/transformers/OcrTransformer.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/ai/transformers/OcrTransformer.kt
@@ -1,8 +1,15 @@
 package me.rerere.rikkahub.data.ai.transformers
 
 import android.content.Context
+import android.net.Uri
 import android.util.Log
+import androidx.core.net.toUri
+import com.google.mlkit.vision.common.InputImage
+import com.google.mlkit.vision.text.TextRecognition
+import com.google.mlkit.vision.text.chinese.ChineseTextRecognizerOptions
+import com.google.mlkit.vision.text.latin.TextRecognizerOptions
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.tasks.await
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.builtins.serializer
 import kotlinx.serialization.json.Json
@@ -86,6 +93,21 @@ object OcrTransformer : InputMessageTransformer, KoinComponent {
             return cachedResult
         }
 
+        // Local ML Kit OCR first: offline, free, stable. Falls back to AI OCR when empty.
+        val localResult = performLocalOcr(part.url)
+        if (!localResult.isNullOrBlank()) {
+            Log.i(TAG, "performOcr: using local ML Kit result")
+            val localOcrResult = """
+                <image_file_ocr>
+                   $localResult
+                </image_file_ocr>
+                * The image_file_ocr tag contains a description of an image that the user uploaded to you, not the user's prompt.
+            """.trimIndent()
+            cache.put(part.url, localOcrResult)
+            return localOcrResult
+        }
+        Log.i(TAG, "performOcr: local OCR empty, falling back to AI OCR")
+
         val settings = get<SettingsStore>().settingsFlow.value
         val model = settings.findModelById(settings.ocrModelId) ?: return "[Image]"
         val providerSetting = model.findProvider(settings.providers) ?: return "[Image]"
@@ -119,5 +141,40 @@ object OcrTransformer : InputMessageTransformer, KoinComponent {
         return ocrResult
     }.getOrElse {
         "[ERROR, OCR failed: $it]"
+    }
+
+    /**
+     * Local OCR via ML Kit. Chinese model + Latin model both run, results merged
+     * line-by-line (covers mixed CJK + Latin content). Returns null when nothing
+     * was recognized (e.g. model not downloaded yet or image decode failure),
+     * letting the caller fall back to the configured AI OCR model.
+     */
+    private suspend fun performLocalOcr(url: String): String? = withContext(Dispatchers.IO) {
+        runCatching {
+            val context = get<Context>()
+            val image: InputImage = when {
+                url.startsWith("file://") -> InputImage.fromFilePath(context, Uri.parse(url))
+                else -> return@runCatching null
+            }
+
+            val chinese = TextRecognition.getClient(ChineseTextRecognizerOptions.Builder().build())
+            val latin = TextRecognition.getClient(TextRecognizerOptions.DEFAULT_OPTIONS)
+            try {
+                val chineseText = runCatching { chinese.process(image).await() }.getOrNull()?.text?.trim()
+                val latinText = runCatching { latin.process(image).await() }.getOrNull()?.text?.trim()
+
+                val combined = LinkedHashSet<String>()
+                listOfNotNull(chineseText, latinText).forEach { text ->
+                    text.lines().forEach { line ->
+                        val trimmed = line.trim()
+                        if (trimmed.isNotBlank()) combined.add(trimmed)
+                    }
+                }
+                combined.joinToString("\n").takeIf { it.isNotBlank() }
+            } finally {
+                chinese.close()
+                latin.close()
+            }
+        }.getOrNull()
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,7 @@
 [versions]
 agp = "9.3.1"
 barcodeScanning = "17.3.0"
+textRecognition = "16.0.1"
 cameraCore = "1.6.1"
 dom4j = "2.2.0"
 jlatexmath = "1.5"
@@ -74,6 +75,8 @@ androidx-media3-common = { module = "androidx.media3:media3-common", version.ref
 androidx-media3-exoplayer = { module = "androidx.media3:media3-exoplayer", version.ref = "media3" }
 androidx-media3-ui = { module = "androidx.media3:media3-ui", version.ref = "media3" }
 barcode-scanning = { module = "com.google.mlkit:barcode-scanning", version.ref = "barcodeScanning" }
+text-recognition-chinese = { module = "com.google.mlkit:text-recognition-chinese", version.ref = "textRecognition" }
+text-recognition = { module = "com.google.mlkit:text-recognition", version.ref = "textRecognition" }
 dom4j = { module = "org.dom4j:dom4j", version.ref = "dom4j" }
 jlatexmath = { module = "com.github.rikkahub.jlatexmath-android:jlatexmath", version.ref = "jlatexmath" }
 jlatexmath-font-greek = { module = "com.github.rikkahub.jlatexmath-android:jlatexmath-font-greek", version.ref = "jlatexmath" }


### PR DESCRIPTION
## What

Images sent to non-vision models are currently transcribed by a configured AI OCR model. If that model is text-only or the network fails, OCR silently produces wrong or empty results.

This PR adds an on-device ML Kit OCR pass **before** the AI call:
- Chinese + Latin recognizers run locally, results merged line-by-line (covers CJK + Latin mixed content)
- Local result is used as-is when non-empty; falls back to the configured AI OCR model otherwise
- Works offline, free, no hallucination risk

## Changes
- `OcrTransformer`: local-first OCR with AI fallback
- `gradle/libs.versions.toml`: add ML Kit text-recognition (chinese + latin)
- `app/build.gradle.kts`: wire new dependencies

## Notes
- First run downloads the ~20MB Chinese model over the network, cached afterwards
- Behavior unchanged for vision-capable models (image passed through directly)