### PR TITLE
fix(app): ignore preset messages in time reminders

### DIFF
--- a/app/src/main/java/me/rerere/rikkahub/data/ai/transformers/TimeReminderTransformer.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/ai/transformers/TimeReminderTransformer.kt
@@ -10,6 +10,7 @@ import java.time.ZoneId
 import java.time.format.TextStyle
 import java.util.Locale
 import kotlin.time.toJavaInstant
+import kotlin.uuid.Uuid
 
 private const val TIME_GAP_THRESHOLD_SECONDS = 3600L // 1 小时
 
@@ -24,33 +25,45 @@ object TimeReminderTransformer : InputMessageTransformer {
         messages: List<UIMessage>,
     ): List<UIMessage> {
         if (!ctx.assistant.enableTimeReminder) return messages
-        return applyTimeReminder(messages)
+        val presetMessageIds = ctx.assistant.presetMessages.map { it.id }.toSet()
+        return applyTimeReminder(messages, presetMessageIds)
     }
 }
 
-internal fun applyTimeReminder(messages: List<UIMessage>): List<UIMessage> {
+internal fun applyTimeReminder(
+    messages: List<UIMessage>,
+    presetMessageIds: Set<Uuid> = emptySet(),
+): List<UIMessage> {
     val result = mutableListOf<UIMessage>()
     val tz = TimeZone.currentSystemDefault()
 
-    var firstUserFound = false
-    for (i in messages.indices) {
-        val current = messages[i]
+    var firstRealUserFound = false
+    var previousRealMessage: UIMessage? = null
+    for (current in messages) {
+        // Preset messages prime the assistant but are not elapsed conversation history.
+        if (current.id in presetMessageIds) {
+            result.add(current)
+            continue
+        }
+
         if (current.role == MessageRole.USER) {
             val currInstant = current.createdAt.toInstant(tz)
-            if (!firstUserFound) {
-                firstUserFound = true
+            if (!firstRealUserFound) {
+                firstRealUserFound = true
                 result.add(buildTimeReminderMessage(null, currInstant))
             } else {
-                val previous = messages[i - 1]
-                val prevInstant = previous.createdAt.toInstant(tz)
-                val gapSeconds = (currInstant - prevInstant).inWholeSeconds
+                previousRealMessage?.let { previous ->
+                    val prevInstant = previous.createdAt.toInstant(tz)
+                    val gapSeconds = (currInstant - prevInstant).inWholeSeconds
 
-                if (gapSeconds > TIME_GAP_THRESHOLD_SECONDS) {
-                    result.add(buildTimeReminderMessage(gapSeconds, currInstant))
+                    if (gapSeconds > TIME_GAP_THRESHOLD_SECONDS) {
+                        result.add(buildTimeReminderMessage(gapSeconds, currInstant))
+                    }
                 }
             }
         }
         result.add(current)
+        previousRealMessage = current
     }
 
     return result

--- a/app/src/test/java/me/rerere/rikkahub/data/ai/transformers/TimeReminderTransformerTest.kt
+++ b/app/src/test/java/me/rerere/rikkahub/data/ai/transformers/TimeReminderTransformerTest.kt
@@ -17,6 +17,12 @@ class TimeReminderTransformerTest {
         createdAt = createdAt,
     )
 
+    private fun assistantMessage(text: String, createdAt: LocalDateTime) = UIMessage(
+        role = MessageRole.ASSISTANT,
+        parts = listOf(UIMessagePart.Text(text)),
+        createdAt = createdAt,
+    )
+
     private fun getMessageText(msg: UIMessage): String =
         msg.parts.filterIsInstance<UIMessagePart.Text>().joinToString("") { it.text }
 
@@ -68,6 +74,21 @@ class TimeReminderTransformerTest {
     }
 
     @Test
+    fun `gap should still be measured from a normal assistant response`() {
+        val messages = listOf(
+            userMessage("Hello", LocalDateTime(2026, 2, 22, 10, 0, 0)),
+            assistantMessage("Hi", LocalDateTime(2026, 2, 22, 10, 0, 0)),
+            userMessage("World", LocalDateTime(2026, 2, 22, 12, 0, 0)),
+        )
+
+        val result = applyTimeReminder(messages)
+
+        assertEquals(5, result.size)
+        assertTrue(getMessageText(result[3]).contains("2 h since last message"))
+        assertEquals("World", getMessageText(result[4]))
+    }
+
+    @Test
     fun `injected message should contain day of week and gap in hours`() {
         val messages = listOf(
             userMessage("Hello", LocalDateTime(2026, 2, 22, 10, 0, 0)),
@@ -106,6 +127,25 @@ class TimeReminderTransformerTest {
         assertEquals("Msg 2", getMessageText(result[3]))
         assertTrue(getMessageText(result[4]).contains("<time_reminder>"))
         assertEquals("Msg 3", getMessageText(result[5]))
+    }
+
+    @Test
+    fun `preset messages should not create a time gap before first real user message`() {
+        val presetUser = userMessage("Preset user", LocalDateTime(2026, 1, 1, 10, 0, 0))
+        val presetAssistant = assistantMessage("Preset assistant", LocalDateTime(2026, 1, 1, 10, 1, 0))
+        val realUser = userMessage("Hello", LocalDateTime(2026, 2, 22, 10, 0, 0))
+
+        val result = applyTimeReminder(
+            messages = listOf(presetUser, presetAssistant, realUser),
+            presetMessageIds = setOf(presetUser.id, presetAssistant.id),
+        )
+
+        assertEquals(4, result.size)
+        assertEquals(presetUser, result[0])
+        assertEquals(presetAssistant, result[1])
+        assertTrue(getMessageText(result[2]).contains("<time_reminder>"))
+        assertFalse(getMessageText(result[2]).contains("since last message"))
+        assertEquals(realUser, result[3])
     }
 
     @Test


### PR DESCRIPTION
## What happened

When time reminders were enabled, preset chat messages were treated as real conversation history. Since their timestamps came from when the preset was created or imported, the first real user message could receive a reminder such as `52 d since last message`. Preset messages provide initial prompt context rather than representing messages sent in the current conversation, so their timestamps should not be used for elapsed-time reminders.

## Fix

`TimeReminderTransformer` now ignores preset messages when calculating elapsed time. Preset messages are still sent unchanged, and normal time gaps between real messages continue to work.

## Testing

- `./gradlew --no-daemon --no-configuration-cache :app:testDebugUnitTest --tests 'me.rerere.rikkahub.data.ai.transformers.TimeReminderTransformerTest'`
- 10 tests passed locally.