### PR TITLE
perf(workspace): 优化 rootfs 硬链接处理，极大幅度减少磁盘占用

### DIFF
--- a/workspace/src/main/java/me/rerere/workspace/RootfsInstaller.kt
+++ b/workspace/src/main/java/me/rerere/workspace/RootfsInstaller.kt
@@ -3,11 +3,11 @@ package me.rerere.workspace
 import java.io.BufferedInputStream
 import java.io.EOFException
 import java.io.File
-import java.io.IOException
 import java.io.InputStream
 import java.net.HttpURLConnection
 import java.net.URL
 import java.nio.file.Files
+import java.nio.file.LinkOption
 import java.util.Locale
 import java.util.zip.GZIPInputStream
 import org.tukaani.xz.XZInputStream
@@ -33,7 +33,13 @@ class RootfsInstaller(
             stagingDir.deleteRecursively()
             stagingDir.mkdirs()
             download(url, archive, onProgress)
-            extractTar(archive, stagingDir, format, onProgress)
+            extractTar(
+                archive = archive,
+                targetDir = stagingDir,
+                format = format,
+                installedRoot = linuxDir,
+                onProgress = onProgress,
+            )
             linuxDir.deleteRecursively()
             require(stagingDir.renameTo(linuxDir)) {
                 "Failed to move rootfs into workspace"
@@ -102,8 +108,10 @@ class RootfsInstaller(
         archive: File,
         targetDir: File,
         format: ArchiveFormat = ArchiveFormat.fromFile(archive),
+        installedRoot: File = targetDir,
         onProgress: (RootfsInstallProgress) -> Unit,
     ) {
+        val hardLinks = linkedMapOf<File, File>()
         format.wrapStream(BufferedInputStream(archive.inputStream())).use { input ->
             var entries = 0
             var pendingName: String? = null
@@ -140,10 +148,23 @@ class RootfsInstaller(
                 }
                 val target = targetDir.safeResolve(header.name)
                 target.parentFile?.mkdirs()
+                if (header.type == TarEntryType.FILE ||
+                    header.type == TarEntryType.DIRECTORY ||
+                    header.type == TarEntryType.SYMLINK
+                ) {
+                    hardLinks.remove(target)
+                }
                 when (header.type) {
                     TarEntryType.DIRECTORY -> target.mkdirs()
                     TarEntryType.SYMLINK -> createSymlink(targetDir, target, header.linkName)
-                    TarEntryType.HARDLINK -> createHardLink(targetDir, target, header.linkName)
+                    TarEntryType.HARDLINK -> {
+                        require(header.linkName.isNotBlank()) {
+                            "Hard link target is blank: ${header.name}"
+                        }
+                        target.delete()
+                        hardLinks[target] = targetDir.safeResolve(header.linkName)
+                    }
+
                     TarEntryType.FILE -> {
                         target.outputStream().use { output ->
                             input.copyExactly(output, header.size)
@@ -175,6 +196,7 @@ class RootfsInstaller(
                 )
             }
         }
+        materializeHardLinks(targetDir, installedRoot, hardLinks)
     }
 
     private fun createSymlink(root: File, target: File, linkName: String) {
@@ -193,25 +215,70 @@ class RootfsInstaller(
         Files.createSymbolicLink(target.toPath(), linkTarget.toPath())
     }
 
-    private fun createHardLink(root: File, target: File, linkName: String) {
-        if (linkName.isBlank()) return
-        val source = root.safeResolve(linkName)
-        if (!source.exists()) return
-        target.delete()
-        runCatching {
-            Files.createLink(target.toPath(), source.toPath())
-        }.recoverCatching { error ->
-            if (error !is IOException &&
-                error !is UnsupportedOperationException &&
-                error !is SecurityException
-            ) {
-                throw error
+    private fun materializeHardLinks(
+        extractedRoot: File,
+        installedRoot: File,
+        hardLinks: Map<File, File>,
+    ) {
+        if (hardLinks.isEmpty()) return
+
+        val sources = hardLinks.mapValues { (link, _) ->
+            var current = link
+            val visited = mutableSetOf<File>()
+            while (current in hardLinks) {
+                require(visited.add(current)) { "Hard link cycle: ${link.path}" }
+                current = hardLinks.getValue(current)
             }
-            source.copyTo(target, overwrite = true)
-            target.setReadable(source.canRead(), false)
-            target.setWritable(source.canWrite(), true)
-            target.setExecutable(source.canExecute(), false)
-        }.getOrThrow()
+            require(Files.isRegularFile(current.toPath(), LinkOption.NOFOLLOW_LINKS)) {
+                "Hard link target is missing or not a regular file: ${current.path}"
+            }
+            current
+        }
+
+        val stagingRoot = extractedRoot.canonicalFile.toPath()
+        val finalRoot = installedRoot.canonicalFile.toPath()
+        fun finalPath(file: File): java.nio.file.Path {
+            val path = file.toPath().toAbsolutePath().normalize()
+            require(path.startsWith(stagingRoot)) { "Rootfs entry escapes target directory: $path" }
+            return finalRoot.resolve(stagingRoot.relativize(path))
+        }
+
+        sources.entries
+            .groupBy(keySelector = { it.value }, valueTransform = { it.key })
+            .forEach { (source, aliases) ->
+                checkInterrupted()
+                val publicPaths = listOf(source) + aliases
+                require(publicPaths.size in 2..MAX_LINK_COUNT) {
+                    "Unsupported hard link count: ${publicPaths.size}"
+                }
+                val countSuffix = publicPaths.size.toString().padStart(4, '0')
+                val (intermediate, backing) = (1..MAX_LINK_COUNT)
+                    .asSequence()
+                    .map { suffix ->
+                        val intermediate = File(
+                            source.parentFile,
+                            "$LINK2SYMLINK_PREFIX${source.name}${suffix.toString().padStart(4, '0')}",
+                        )
+                        intermediate to File("${intermediate.path}.$countSuffix")
+                    }
+                    .firstOrNull { (intermediate, backing) ->
+                        intermediate !in hardLinks &&
+                            backing !in hardLinks &&
+                            !Files.exists(intermediate.toPath(), LinkOption.NOFOLLOW_LINKS) &&
+                            !Files.exists(backing.toPath(), LinkOption.NOFOLLOW_LINKS)
+                    }
+                    ?: error("Unable to allocate hard link backing file for ${source.path}")
+
+                // PRoot recognizes public -> .l2s.* -> .l2s.*.NNNN as an emulated hard-link group.
+                // Targets use finalRoot because extractedRoot is renamed after extraction.
+                Files.move(source.toPath(), backing.toPath())
+                Files.createSymbolicLink(intermediate.toPath(), finalPath(backing))
+                publicPaths.forEach { path ->
+                    checkInterrupted()
+                    path.delete()
+                    Files.createSymbolicLink(path.toPath(), finalPath(intermediate))
+                }
+            }
     }
 
     private fun InputStream.readTarHeader(): TarHeader? {
@@ -414,5 +481,7 @@ class RootfsInstaller(
         private const val PROGRESS_STEP_BYTES = 512 * 1024
         private const val CONNECT_TIMEOUT_MS = 30_000
         private const val READ_TIMEOUT_MS = 60_000
+        private const val LINK2SYMLINK_PREFIX = ".l2s."
+        private const val MAX_LINK_COUNT = 9999
     }
 }

--- a/workspace/src/test/java/me/rerere/workspace/RootfsInstallerTest.kt
+++ b/workspace/src/test/java/me/rerere/workspace/RootfsInstallerTest.kt
@@ -2,11 +2,13 @@ package me.rerere.workspace
 
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
 import java.io.File
 import java.io.OutputStream
+import java.nio.file.Files
 import java.util.zip.GZIPOutputStream
 
 class RootfsInstallerTest {
@@ -49,14 +51,47 @@ class RootfsInstallerTest {
         assertEquals("content", File(target, "dir/file.txt").readText())
     }
 
+    @Test
+    fun `extract preserves hard links after staging move`() {
+        val archive = tmp.newFile("rootfs.tar.gz")
+        GZIPOutputStream(archive.outputStream()).use { out ->
+            out.writeTarEntry("usr/bin/tool-before", '1', linkName = "bin/tool")
+            out.writeTarEntry("bin/tool", '0', "content".toByteArray())
+            out.writeTarEntry("usr/bin/tool-after", '1', linkName = "bin/tool")
+            out.write(ByteArray(TAR_BLOCK * 2))
+        }
+
+        val staging = tmp.newFolder("staging")
+        val installed = File(tmp.root, "linux")
+        createInstaller().extractTar(archive, staging, installedRoot = installed) {}
+        assertTrue(staging.renameTo(installed))
+
+        val paths = listOf(
+            File(installed, "bin/tool"),
+            File(installed, "usr/bin/tool-before"),
+            File(installed, "usr/bin/tool-after"),
+        )
+        val intermediate = Files.readSymbolicLink(paths.first().toPath())
+        assertTrue(paths.all { Files.isSymbolicLink(it.toPath()) })
+        assertTrue(paths.all { Files.readSymbolicLink(it.toPath()) == intermediate })
+        assertTrue(Files.readSymbolicLink(intermediate).fileName.toString().endsWith(".0003"))
+        assertTrue(paths.all { it.readText() == "content" })
+    }
+
     private fun createInstaller() = RootfsInstaller(WorkspaceManager(tmp.newFolder()))
 
-    private fun OutputStream.writeTarEntry(name: String, type: Char, data: ByteArray) {
+    private fun OutputStream.writeTarEntry(
+        name: String,
+        type: Char,
+        data: ByteArray = ByteArray(0),
+        linkName: String = "",
+    ) {
         val header = ByteArray(TAR_BLOCK)
         name.toByteArray(Charsets.UTF_8).copyInto(header, 0)
         "0000755".toByteArray().copyInto(header, 100)
         data.size.toLong().toOctalField().copyInto(header, 124)
         header[156] = type.code.toByte()
+        linkName.toByteArray(Charsets.UTF_8).copyInto(header, 157)
         write(header)
         write(data)
         val padding = (TAR_BLOCK - data.size % TAR_BLOCK) % TAR_BLOCK


### PR DESCRIPTION
这是原 PR #1611 因原 fork 删除后恢复的替代 PR。

原 PR：https://github.com/rikkahub/rikkahub/pull/1611

Closes #1608

本 PR 改为直接生成 PRoot 支持的 `--link2symlink` 格式来处理硬链接。
具体做法是提取时先收集硬链接条目，提取完后统一转成 `public path -> .l2s.intermediate -> .l2s.backing.NNNN` 的结构。考虑到 staging 目录会被重命名，符号链接的目标直接用了最终的 `linux/` 绝对路径。

改完后 Ubuntu Base 解压完正常回到 120M 左右。没有任何 UI 和 API 层面的修改。

-----

对于之前已经解压膨胀的环境，可以把重复复制的 `coreutils` 转换回 PRoot 的链接格式来释放空间（不知道这么整有没有风险... re考虑给个一次性的自动修复ui吗）：

```sh
set -eu

source=/usr/bin/coreutils
dir=/usr/lib/cargo/bin/coreutils
[ -f "$source" ] && [ -d "$dir" ]

rm -f -- "$dir"/.rikkahub-hardlink-fix.*

fixed=0
for target in "$dir"/*; do
    [ -f "$target" ] || continue
    [ "$source" -ef "$target" ] && continue
    cmp -s -- "$source" "$target" || continue

    tmp=$(mktemp "$dir/.rikkahub-hardlink-fix.XXXXXX")
    rm -f -- "$tmp"
    if ln -- "$source" "$tmp" && mv -f -- "$tmp" "$target"; then
        fixed=$((fixed + 1))
    else
        rm -f -- "$tmp"
        exit 1
    fi
done

rm -f -- "$dir"/.rikkahub-hardlink-fix.*
printf 'Repaired %s duplicated coreutils files.\n' "$fixed"