### PR TITLE
fix(ai): 修复内置搜索与外挂搜索同时启用的问题

### DIFF
--- a/app/src/main/java/me/rerere/rikkahub/service/ChatService.kt
+++ b/app/src/main/java/me/rerere/rikkahub/service/ChatService.kt
@@ -29,6 +29,7 @@ import kotlinx.serialization.json.jsonObject
 import me.rerere.ai.core.MessageRole
 import me.rerere.ai.core.ReasoningLevel
 import me.rerere.ai.core.Tool
+import me.rerere.ai.provider.BuiltInTools
 import me.rerere.ai.provider.Model
 import me.rerere.ai.provider.ModelAbility
 import me.rerere.ai.provider.ProviderManager
@@ -100,6 +101,10 @@ internal fun backgroundTextGenerationParams(
     customHeaders = model.customHeaders,
     customBody = model.customBodies,
 )
+
+internal fun shouldUseExternalWebSearch(assistant: Assistant, model: Model): Boolean {
+    return assistant.enableWebSearch && BuiltInTools.Search !in model.tools
+}
 
 data class ChatError(
     val id: Uuid = Uuid.random(),
@@ -479,6 +484,7 @@ class ChatService(
         } else {
             model.displayName
         }
+        val useExternalWebSearch = shouldUseExternalWebSearch(assistant, model)
 
         runCatching {
 
@@ -487,7 +493,7 @@ class ChatService(
 
             // memory tool
             if (!model.abilities.contains(ModelAbility.TOOL)) {
-                if (assistant.enableWebSearch || mcpManager.getAllAvailableTools().isNotEmpty()) {
+                if (useExternalWebSearch || mcpManager.getAllAvailableTools().isNotEmpty()) {
                     addError(
                         IllegalStateException(context.getString(R.string.tools_warning)),
                         conversationId,
@@ -530,7 +536,7 @@ class ChatService(
                 },
                 outputTransformers = outputTransformers,
                 tools = buildList {
-                    if (assistant.enableWebSearch) {
+                    if (useExternalWebSearch) {
                         addAll(createSearchTools(settings))
                     }
                     addAll(localTools.getTools(assistant.localTools))

--- a/app/src/test/java/me/rerere/rikkahub/service/ChatServiceTest.kt
+++ b/app/src/test/java/me/rerere/rikkahub/service/ChatServiceTest.kt
@@ -2,10 +2,14 @@ package me.rerere.rikkahub.service
 
 import kotlinx.serialization.json.JsonPrimitive
 import me.rerere.ai.core.ReasoningLevel
+import me.rerere.ai.provider.BuiltInTools
 import me.rerere.ai.provider.CustomBody
 import me.rerere.ai.provider.CustomHeader
 import me.rerere.ai.provider.Model
+import me.rerere.rikkahub.data.model.Assistant
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class ChatServiceTest {
@@ -22,8 +26,48 @@ class ChatServiceTest {
         val params = backgroundTextGenerationParams(model)
 
         assertEquals(model, params.model)
-        assertEquals(ReasoningLevel.OFF, params.reasoningLevel)
+        assertEquals(ReasoningLevel.AUTO, params.reasoningLevel)
         assertEquals(headers, params.customHeaders)
         assertEquals(bodies, params.customBody)
+    }
+
+    @Test
+    fun `external web search is disabled when assistant preference is disabled`() {
+        val assistant = Assistant(enableWebSearch = false)
+        val model = Model()
+
+        assertFalse(shouldUseExternalWebSearch(assistant, model))
+    }
+
+    @Test
+    fun `external web search is enabled when assistant preference is enabled`() {
+        val assistant = Assistant(enableWebSearch = true)
+        val model = Model()
+
+        assertTrue(shouldUseExternalWebSearch(assistant, model))
+    }
+
+    @Test
+    fun `built-in search suppresses enabled external web search`() {
+        val assistant = Assistant(enableWebSearch = true)
+        val model = Model(tools = setOf(BuiltInTools.Search))
+
+        assertFalse(shouldUseExternalWebSearch(assistant, model))
+    }
+
+    @Test
+    fun `built-in search remains exclusive when external web search is disabled`() {
+        val assistant = Assistant(enableWebSearch = false)
+        val model = Model(tools = setOf(BuiltInTools.Search))
+
+        assertFalse(shouldUseExternalWebSearch(assistant, model))
+    }
+
+    @Test
+    fun `unrelated built-in tools do not suppress external web search`() {
+        val assistant = Assistant(enableWebSearch = true)
+        val model = Model(tools = setOf(BuiltInTools.UrlContext))
+
+        assertTrue(shouldUseExternalWebSearch(assistant, model))
     }
 }


### PR DESCRIPTION
这是原 PR #1613 因原 fork 删除后恢复的替代 PR。

原 PR：https://github.com/rikkahub/rikkahub/pull/1613

Closes #1579 
Closes #1652

## 问题
当 Assistant 开启了“网络搜索”选项，且当前使用的模型本身自带内置的 Web Search (BuiltInTools.Search) 时，两套搜索会被同时发给模型。根据UI的隐藏策略，这应该是不符合预期的吧rerere ：（


## 修复
- 引入纯函数 `shouldUseExternalWebSearch` 统一判断逻辑：当检测到模型自带 `BuiltInTools.Search` 时，主动抑制/覆盖掉 Assistant 级别的外挂网络搜索。
- 在 `ChatService.kt` 中应用此逻辑，确保工具集只包含其中一种搜索。
- 补充完整的单元测试（GPT就喜欢这个
-  顺手修复了 `ChatServiceTest.kt` 中因为 `ReasoningLevel` 默认值变更导致的一个陈旧测试报错 (`OFF` -> `AUTO`)。