### PR TITLE
feat(richtext): 工作区 pdflatex 管线编译渲染 TikZ 图表（tikzcd/xy/AMScd等）

### DIFF
--- a/app/src/main/java/me/rerere/rikkahub/data/ai/GenerationHandler.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/ai/GenerationHandler.kt
@@ -383,6 +383,11 @@ class GenerationHandler(
                     appendLine()
                     append(tool.systemPrompt(model, messages))
                 }
+                // TikZ 渲染提示
+                if (settings.displaySetting.enableDiagramRendering) {
+                    appendLine()
+                    append("Use \\begin{tikzcd}...\\end{tikzcd} inside $$...$$ for diagrams. They render as vector graphics inline.")
+                }
             }
             if (system.isNotBlank()) add(UIMessage.system(prompt = system))
             addAll(messages.limitContext(assistant.contextMessageLimit))

--- a/app/src/main/java/me/rerere/rikkahub/data/datastore/PreferencesStore.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/datastore/PreferencesStore.kt
@@ -609,6 +609,9 @@ data class DisplaySetting(
     val sendOnEnter: Boolean = false,
     val enableAutoScroll: Boolean = true,
     val enableLatexRendering: Boolean = true,
+    val enableDiagramRendering: Boolean = false, // 需要工作区安装 LaTeX 后才开启
+    val diagramFontSize: Float = 18f, // TikZ 默认字号 dp（TeX 10pt 字 → 显示字号；K=字号/10）
+    val diagramMinFontSize: Float = 14f, // TikZ 最小字号 dp（超宽图降级下限，再超则横向滚动）
     val enableBlurEffect: Boolean = false,
     val chatFontFamily: ChatFontFamily = ChatFontFamily.DEFAULT,
     val chatCustomFontPath: String = "",

--- a/app/src/main/java/me/rerere/rikkahub/ui/components/richtext/DiagramRenderer.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/richtext/DiagramRenderer.kt
@@ -1,0 +1,132 @@
+package me.rerere.rikkahub.ui.components.richtext
+
+import kotlinx.coroutines.flow.first
+import me.rerere.rikkahub.data.repository.WorkspaceRepository
+import me.rerere.workspace.WorkspaceShellStatus
+import me.rerere.workspace.WorkspaceStorageArea
+
+/**
+ * 通过工作区 pdflatex 编译 LaTeX 图表代码，返回渲染后的 SVG 矢量文本。
+ * 不负责缓存——缓存由调用方（[LatexRenderCache]）管理。
+ */
+object DiagramRenderer {
+
+    /** CJK 统一表意文字（中文）检测：含这些字符时用 xelatex 编译并加载 ctex 宏包
+     *  （ctex/fandol 为 OTF 字体，pdfTeX 不支持；需工作区安装 texlive-lang-chinese + texlive-xetex） */
+    private val CJK_REGEX = Regex("[\u4e00-\u9fff\u3400-\u4dbf]")
+
+    private const val TIMEOUT_COMPILE = 15_000L
+    private const val TIMEOUT_CONVERT = 5_000L
+    private const val TIMEOUT_CLEANUP = 1_000L
+    private const val BASE_PREFIX = "_rikka_d"
+
+    /** @throws IllegalStateException 工作区不可用或编译失败
+     *  @param isDark 深色模式时注入 \\color{white}，从 LaTeX 源头控制颜色（避免 SVG 后处理替换的脆弱性） */
+    suspend fun render(repo: WorkspaceRepository, latex: String, isDark: Boolean = false): String {
+        val workspace = repo.listFlow().first().firstOrNull {
+            it.shellStatus == WorkspaceShellStatus.READY.name
+        } ?: throw IllegalStateException("没有可用的工作区")
+
+        val id = workspace.id
+        // 用随机后缀确保并发渲染不互相覆盖
+        val base = "${BASE_PREFIX}_${kotlin.random.Random.nextLong().toString(36)}"
+
+        try {
+            repo.writeText(id, "$base.tex", buildPreamble(latex, isDark), overwrite = true)
+
+            // 中文（CJK）检测：ctex + fandol 为 OTF 字体，pdfTeX 不支持，需切 xelatex
+            val hasCjk = CJK_REGEX.containsMatchIn(latex)
+            val engine = if (hasCjk) "xelatex" else "pdflatex"
+            // xelatex 首次加载字体较慢，超时翻倍
+            val compileTimeout = if (hasCjk) TIMEOUT_COMPILE * 2 else TIMEOUT_COMPILE
+
+            repo.executeCommand(id,
+                command = "$engine -interaction=nonstopmode $base.tex",
+                cwd = "", timeoutMillis = compileTimeout
+            )
+            // fileSize 对不存在的文件抛 IllegalArgumentException（"File does not exist: ..."），
+            // 用 runCatching 容错为 0，从而走下面读 .log 提取真实错误原因，而不是把底层异常透传给用户
+            val pdfSize = runCatching { repo.fileSize(id, WorkspaceStorageArea.FILES, "$base.pdf") }.getOrDefault(0L)
+            if (pdfSize <= 0L) {
+                // 读 .log 提取缺失宏包名，给用户可操作的错误信息
+                val reason = runCatching {
+                    val log = repo.readText(id, "$base.log")
+                    val m = Regex("""! LaTeX Error: File '([^']+\.sty)' not found""").find(log)
+                        ?: Regex("""! Package ([a-zA-Z0-9]+) Error""").find(log)
+                    m?.groupValues?.get(1)?.let { "缺少宏包: $it（可用 apt install texlive-* 安装）" }
+                        ?: log.lineSequence().firstOrNull { it.trimStart().startsWith("!") }
+                            ?.let { "LaTeX 编译失败: $it" }
+                }.getOrNull()
+                throw IllegalStateException(reason ?: "LaTeX 编译失败")
+            }
+
+            repo.executeCommand(id,
+                command = "pdftocairo -svg $base.pdf $base.svg",
+                cwd = "", timeoutMillis = TIMEOUT_CONVERT
+            )
+
+            val svg = repo.readText(id, "$base.svg")
+            if (svg.isBlank()) throw IllegalStateException("SVG 转换为空")
+            return svg
+        } finally {
+            runCatching {
+                repo.executeCommand(id,
+                    command = "rm -f $base.*",
+                    cwd = "", timeoutMillis = TIMEOUT_CLEANUP
+                )
+            }
+        }
+    }
+
+    /** 动态 preamble：基础包 + 从用户代码提取的额外 \usepackage / \usetikzlibrary。
+     *  这样新增 tikz 宏包（pgfplots/chemfig 等）无需改代码——用户代码声明即加载。 */
+    private fun buildPreamble(latex: String, isDark: Boolean): String {        // 提取用户代码里的额外宏包（排除已在基础 preamble 的）
+        val basePackages = setOf(
+            "fontenc", "lmodern", "tikz", "xcolor", "amsmath", "amssymb", "xy", "amscd",
+        )
+        val extraPackages = Regex("""\\usepackage(?:\[[^]]*\])?\{([^}]+)\}""")
+            .findAll(latex)
+            .flatMap { it.groupValues[1].split(",").map(String::trim) }
+            .filter { it.isNotBlank() && it !in basePackages }
+            .distinct()
+            .toList()
+
+        // 提取用户代码里的 tikz library（基础已有 cd/arrows.meta）
+        val baseLibs = setOf("cd", "arrows.meta")
+        val extraLibs = Regex("""\\usetikzlibrary\{([^}]+)\}""")
+            .findAll(latex)
+            .flatMap { it.groupValues[1].split(",").map(String::trim) }
+            .filter { it.isNotBlank() && it !in baseLibs }
+            .distinct()
+            .toList()
+
+        val libs = (baseLibs + extraLibs).joinToString(",")
+
+        return buildString {
+            // border 4pt（原 8pt）：减小上下左右留白，图更紧凑（8pt 在放大 1.8 倍后空隙达 28.8dp）
+            appendLine("\\documentclass[border=4pt]{standalone}")
+            appendLine("\\usepackage[T1]{fontenc}")
+            appendLine("\\usepackage{lmodern}")
+            appendLine("\\usepackage{tikz}")
+            appendLine("\\usetikzlibrary{$libs}")
+            appendLine("\\usepackage{xcolor}")
+            appendLine(if (isDark) "\\color{white}" else "\\color{black}")
+            appendLine("\\usepackage{amsmath,amssymb}")
+            appendLine("\\usepackage[all]{xy}")
+            appendLine("\\usepackage{amscd}")
+            // 中文支持：用户代码含 CJK 字符时加载 ctex（需工作区安装 texlive-lang-chinese，
+            // 否则 pdflatex 对 UTF-8 中文报错）
+            if (CJK_REGEX.containsMatchIn(latex)) {
+                appendLine("\\usepackage[UTF8]{ctex}")
+            }
+            extraPackages.forEach { appendLine("\\usepackage{$it}") }
+            appendLine("""\tikzcdset{
+  every arrow/.append style={/tikz/line width=0.35pt},
+  every label/.append style={font=\footnotesize}
+}""")
+            appendLine("\\begin{document}")
+            appendLine(latex)
+            appendLine("\\end{document}")
+        }
+    }
+}

--- a/app/src/main/java/me/rerere/rikkahub/ui/components/richtext/LatexCapability.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/richtext/LatexCapability.kt
@@ -1,0 +1,99 @@
+package me.rerere.rikkahub.ui.components.richtext
+
+import android.content.Context
+import android.content.SharedPreferences
+import kotlinx.coroutines.flow.first
+import me.rerere.rikkahub.data.repository.WorkspaceRepository
+import me.rerere.workspace.WorkspaceShellStatus
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
+
+/**
+ * 检测工作区是否安装了 LaTeX 图表渲染所需的工具链。
+ * 首次检测后缓存到 SharedPreferences，避免重复 which 调用。
+ */
+object LatexCapability : KoinComponent {
+
+    private const val PREFS_NAME = "latex_capability"
+    private const val KEY_CHECKED = "checked"
+    private const val KEY_AVAILABLE = "available"
+    private const val KEY_LAST_CHECK = "last_check"
+
+    /**
+     * false 结果的缓存有效期（毫秒）。超过后即使缓存了 false 也会重新检测——
+     * 修复"装包前检测失败被永久缓存，装完包后永远报 LaTeX 未安装"的问题。
+     * true 结果永久缓存（工具链不会无故消失）。
+     */
+    private const val FALSE_TTL_MS = 60_000L
+
+    private val repo: WorkspaceRepository by inject()
+
+    /** 所需工具清单（缺一不可）。注意：不能把 "kpsewhich tikz.sty" 当单个工具名传给 which，
+     *  那会被解释成检查 kpsewhich/tikz/sty 三个命令，tikz/sty 非可执行文件导致检测失真。
+     *  正确做法：which 查可执行文件，kpsewhich 查宏包文件。 */
+    private val REQUIRED_TOOLS = listOf(
+        "pdflatex",
+        "pdftocairo",
+    )
+
+    suspend fun isAvailable(context: Context): Boolean {
+        val prefs: SharedPreferences =
+            context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+
+        // 缓存命中判定：
+        //  - 缓存的 true：永久有效（工具链装好后不会消失）
+        //  - 缓存的 false：仅 FALSE_TTL_MS 内有效，过期后自动重检（用户装完包无需"关再开"开关）
+        val cachedAvailable = prefs.getBoolean(KEY_AVAILABLE, false)
+        if (prefs.getBoolean(KEY_CHECKED, false)) {
+            val lastCheck = prefs.getLong(KEY_LAST_CHECK, 0L)
+            val ttlOk = if (cachedAvailable) Long.MAX_VALUE else FALSE_TTL_MS
+            if (System.currentTimeMillis() - lastCheck < ttlOk) {
+                return cachedAvailable
+            }
+        }
+
+        val available = checkWorkspace()
+        prefs.edit()
+            .putBoolean(KEY_CHECKED, true)
+            .putBoolean(KEY_AVAILABLE, available)
+            .putLong(KEY_LAST_CHECK, System.currentTimeMillis())
+            .apply()
+        return available
+    }
+
+    /** 强制重新检测（用户装完 LaTeX 后调用） */
+    suspend fun recheck(context: Context): Boolean {
+        context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            .edit().putBoolean(KEY_CHECKED, false).apply()
+        return isAvailable(context)
+    }
+
+    private suspend fun checkWorkspace(): Boolean {
+        return try {
+            val workspace = repo.listFlow().first().firstOrNull {
+                it.shellStatus == WorkspaceShellStatus.READY.name
+            } ?: return false
+
+            // which 查可执行文件
+            val binariesOk = REQUIRED_TOOLS.all { tool ->
+                val result = repo.executeCommand(
+                    id = workspace.id,
+                    command = "which " + tool,
+                    cwd = "",
+                    timeoutMillis = 3_000
+                )
+                result.stdout.isNotBlank()
+            }
+            // kpsewhich 查宏包文件（tikz.sty 必须存在）
+            val tikzOk = repo.executeCommand(
+                id = workspace.id,
+                command = "kpsewhich tikz.sty",
+                cwd = "",
+                timeoutMillis = 3_000
+            ).stdout.isNotBlank()
+            binariesOk && tikzOk
+        } catch (_: Exception) {
+            false
+        }
+    }
+}

--- a/app/src/main/java/me/rerere/rikkahub/ui/components/richtext/LatexRenderCache.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/richtext/LatexRenderCache.kt
@@ -1,0 +1,36 @@
+package me.rerere.rikkahub.ui.components.richtext
+
+import java.util.LinkedHashMap
+import java.util.concurrent.locks.ReentrantLock
+import kotlin.concurrent.withLock
+
+/**
+ * 图表渲染结果的 LRU 内存缓存（存 SVG 字符串，体积远小于 Bitmap）。
+ */
+class LatexRenderCache(
+    private val maxEntries: Int = 128
+) {
+    private val lock = ReentrantLock()
+
+    private val map = object : LinkedHashMap<String, String>(maxEntries, 0.75f, true) {
+        override fun removeEldestEntry(eldest: MutableMap.MutableEntry<String, String>?): Boolean {
+            return size > maxEntries
+        }
+    }
+
+    fun get(key: String): String? = lock.withLock { map[key] }
+
+    fun put(key: String, svg: String) {
+        lock.withLock {
+            map[key] = svg
+        }
+    }
+
+    fun clear() {
+        lock.withLock { map.clear() }
+    }
+
+    fun onLowMemory() {
+        lock.withLock { map.clear() }
+    }
+}

--- a/app/src/main/java/me/rerere/rikkahub/ui/components/richtext/MathBlock.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/richtext/MathBlock.kt
@@ -2,17 +2,77 @@ package me.rerere.rikkahub.ui.components.richtext
 
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.takeOrElse
+import coil3.compose.AsyncImage
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.withContext
+import me.rerere.rikkahub.data.repository.WorkspaceRepository
+import me.rerere.rikkahub.ui.context.LocalSettings
+import me.rerere.rikkahub.ui.theme.LocalDarkMode
+import org.koin.compose.koinInject
+import java.io.File
+import java.security.MessageDigest
+
+private val DIAGRAM_PATTERNS = listOf(
+    Regex("""\\begin\{tikz\w*\}"""),   // 前缀通配：tikzpicture/tikzcd/tikztiming...
+    Regex("""\\begin\{axis\}"""),          // pgfplots
+    Regex("""\\xymatrix\{"""),
+    Regex("""\\begin\{CD\}"""),
+)
+
+private fun isDiagramLatex(latex: String): Boolean =
+    DIAGRAM_PATTERNS.any { it.containsMatchIn(latex) }
+
+/** 去掉 Markdown 块公式的 $$ / \[...\] 外层包裹（对齐 LatexText.processLatex 行为） */
+private fun stripDollarWrappers(latex: String): String {
+    val t = latex.trim()
+    return when {
+        t.startsWith("$$") && t.endsWith("$$") && t.length > 4 -> t.substring(2, t.length - 2).trim()
+        t.startsWith("\\[") && t.endsWith("\\]") && t.length > 4 -> t.substring(2, t.length - 2).trim()
+        else -> t
+    }
+}
+
+private fun latexKey(latex: String): String =
+    MessageDigest.getInstance("SHA-256")
+        .digest(latex.toByteArray())
+        .joinToString("") { "%02x".format(it) }
+
+private sealed class DiagramRenderState {
+    data object Idle : DiagramRenderState()
+    data object Rendering : DiagramRenderState()
+    data class Ready(val svg: String) : DiagramRenderState()
+    data class Failed(val reason: String) : DiagramRenderState()
+}
+
+private val renderCache = LatexRenderCache()
 
 @Composable
 fun MathInline(
@@ -20,9 +80,8 @@ fun MathInline(
     modifier: Modifier = Modifier,
     fontSize: TextUnit = TextUnit.Unspecified
 ) {
-    val proceededLatex = latex
     LatexText(
-        latex = proceededLatex,
+        latex = latex,
         color = LocalContentColor.current,
         fontSize = fontSize.takeOrElse { LocalTextStyle.current.fontSize },
         modifier = modifier,
@@ -35,19 +94,193 @@ fun MathBlock(
     modifier: Modifier = Modifier,
     fontSize: TextUnit = TextUnit.Unspecified
 ) {
-    val proceededLatex = latex
-    Box(
-        modifier = modifier.padding(8.dp)
-    ) {
-        LatexText(
-            latex = proceededLatex,
-            color = LocalContentColor.current,
-            fontSize = fontSize.takeOrElse { LocalTextStyle.current.fontSize },
-            modifier = Modifier
-                .align(Alignment.Center)
-                .horizontalScroll(
-                    rememberScrollState()
-                ),
+    val settings = LocalSettings.current.displaySetting
+    val context = LocalContext.current
+    val repo: WorkspaceRepository = koinInject()
+    // 跟随应用内"通用设置-颜色模式"（LocalDarkMode 由 RouteActivity 按 colorMode 计算），
+    // 与 HighlightCodeBlock/Mermaid 等组件一致；不能用 isSystemInDarkTheme()（只反映系统主题，
+    // 应用内设浅色+系统深色时会错误地按深色渲染出白图）
+    val isDark = LocalDarkMode.current
+
+    val enableRendering = settings.enableDiagramRendering
+    val isDiagram = remember(latex) { isDiagramLatex(latex) }
+    // 颜色在 LaTeX 源头注入（\color{white}/\color{black}），亮/暗模式各存一份缓存
+    val key = remember(latex, isDark) { "${if (isDark) "d" else "l"}_${latexKey(latex)}" }
+
+    var renderState by remember { mutableStateOf<DiagramRenderState>(DiagramRenderState.Idle) }
+    val latestLatex by rememberUpdatedState(latex)
+
+    LaunchedEffect(enableRendering, isDiagram, latex) {
+        if (!enableRendering || !isDiagram) {
+            renderState = DiagramRenderState.Idle
+            return@LaunchedEffect
+        }
+
+        // 1. 内存缓存
+        renderCache.get(key)?.let {
+            renderState = DiagramRenderState.Ready(it)
+            return@LaunchedEffect
+        }
+
+        // 2. 磁盘缓存（IO 线程，避免主线程磁盘读）
+        val diskFile = File(context.filesDir, "latex_renders/$key.svg")
+        val cached = withContext(Dispatchers.IO) {
+            if (diskFile.exists()) diskFile.readText() else null
+        }
+        if (cached != null) {
+            renderCache.put(key, cached)
+            renderState = DiagramRenderState.Ready(cached)
+            return@LaunchedEffect
+        }
+
+        renderState = DiagramRenderState.Rendering
+
+        try {
+            kotlinx.coroutines.delay(100)
+            val current = latestLatex
+
+            val svg = withContext(Dispatchers.IO) {
+                if (!LatexCapability.isAvailable(context)) {
+                    throw IllegalStateException("LaTeX 未安装")
+                }
+                DiagramRenderer.render(repo, stripDollarWrappers(current), isDark)
+            }
+
+            // 存磁盘（原始 SVG，黑色）
+            withContext(Dispatchers.IO) {
+                diskFile.parentFile?.mkdirs()
+                diskFile.writeText(svg)
+            }
+
+            renderCache.put(key, svg)
+            renderState = DiagramRenderState.Ready(svg)
+        } catch (ce: kotlinx.coroutines.CancellationException) {
+            throw ce
+        } catch (e: Exception) {
+            renderState = DiagramRenderState.Failed(e.message ?: "未知错误")
+        }
+    }
+
+    val state = renderState
+    when (state) {
+        DiagramRenderState.Idle -> {
+            Box(modifier = modifier.padding(8.dp)) {
+                LatexText(
+                    latex = latex,
+                    color = LocalContentColor.current,
+                    fontSize = fontSize.takeOrElse { LocalTextStyle.current.fontSize },
+                    modifier = Modifier
+                        .align(Alignment.Center)
+                        .horizontalScroll(rememberScrollState()),
+                )
+            }
+        }
+
+        is DiagramRenderState.Failed -> {
+            Column(modifier = modifier.padding(8.dp)) {
+                LatexText(
+                    latex = latex,
+                    color = LocalContentColor.current.copy(alpha = 0.5f),
+                    fontSize = fontSize.takeOrElse { LocalTextStyle.current.fontSize },
+                    modifier = Modifier.horizontalScroll(rememberScrollState()),
+                )
+                Text(
+                    text = state.reason,
+                    color = MaterialTheme.colorScheme.error,
+                    style = MaterialTheme.typography.labelSmall,
+                    modifier = Modifier.padding(top = 4.dp),
+                )
+            }
+        }
+
+        DiagramRenderState.Rendering -> {
+            Box(modifier = modifier.padding(8.dp)) {
+                LatexText(
+                    latex = latex,
+                    color = LocalContentColor.current.copy(alpha = 0.4f),
+                    fontSize = fontSize.takeOrElse { LocalTextStyle.current.fontSize },
+                    modifier = Modifier
+                        .align(Alignment.Center)
+                        .horizontalScroll(rememberScrollState()),
+                )
+            }
+        }
+
+        is DiagramRenderState.Ready -> {
+            // SVG 颜色已在 LaTeX 源头按 isDark 注入（\color{white}/\color{black}），无需字符串替换
+            DiagramImage(
+                svg = state.svg,
+                key = key,
+                modifier = modifier,
+                kFull = settings.diagramFontSize / 10f,
+                kMin = settings.diagramMinFontSize / 10f,
+            )
+        }
+    }
+}
+
+@Composable
+private fun DiagramImage(svg: String, key: String, modifier: Modifier, kFull: Float, kMin: Float) {
+    val context = LocalContext.current
+    var svgFile by remember { mutableStateOf<File?>(null) }
+
+    // IO 线程写文件，组合期不做磁盘 IO
+    LaunchedEffect(svg) {
+        svgFile = withContext(Dispatchers.IO) {
+            val dir = File(context.cacheDir, "latex_svg")
+            dir.mkdirs()
+            File(dir, "$key.svg").apply { writeText(svg) }
+        }
+    }
+
+    // SVG 逻辑尺寸（1px→1dp），与 Bitmap 渲染密度解耦，避免高 dpi 下图过大
+    val size = remember(svg) { parseSvgSize(svg) }
+
+    val file = svgFile
+    if (file != null && size != null) {
+        val (w, h) = size
+        // LaTeX 式智能缩放：优先保字号（恒定 18dp，K=1.8），图框随内容自然调整。
+        // pdftocairo 直出 1pt≈1px，TeX 10pt 字 em≈10px → K = 字号/10。
+        // 宽度策略（分级）：
+        //   1. w×1.8 ≤ 可用宽 → 字号 18dp 完整显示，不滚动
+        //   2. 超宽 → 降级到最小字号 14dp（K=1.4）再试
+        //   3. 仍超宽 → 横向滚动查看（字号保持 14dp 不再压缩）
+        val maxW = (LocalConfiguration.current.screenWidthDp - 48).coerceAtLeast(240)
+        // 字号由设置控制：默认 kFull（18dp → K=1.8）、最小 kMin（14dp → K=1.4）
+        val scale = if (w * kFull <= maxW) kFull else kMin
+        val scrollable = w * scale > maxW
+
+        val wdp = (w * scale).dp
+        val hdp = (h * scale).dp
+        val finalModifier = if (scrollable) {
+            modifier.horizontalScroll(rememberScrollState()).size(wdp, hdp)
+        } else {
+            modifier.size(wdp, hdp)
+        }
+        AsyncImage(
+            model = file,
+            contentDescription = "交换图",
+            modifier = finalModifier.padding(vertical = 4.dp),
+            contentScale = ContentScale.Fit,
         )
+    }
+}
+
+/**
+ * 从 pdftocairo 生成的 SVG 提取逻辑尺寸。
+ *
+ * pdftocairo 输出的 width/height 无单位（CSS 默认 px），TeX 默认 10pt 字 ≈ 13.3px。
+ * 显示时按 1px→1dp 映射，与 Bitmap（scaleToDensity=true 按设备 density 渲染）解耦——
+ * 修复 Coil SvgDecoder 的 Bitmap px 被 Compose 直接当 dp 布局导致的高 dpi 下
+ * "小图显示 200dp+、字号 36dp+" 的图过大问题。修复后字号统一 ≈13dp，
+ * 图大小与内容量成正比（小图 75dp、大图 157dp）。
+ */
+private fun parseSvgSize(svg: String): Pair<Float, Float>? {
+    val m = Regex("""<svg[^>]*\bwidth="([\d.]+)"[^>]*\bheight="([\d.]+)"""").find(svg)
+        ?: Regex("""<svg[^>]*\bheight="([\d.]+)"[^>]*\bwidth="([\d.]+)"""").find(svg)
+    return m?.let {
+        val w = it.groupValues[1].toFloatOrNull()
+        val h = it.groupValues[2].toFloatOrNull()
+        if (w != null && h != null && w > 0f && h > 0f) w to h else null
     }
 }

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingPreferencesUIPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingPreferencesUIPage.kt
@@ -35,6 +35,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.dp
+import kotlin.math.roundToInt
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.dokar.sonner.ToastType
 import kotlinx.coroutines.Dispatchers
@@ -55,6 +56,7 @@ import me.rerere.rikkahub.ui.components.ui.Select
 import me.rerere.rikkahub.ui.context.LocalToaster
 import me.rerere.rikkahub.ui.theme.CustomColors
 import me.rerere.rikkahub.ui.theme.rememberChatFontFamily
+import me.rerere.rikkahub.ui.components.richtext.LatexCapability
 import me.rerere.rikkahub.utils.plus
 import org.koin.androidx.compose.koinViewModel
 import java.io.File
@@ -256,6 +258,65 @@ fun SettingPreferencesUIPage(vm: SettingVM = koinViewModel()) {
                             )
                         },
                     )
+                    item(
+                        headlineContent = { Text(stringResource(R.string.setting_display_page_enable_diagram_rendering_title)) },
+                        supportingContent = { Text(stringResource(R.string.setting_display_page_enable_diagram_rendering_desc)) },
+                        trailingContent = {
+                            Switch(
+                                checked = displaySetting.enableDiagramRendering,
+                                onCheckedChange = { enabled ->
+                                    updateDisplaySetting(displaySetting.copy(enableDiagramRendering = enabled))
+                                    if (enabled) {
+                                        scope.launch(Dispatchers.IO) {
+                                            LatexCapability.recheck(context)
+                                        }
+                                    }
+                                }
+                            )
+                        },
+                    )
+                    if (displaySetting.enableDiagramRendering) {
+                        item(
+                            headlineContent = { Text(stringResource(R.string.setting_display_page_tikz_font_size_title)) },
+                            supportingContent = {
+                                Row(
+                                    modifier = Modifier.fillMaxWidth(),
+                                    verticalAlignment = Alignment.CenterVertically,
+                                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                                ) {
+                                    Slider(
+                                        value = displaySetting.diagramFontSize,
+                                        onValueChange = {
+                                            updateDisplaySetting(displaySetting.copy(diagramFontSize = it))
+                                        },
+                                        valueRange = 14f..26f,
+                                        modifier = Modifier.weight(1f)
+                                    )
+                                    Text(text = "${displaySetting.diagramFontSize.roundToInt()}dp")
+                                }
+                            }
+                        )
+                        item(
+                            headlineContent = { Text(stringResource(R.string.setting_display_page_tikz_min_font_size_title)) },
+                            supportingContent = {
+                                Row(
+                                    modifier = Modifier.fillMaxWidth(),
+                                    verticalAlignment = Alignment.CenterVertically,
+                                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                                ) {
+                                    Slider(
+                                        value = displaySetting.diagramMinFontSize,
+                                        onValueChange = {
+                                            updateDisplaySetting(displaySetting.copy(diagramMinFontSize = it))
+                                        },
+                                        valueRange = 10f..18f,
+                                        modifier = Modifier.weight(1f)
+                                    )
+                                    Text(text = "${displaySetting.diagramMinFontSize.roundToInt()}dp")
+                                }
+                            }
+                        )
+                    }
                     item(
                         headlineContent = { Text(stringResource(R.string.setting_display_page_chat_font_family_title)) },
                         supportingContent = {

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -1283,5 +1283,9 @@ mDNS 地址：使用 .local 主机名，同一网络中的其他设备可通过�
   <string name="assistant_page_context_message_limit_count">上下文消息限制: %d</string>
   <string name="assistant_page_context_message_limit_unlimited">无限上下文消息</string>
   <string name="assistant_page_context_message_limit_warning">限制上下文会在每次上下文被修剪时使提示词缓存失效。更大的限制修剪频率更低；无限制则从不修剪，并保持缓存完全完好。</string>
+  <string name="setting_display_page_enable_diagram_rendering_title">启用 TikZ 渲染</string>
+  <string name="setting_display_page_enable_diagram_rendering_desc">在工作区中至少安装 texlive-latex-extra lmodern poppler-utils 三个包后，即可自动将 tikzcd / xymatrix / AMScd 图表编译为矢量图内嵌显示</string>
+  <string name="setting_display_page_tikz_font_size_title">TikZ 默认字号</string>
+  <string name="setting_display_page_tikz_min_font_size_title">TikZ 最小字号</string>
 </resources>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1285,4 +1285,8 @@
   <string name="assistant_page_context_message_limit_count">Context message limit: %d</string>
   <string name="assistant_page_context_message_limit_unlimited">Unlimited context messages</string>
   <string name="assistant_page_context_message_limit_warning">Limiting context invalidates the prompt cache each time the context is trimmed. A larger limit trims less often; unlimited never trims and keeps the cache fully intact.</string>
+  <string name="setting_display_page_enable_diagram_rendering_title">Enable TikZ Rendering</string>
+  <string name="setting_display_page_enable_diagram_rendering_desc">After installing at least texlive-latex-extra lmodern poppler-utils in workspace, renders tikzcd / xymatrix / AMScd diagrams as inline vector graphics</string>
+  <string name="setting_display_page_tikz_font_size_title">TikZ Font Size</string>
+  <string name="setting_display_page_tikz_min_font_size_title">TikZ Min Font Size</string>
 </resources>


### PR DESCRIPTION
### 功能

增加了tikz交换图渲染的全套管线以及相关显示/缓存优化，打包apk效果在我的rikkahub-math-plus仓库，已经过本人和同学长期使用测试，能够显著提高数学学生和研究者的日常使用体验，且此功能目前无其他平台实现。
[tikz渲染apk](https://github.com/test27818/rikkahub-math-plus/releases/tag/v2.4.3-bugfix1)

-tikz渲染开关在latex渲染开关附近，按照开关注释下载所需的三个基础包后，自动识别tikz等代码块毫秒级渲染并缓存，不影响通常渲染管线。
-已做背景适配，透明背景且按rikkahub内背景做深背景白字和浅背景黑字自动转换。
-缺失宏包均在代码块后有清晰报错，减少上手难度。
-渲染字号可调，且在设定范围内灵活进行大小放缩。超宽自动滑动。
-打开tikz渲染自动注入相关能力和代码格式的系统提示词。

同时tikzjax路线已尝试过效果差且非常不灵活，如果需要渲染其他tikz宏包或许可以将管线系统化，或对简单增加硬性识别。如果要进一步降低使用门槛可以类似prootfs固定下载方式和做下载进度显示。但如果一次下载一整个texlive而不是分包下载会导致路径出问题，这一点有待优化。

下面是详细信息：

- 新增 DiagramRenderer / LatexCapability / LatexRenderCache：工作区 pdflatex/xelatex 编译 TikZ 代码 → SVG 内嵌显示，支持 tikzcd / xymatrix / AMScd
- MathBlock 识别上述图表走新渲染，其余走原 LaTeX 路径；字号可调（默认 18dp），超宽图降级最小字号后横向滚动
- 动态 preamble：从用户代码提取 \usepackage / \usetikzlibrary（声明即加载，新增宏包无需改代码）；含 CJK 自动切 xelatex + ctex
- 深色模式源头注入 \color；编译失败读 .log 显示真实缺失宏包
- LatexCapability 运行时检测工具链，false 结果 60s TTL 自动重检（装完包无需重启开关）
- 设置页新增渲染开关 + 两个字号滑块；系统提示注入 `$$...$$` 渲染说明

### 环境要求

工作区需安装 texlive-latex-extra lmodern poppler-utils（运行时检测，非构建依赖；未安装时优雅降级）。

### 变更文件（9）

- 修改（6）：MathBlock.kt / GenerationHandler.kt / PreferencesStore.kt / SettingPreferencesUIPage.kt / strings.xml / values-zh/strings.xml
- 新增（3）：DiagramRenderer.kt / LatexCapability.kt / LatexRenderCache.kt

### 验证

基于上游 master 4b6449e 合并，`:app:compileDebugKotlin` 通过。