### PR TITLE
fix(chat): 并行调用免审批工具被搁置、切换会话丢失生成内容、切换助手不生效

### DIFF
--- a/app/src/main/java/me/rerere/rikkahub/data/ai/GenerationHandler.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/ai/GenerationHandler.kt
@@ -232,8 +232,12 @@ class GenerationHandler(
                 toolsToProcess = updatedTools
             } else {
                 // Resuming after user interaction - use the resumable tools directly.
+                // 并行调用中免审批的工具在等待审批时被搁置 (仍为 Auto 且未执行),
+                // 恢复时必须一并执行, 否则该 tool call 永远没有结果, 下轮请求会因缺失 tool 结果报错
                 Log.i(TAG, "generateText: resuming with ${pendingTools.size} resumable tools")
-                toolsToProcess = messages.last().getTools().filter { it.canResumeExecution }
+                toolsToProcess = messages.last().getTools().filter {
+                    it.canResumeExecution || (!it.isExecuted && it.approvalState is ToolApprovalState.Auto)
+                }
             }
 
             // Handle tools (execute approved tools, handle denied tools)

--- a/app/src/main/java/me/rerere/rikkahub/service/ChatService.kt
+++ b/app/src/main/java/me/rerere/rikkahub/service/ChatService.kt
@@ -277,22 +277,35 @@ class ChatService(
 
     // ---- 初始化对话 ----
 
-    suspend fun initializeConversation(conversationId: Uuid) {
-        getOrCreateSession(conversationId) // 确保 session 存在
-        val conversation = conversationRepo.getConversationById(conversationId)
-        if (conversation != null) {
-            updateConversation(conversationId, conversation)
-            settingsStore.updateAssistant(conversation.assistantId)
+    suspend fun initializeConversation(conversationId: Uuid, syncAssistant: Boolean = true) {
+        val session = getOrCreateSession(conversationId)
+        val conversation = if (session.isGenerating) {
+            // 正在生成时内存态比数据库快照新 (流式消息尚未落库), 覆盖会导致
+            // 生成内容永久丢失 (onSuccess 会把被覆盖的状态存回库), 且
+            // checkFilesDelete 会误删流式消息引用的文件; 以内存态为准
+            session.state.value
         } else {
-            // 新建对话, 并添加预设消息
-            val currentSettings = settingsStore.settingsFlowRaw.first()
-            val assistant = currentSettings.getCurrentAssistant()
-            val newConversation = Conversation.ofId(
-                id = conversationId,
-                assistantId = assistant.id,
-                newConversation = true
-            ).updateCurrentMessages(assistant.presetMessages)
-            updateConversation(conversationId, newConversation)
+            val dbConversation = conversationRepo.getConversationById(conversationId)
+            if (dbConversation != null) {
+                updateConversation(conversationId, dbConversation)
+                dbConversation
+            } else {
+                // 新建对话, 并添加预设消息
+                val currentSettings = settingsStore.settingsFlowRaw.first()
+                val assistant = currentSettings.getCurrentAssistant()
+                val newConversation = Conversation.ofId(
+                    id = conversationId,
+                    assistantId = assistant.id,
+                    newConversation = true
+                ).updateCurrentMessages(assistant.presetMessages)
+                updateConversation(conversationId, newConversation)
+                newConversation
+            }
+        }
+        // 重返同一会话 (如从设置页返回导致的重复初始化) 时不同步,
+        // 否则会反向覆盖用户刚在设置里切换的当前助手
+        if (syncAssistant) {
+            settingsStore.updateAssistant(conversation.assistantId)
         }
     }
 

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ChatDrawer.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ChatDrawer.kt
@@ -285,19 +285,9 @@ fun ChatDrawerContent(
             AssistantPicker(
                 settings = settings,
                 onUpdateSettings = {
-                    val updateJob = vm.updateSettings(it)
-                    scope.launch {
-                        updateJob.join()
-                        val id = if (context.readBooleanPreference("create_new_conversation_on_start", true)) {
-                            Uuid.random()
-                        } else {
-                            repo.getConversationsOfAssistant(it.assistantId)
-                                .first()
-                                .firstOrNull()
-                                ?.id ?: Uuid.random()
-                        }
-                        navigateToChatPage(navigator = navController, chatId = id)
-                    }
+                    // 切换助手后的会话跳转由 ChatPage 的助手一致性对账统一处理
+                    // (同时覆盖从助手设置页切换的场景), 此处只需更新设置
+                    vm.updateSettings(it)
                 },
                 modifier = Modifier.fillMaxWidth(),
                 onClickSetting = {

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ChatPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ChatPage.kt
@@ -284,6 +284,14 @@ private fun ChatPageContent(
     val assistant = setting.getCurrentAssistant()
     var showFilesSheet by remember { mutableStateOf(false) }
 
+    // 全局当前助手与本会话归属不一致时 (如在助手设置里切换助手后返回, 未点新话题),
+    // 自动跳转到当前助手的会话, 与抽屉切换助手后的行为一致; 判定在 VM 内做新鲜读取
+    LaunchedEffect(vm.conversationInitialized, setting.assistantId, conversation.assistantId) {
+        if (!vm.conversationInitialized) return@LaunchedEffect
+        val targetId = vm.resolveAssistantMismatchTarget() ?: return@LaunchedEffect
+        navigateToChatPage(navigator = navController, chatId = targetId)
+    }
+
     val completionProviders = remember(assistant.workspaceId, conversation.workspaceCwd, workspaceRepository) {
         assistant.workspaceId?.let { workspaceId ->
             listOf(

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ChatVM.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ChatVM.kt
@@ -16,6 +16,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
@@ -38,6 +39,8 @@ import me.rerere.rikkahub.data.repository.ConversationRepository
 import me.rerere.rikkahub.data.repository.FavoriteRepository
 import me.rerere.rikkahub.service.ChatError
 import me.rerere.rikkahub.service.ChatService
+import me.rerere.rikkahub.ui.hooks.readBooleanPreference
+import me.rerere.rikkahub.ui.hooks.readStringPreference
 import me.rerere.rikkahub.ui.hooks.writeStringPreference
 import me.rerere.rikkahub.ui.hooks.ChatInputState
 import me.rerere.rikkahub.utils.UiState
@@ -61,6 +64,8 @@ class ChatVM(
     private val _conversationId: Uuid = Uuid.parse(id)
     val conversation: StateFlow<Conversation> = chatService.getConversationFlow(_conversationId)
     var chatListInitialized by mutableStateOf(false) // 聊天列表是否已经滚动到底部
+    var conversationInitialized by mutableStateOf(false) // initializeConversation 是否已完成
+        private set
 
     // 聊天输入状态 - 保存在 ViewModel 中避免 TransactionTooLargeException
     val inputState = ChatInputState()
@@ -83,9 +88,18 @@ class ChatVM(
         // 添加对话引用
         chatService.addConversationReference(_conversationId)
 
+        // 必须在写入 lastConversationId 之前读取: 重返同一会话 (如从设置页返回,
+        // ViewModel 被重建) 时不能把全局当前助手反向同步回本会话的助手
+        val isReturningToSameConversation =
+            context.readStringPreference("lastConversationId", null) == _conversationId.toString()
+
         // 初始化对话
         viewModelScope.launch {
-            chatService.initializeConversation(_conversationId)
+            chatService.initializeConversation(
+                conversationId = _conversationId,
+                syncAssistant = !isReturningToSameConversation,
+            )
+            conversationInitialized = true
         }
 
         // 记住对话ID, 方便下次启动恢复
@@ -276,8 +290,34 @@ class ChatVM(
         }
     }
 
-    fun moveConversationToAssistant(conversation: Conversation, targetAssistantId: Uuid) {
-        viewModelScope.launch {
+    /**
+     * 当前会话归属助手与全局当前助手不一致时 (如在设置页切换助手后返回本页),
+     * 返回应跳转的目标会话 id; 一致或当前助手无效时返回 null。
+     * 用 settingsFlow 的新鲜读取做权威判定, 避免 Compose 快照的时序竞态。
+     */
+    suspend fun resolveAssistantMismatchTarget(): Uuid? {
+        val currentSettings = settingsStore.settingsFlow.first()
+        if (conversation.value.assistantId == currentSettings.assistantId) return null
+        if (currentSettings.assistants.none { it.id == currentSettings.assistantId }) return null
+        return resolveConversationIdForAssistant(currentSettings.assistantId)
+    }
+
+    /**
+     * 解析当前助手对应的目标会话: 按偏好新建会话, 或复用该助手最近的会话。
+     * 与抽屉助手选择器切换后的跳转逻辑保持一致。
+     */
+    suspend fun resolveConversationIdForAssistant(assistantId: Uuid): Uuid {
+        return if (context.readBooleanPreference("create_new_conversation_on_start", true)) {
+            Uuid.random()
+        } else {
+            conversationRepo.getConversationsOfAssistant(assistantId)
+                .first()
+                .firstOrNull()
+                ?.id ?: Uuid.random()
+        }
+    }
+
+    fun moveConversationToAssistant(conversation: Conversation, targetAssistantId: Uuid) {        viewModelScope.launch {
             val conversationFull = conversationRepo.getConversationById(conversation.id) ?: return@launch
             // 文件夹是助手内分组，切换助手后原文件夹在新助手下不可见，需清空归属避免会话丢失
             val updatedConversation = conversationFull.copy(


### PR DESCRIPTION
### Changes

**修复并行调用中免审批工具被搁置不执行**
- 模型并行调用「需审批工具 + 免审批工具」时，首轮把前者标记为 `Pending` 后即 break 等待审批，后者保持 `Auto` 且未执行；批准/拒绝后恢复执行的过滤条件 `canResumeExecution` 只认 `Approved/Denied/Answered`，`Auto` 工具被永远跳过，下一轮请求因该 tool call 缺失结果直接报错
- 恢复路径改为同时纳入未执行的 `Auto` 工具；能进入恢复路径的消息都已经过审批标记扫描，仍为 `Auto` 的必然是免审批工具，不会绕过审批

**修复切换会话丢失生成中内容**
- 会话生成中切走再快速切回，ChatVM 重建触发 `initializeConversation` 用数据库快照覆盖内存态（流式回复尚未落库）；若覆盖落在最后一个 chunk 之后，生成流收尾会把残缺状态存回数据库，回复永久丢失，`checkFilesDelete` 还会误删流式消息引用的文件
- 会话正在生成时跳过快照覆盖，以内存态为准

**修复切换助手后直接发送不生效**
- 在助手设置页切换助手后返回聊天页，重复初始化会把全局当前助手反向改回本会话归属（表现为界面仍是旧助手），且发送按会话归属走旧助手，需手动点新话题才生效
- 重返同一会话（`lastConversationId` 先读后写判断）不再反向同步助手
- ChatPage 增加助手一致性对账：全局助手与会话归属不一致时自动跳转到当前助手的会话（新建或复用最近会话，沿用抽屉切换的偏好逻辑），任意入口切换助手后直接发送即可；#1589 在抽屉里的手工跳转改由对账统一处理，避免双重导航
- 从历史记录打开其他助手的会话仍会同步全局助手，行为不变

### Verification
- `./gradlew assembleDebug` 通过
- debug 包验证场景：并行审批工具批准/拒绝后免审批工具均正常执行；生成中切换会话内容不丢失、正常落库；设置页切换助手后返回直接发送使用新助手，历史打开旧会话仍自动跟随

🤖 Generated with [Claude Code](https://claude.com/claude-code)
