### PR TITLE
feat(app): support sharing images

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -83,6 +83,13 @@
         <data android:mimeType="text/plain" />
       </intent-filter>
       <intent-filter>
+        <action android:name="android.intent.action.SEND" />
+
+        <category android:name="android.intent.category.DEFAULT" />
+
+        <data android:mimeType="image/*" />
+      </intent-filter>
+      <intent-filter>
         <action android:name="android.intent.action.PROCESS_TEXT" />
 
         <category android:name="android.intent.category.DEFAULT" />

--- a/app/src/main/java/me/rerere/rikkahub/RouteActivity.kt
+++ b/app/src/main/java/me/rerere/rikkahub/RouteActivity.kt
@@ -2,6 +2,7 @@ package me.rerere.rikkahub
 
 import android.annotation.SuppressLint
 import android.content.Intent
+import android.net.Uri
 import android.os.Build
 import android.os.Bundle
 import android.view.KeyEvent
@@ -198,13 +199,25 @@ class RouteActivity : ComponentActivity() {
         }
     }
 
+    private fun Intent.shareStreamUri(): Uri? {
+        val uri = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            getParcelableExtra(Intent.EXTRA_STREAM, Uri::class.java)
+        } else {
+            @Suppress("DEPRECATION")
+            getParcelableExtra(Intent.EXTRA_STREAM)
+        }
+        if (uri != null) return uri
+        // Some senders deliver the stream via ClipData (e.g. multiple images)
+        return clipData?.takeIf { it.itemCount > 0 }?.getItemAt(0)?.uri
+    }
+
     @Composable
     private fun ShareHandler(backStack: MutableList<NavKey>) {
         val shareIntent = remember {
             Intent().apply {
                 action = intent?.action
                 putExtra(Intent.EXTRA_TEXT, intent?.getStringExtra(Intent.EXTRA_TEXT))
-                putExtra(Intent.EXTRA_STREAM, intent?.getStringExtra(Intent.EXTRA_STREAM))
+                putExtra(Intent.EXTRA_STREAM, intent?.shareStreamUri())
                 putExtra(Intent.EXTRA_PROCESS_TEXT, intent?.getCharSequenceExtra(Intent.EXTRA_PROCESS_TEXT))
             }
         }
@@ -213,7 +226,7 @@ class RouteActivity : ComponentActivity() {
             when (shareIntent.action) {
                 Intent.ACTION_SEND -> {
                     val text = shareIntent.getStringExtra(Intent.EXTRA_TEXT) ?: ""
-                    val imageUri = shareIntent.getStringExtra(Intent.EXTRA_STREAM)
+                    val imageUri = shareIntent.shareStreamUri()?.toString()
                     backStack.add(Screen.ShareHandler(text, imageUri))
                 }
 


### PR DESCRIPTION
Adds RikkaHub to the system share menu for images, attaching it to a new chat. The `ShareHandler` already attempted to receive images, I just had to declare support for it in `AndroidManifest.xml` and fix the image URI code.

`./gradlew test` passes and I've tested on my phone running android 16.

---

将RikkaHub添加到系统图片分享菜单中，并将其附加到新聊天。`ShareHandler`已经尝试接收图片，我只需在`AndroidManifest.xml`中声明对此的支持，并修复图片URI代码。

`./gradlew test`通过，我已经在运行Android 16的手机上进行了测试。

---

<img width="269" height="562" alt="rikkahub_share_image" src="https://github.com/user-attachments/assets/016078ac-a116-4069-8254-6ddb98d5dbad" />
