### PR TITLE
feat(setting): 支持按天数自动清理历史图片，控制存储占用

### DIFF
--- a/app/src/main/java/me/rerere/rikkahub/RikkaHubApp.kt
+++ b/app/src/main/java/me/rerere/rikkahub/RikkaHubApp.kt
@@ -82,6 +82,9 @@ class RikkaHubApp : Application() {
         // sync upload files to DB
         syncManagedFiles()
 
+        // auto cleanup old upload images (if enabled in settings)
+        cleanupOldImages()
+
         // Start WebServer if enabled in settings
         startWebServerIfEnabled()
 
@@ -150,6 +153,20 @@ class RikkaHubApp : Application() {
                 get<FilesManager>().syncFolder()
             }.onFailure {
                 Log.e(TAG, "syncManagedFiles failed", it)
+            }
+        }
+    }
+
+    private fun cleanupOldImages() {
+        get<AppScope>().launch(Dispatchers.IO) {
+            runCatching {
+                val days = get<SettingsStore>().settingsFlowRaw.first().autoCleanupImageDays
+                if (days > 0) {
+                    val (count, freedBytes) = get<FilesManager>().deleteOlderThan(days)
+                    Log.i(TAG, "cleanupOldImages: deleted $count files, freed ${freedBytes / 1024} KB")
+                }
+            }.onFailure {
+                Log.e(TAG, "cleanupOldImages failed", it)
             }
         }
     }

--- a/app/src/main/java/me/rerere/rikkahub/data/datastore/PreferencesStore.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/datastore/PreferencesStore.kt
@@ -146,6 +146,9 @@ class SettingsStore(
         // 备份提醒
         val BACKUP_REMINDER_CONFIG = stringPreferencesKey("backup_reminder_config")
 
+        // 历史图片自动清理
+        val AUTO_CLEANUP_IMAGE_DAYS = intPreferencesKey("auto_cleanup_image_days")
+
         // 统计
         val LAUNCH_COUNT = intPreferencesKey("launch_count")
 
@@ -244,6 +247,7 @@ class SettingsStore(
                 } ?: BackupReminderConfig(),
                 launchCount = preferences[LAUNCH_COUNT] ?: 0,
                 sponsorAlertDismissedAt = preferences[SPONSOR_ALERT_DISMISSED_AT] ?: 0,
+                autoCleanupImageDays = preferences[AUTO_CLEANUP_IMAGE_DAYS] ?: 0,
             )
         }
         .map {
@@ -412,6 +416,7 @@ class SettingsStore(
             preferences[BACKUP_REMINDER_CONFIG] = JsonInstant.encodeToString(settings.backupReminderConfig)
             preferences[LAUNCH_COUNT] = settings.launchCount
             preferences[SPONSOR_ALERT_DISMISSED_AT] = settings.sponsorAlertDismissedAt
+            preferences[AUTO_CLEANUP_IMAGE_DAYS] = settings.autoCleanupImageDays.coerceIn(0, 365)
         }
     }
 
@@ -556,6 +561,7 @@ data class Settings(
     val backupReminderConfig: BackupReminderConfig = BackupReminderConfig(),
     val launchCount: Int = 0,
     val sponsorAlertDismissedAt: Int = 0,
+    val autoCleanupImageDays: Int = 0,
 ) {
     companion object {
         // 构造一个用于初始化的settings, 但它不能用于保存，防止使用初始值存储

--- a/app/src/main/java/me/rerere/rikkahub/data/files/FilesManager.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/files/FilesManager.kt
@@ -377,6 +377,34 @@ class FilesManager(
         repository.deleteById(id) > 0
     }
 
+    /**
+     * 删除指定天数以前上传的文件（按 created_at 判断），返回 (删除文件数, 释放字节数)。
+     * days <= 0 时不执行任何删除。
+     */
+    suspend fun deleteOlderThan(
+        days: Int,
+        folder: String = FileFolders.UPLOAD,
+    ): Pair<Int, Long> = withContext(Dispatchers.IO) {
+        if (days <= 0) {
+            return@withContext Pair(0, 0L)
+        }
+        val cutoff = System.currentTimeMillis() - days * 24L * 60 * 60 * 1000
+        var deletedCount = 0
+        var freedBytes = 0L
+        repository.listByFolder(folder).first().forEach { entity ->
+            if (entity.createdAt < cutoff) {
+                val file = getFile(entity)
+                if (file.delete()) {
+                    freedBytes += entity.sizeBytes
+                }
+                if (repository.deleteByPath(entity.relativePath) > 0) {
+                    deletedCount++
+                }
+            }
+        }
+        Pair(deletedCount, freedBytes)
+    }
+
     suspend fun deleteAll(folder: String = FileFolders.UPLOAD): Boolean = withContext(Dispatchers.IO) {
         val dir = File(context.filesDir, folder)
         val entries = dir.listFiles()

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingFilesPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingFilesPage.kt
@@ -24,6 +24,8 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -52,6 +54,8 @@ import coil3.compose.AsyncImage
 import kotlinx.coroutines.launch
 import me.rerere.rikkahub.data.db.entity.ManagedFileEntity
 import me.rerere.rikkahub.R
+import me.rerere.rikkahub.data.datastore.Settings
+import me.rerere.rikkahub.data.datastore.SettingsStore
 import me.rerere.rikkahub.data.files.FileFolders
 import me.rerere.rikkahub.data.files.FilesManager
 import me.rerere.rikkahub.ui.components.nav.BackButton
@@ -64,6 +68,7 @@ import java.io.File
 @Composable
 fun SettingFilesPage(
     filesManager: FilesManager = koinInject(),
+    settingsStore: SettingsStore = koinInject(),
 ) {
     val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior()
     val gridState = rememberLazyStaggeredGridState()
@@ -80,7 +85,10 @@ fun SettingFilesPage(
     var selectedFolder by remember { mutableStateOf(FileFolders.UPLOAD) }
     var pendingDelete by remember { mutableStateOf<ManagedFileEntity?>(null) }
     var showCleanDialog by remember { mutableStateOf(false) }
+    var autoCleanupMenuOpen by remember { mutableStateOf(false) }
     val files by filesManager.observe(selectedFolder).collectAsState(initial = emptyList())
+    val autoCleanupDays by settingsStore.settingsFlow
+        .collectAsState(initial = Settings.dummy().autoCleanupImageDays)
 
     if (pendingDelete != null) {
         val target = pendingDelete!!
@@ -178,6 +186,29 @@ fun SettingFilesPage(
                 onFolderSelected = { selectedFolder = it }
             )
 
+            AutoCleanupRow(
+                autoCleanupDays = autoCleanupDays,
+                menuOpen = autoCleanupMenuOpen,
+                onMenuOpenChange = { autoCleanupMenuOpen = it },
+                onSelect = { days ->
+                    if (days != autoCleanupDays) {
+                        scope.launch {
+                            settingsStore.update { it.copy(autoCleanupImageDays = days) }
+                            if (days > 0) {
+                                val (count, freedBytes) = filesManager.deleteOlderThan(days)
+                                toaster.show(
+                                    stringResource(
+                                        R.string.setting_files_page_auto_cleanup_done,
+                                        count,
+                                        freedBytes / 1024
+                                    )
+                                )
+                            }
+                        }
+                    }
+                }
+            )
+
             if (files.isEmpty()) {
                 Box(
                     modifier = Modifier
@@ -241,6 +272,63 @@ private fun folderDisplayName(folder: String): String = when (folder) {
     FileFolders.UPLOAD -> stringResource(R.string.setting_files_page_folder_upload)
     else -> folder
 }
+
+private val autoCleanupOptions = listOf(0, 7, 30, 60, 90)
+
+@Composable
+private fun AutoCleanupRow(
+    autoCleanupDays: Int,
+    menuOpen: Boolean,
+    onMenuOpenChange: (Boolean) -> Unit,
+    onSelect: (Int) -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween
+    ) {
+        Column {
+            Text(
+                text = stringResource(R.string.setting_files_page_auto_cleanup_title),
+                style = MaterialTheme.typography.titleSmall
+            )
+            Text(
+                text = stringResource(R.string.setting_files_page_auto_cleanup_desc),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+        Box {
+            TextButton(onClick = { onMenuOpenChange(true) }) {
+                Text(autoCleanupDaysLabel(autoCleanupDays))
+            }
+            DropdownMenu(
+                expanded = menuOpen,
+                onDismissRequest = { onMenuOpenChange(false) }
+            ) {
+                autoCleanupOptions.forEach { days ->
+                    DropdownMenuItem(
+                        text = { Text(autoCleanupDaysLabel(days)) },
+                        onClick = {
+                            onMenuOpenChange(false)
+                            onSelect(days)
+                        }
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun autoCleanupDaysLabel(days: Int): String =
+    if (days <= 0) {
+        stringResource(R.string.setting_files_page_auto_cleanup_off)
+    } else {
+        stringResource(R.string.setting_files_page_auto_cleanup_days, days)
+    }
 
 @Composable
 private fun FileItem(

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingFilesPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingFilesPage.kt
@@ -54,7 +54,6 @@ import coil3.compose.AsyncImage
 import kotlinx.coroutines.launch
 import me.rerere.rikkahub.data.db.entity.ManagedFileEntity
 import me.rerere.rikkahub.R
-import me.rerere.rikkahub.data.datastore.Settings
 import me.rerere.rikkahub.data.datastore.SettingsStore
 import me.rerere.rikkahub.data.files.FileFolders
 import me.rerere.rikkahub.data.files.FilesManager
@@ -81,14 +80,14 @@ fun SettingFilesPage(
     val deleteFailedToast = stringResource(R.string.setting_files_page_delete_failed_toast)
     val cleanedToast = stringResource(R.string.setting_files_page_cleaned_toast)
     val cleanFailedToast = stringResource(R.string.setting_files_page_clean_failed_toast)
+    val autoCleanupDoneTemplate = stringResource(R.string.setting_files_page_auto_cleanup_done)
 
     var selectedFolder by remember { mutableStateOf(FileFolders.UPLOAD) }
     var pendingDelete by remember { mutableStateOf<ManagedFileEntity?>(null) }
     var showCleanDialog by remember { mutableStateOf(false) }
     var autoCleanupMenuOpen by remember { mutableStateOf(false) }
     val files by filesManager.observe(selectedFolder).collectAsState(initial = emptyList())
-    val autoCleanupDays by settingsStore.settingsFlow
-        .collectAsState(initial = Settings.dummy().autoCleanupImageDays)
+    val autoCleanupDays by settingsStore.settingsFlow.collectAsState(initial = 0)
 
     if (pendingDelete != null) {
         val target = pendingDelete!!
@@ -196,13 +195,7 @@ fun SettingFilesPage(
                             settingsStore.update { it.copy(autoCleanupImageDays = days) }
                             if (days > 0) {
                                 val (count, freedBytes) = filesManager.deleteOlderThan(days)
-                                toaster.show(
-                                    stringResource(
-                                        R.string.setting_files_page_auto_cleanup_done,
-                                        count,
-                                        freedBytes / 1024
-                                    )
-                                )
+                                toaster.show(autoCleanupDoneTemplate.format(count, freedBytes / 1024))
                             }
                         }
                     }

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingFilesPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingFilesPage.kt
@@ -51,6 +51,7 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import me.rerere.rikkahub.data.db.entity.ManagedFileEntity
 import me.rerere.rikkahub.R
@@ -87,7 +88,9 @@ fun SettingFilesPage(
     var showCleanDialog by remember { mutableStateOf(false) }
     var autoCleanupMenuOpen by remember { mutableStateOf(false) }
     val files by filesManager.observe(selectedFolder).collectAsState(initial = emptyList())
-    val autoCleanupDays by settingsStore.settingsFlow.collectAsState(initial = 0)
+    val autoCleanupDays by settingsStore.settingsFlow
+        .map { it.autoCleanupImageDays }
+        .collectAsState(initial = 0)
 
     if (pendingDelete != null) {
         val target = pendingDelete!!

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -703,6 +703,11 @@
   <string name="setting_files_page_delete_file_title">ファイルを削除</string>
   <string name="setting_files_page_deleted_toast">削除しました</string>
   <string name="setting_files_page_folder_upload">アップロード</string>
+  <string name="setting_files_page_auto_cleanup_title">古い画像を自動削除</string>
+  <string name="setting_files_page_auto_cleanup_desc">起動時に指定日数より古い画像を削除します。削除された画像は過去のチャットで表示されなくなります。</string>
+  <string name="setting_files_page_auto_cleanup_off">オフ</string>
+  <string name="setting_files_page_auto_cleanup_days">%1$d 日</string>
+  <string name="setting_files_page_auto_cleanup_done">%1$d 個のファイルを削除し、%2$d KB 解放しました</string>
   <string name="setting_files_page_no_files">ファイルがありません</string>
   <string name="setting_files_page_title">ファイル管理</string>
   <string name="setting_mcp_page_add_header">ヘッダーを追加</string>

--- a/app/src/main/res/values-ko-rKR/strings.xml
+++ b/app/src/main/res/values-ko-rKR/strings.xml
@@ -703,6 +703,11 @@
   <string name="setting_files_page_delete_file_title">파일 삭제</string>
   <string name="setting_files_page_deleted_toast">삭제됨</string>
   <string name="setting_files_page_folder_upload">업로드</string>
+  <string name="setting_files_page_auto_cleanup_title">오래된 이미지 자동 정리</string>
+  <string name="setting_files_page_auto_cleanup_desc">앱 시작 시 지정한 일수보다 오래된 이미지를 삭제합니다. 삭제된 이미지는 이전 채팅에서 표시되지 않습니다.</string>
+  <string name="setting_files_page_auto_cleanup_off">끄기</string>
+  <string name="setting_files_page_auto_cleanup_days">%1$d일</string>
+  <string name="setting_files_page_auto_cleanup_done">%1$d개 파일 정리, %2$d KB 확보</string>
   <string name="setting_files_page_no_files">파일 없음</string>
   <string name="setting_files_page_title">파일 관리</string>
   <string name="setting_mcp_page_add_header">헤더 추가</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -703,6 +703,11 @@
   <string name="setting_files_page_delete_file_title">Удалить файл</string>
   <string name="setting_files_page_deleted_toast">Удалено</string>
   <string name="setting_files_page_folder_upload">Загрузить</string>
+  <string name="setting_files_page_auto_cleanup_title">Автоочистка старых изображений</string>
+  <string name="setting_files_page_auto_cleanup_desc">Удалять изображения старше выбранного количества дней при запуске приложения. Удалённые изображения перестанут отображаться в старых чатах.</string>
+  <string name="setting_files_page_auto_cleanup_off">Выкл.</string>
+  <string name="setting_files_page_auto_cleanup_days">%1$d дней</string>
+  <string name="setting_files_page_auto_cleanup_done">Очищено файлов: %1$d, освобождено: %2$d КБ</string>
   <string name="setting_files_page_no_files">Нет файлов</string>
   <string name="setting_files_page_title">Управление файлами</string>
   <string name="setting_mcp_page_add_header">Добавить заголовок</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -703,6 +703,11 @@
   <string name="setting_files_page_delete_file_title">刪除檔案</string>
   <string name="setting_files_page_deleted_toast">已刪除</string>
   <string name="setting_files_page_folder_upload">上傳</string>
+  <string name="setting_files_page_auto_cleanup_title">自動清理歷史圖片</string>
+  <string name="setting_files_page_auto_cleanup_desc">App 啟動時刪除超過設定天數的圖片。被清理的圖片在舊聊天中將無法顯示。</string>
+  <string name="setting_files_page_auto_cleanup_off">關閉</string>
+  <string name="setting_files_page_auto_cleanup_days">%1$d 天</string>
+  <string name="setting_files_page_auto_cleanup_done">已清理 %1$d 個檔案，釋放 %2$d KB</string>
   <string name="setting_files_page_no_files">無檔案</string>
   <string name="setting_files_page_title">檔案管理</string>
   <string name="setting_mcp_page_add_header">添加請求頭</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -741,6 +741,11 @@
   <string name="setting_files_page_delete_file_title">删除文件</string>
   <string name="setting_files_page_deleted_toast">已删除</string>
   <string name="setting_files_page_folder_upload">上传</string>
+  <string name="setting_files_page_auto_cleanup_title">自动清理历史图片</string>
+  <string name="setting_files_page_auto_cleanup_desc">App 启动时删除超过设定天数的图片。被清理的图片在旧聊天中将无法显示。</string>
+  <string name="setting_files_page_auto_cleanup_off">关闭</string>
+  <string name="setting_files_page_auto_cleanup_days">%1$d 天</string>
+  <string name="setting_files_page_auto_cleanup_done">已清理 %1$d 个文件，释放 %2$d KB</string>
   <string name="setting_files_page_no_files">无文件</string>
   <string name="setting_files_page_title">文件管理</string>
   <string name="setting_mcp_page_add_header">添加请求头</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -747,6 +747,11 @@
   <string name="setting_files_page_delete_file_title">Delete File</string>
   <string name="setting_files_page_deleted_toast">Deleted</string>
   <string name="setting_files_page_folder_upload">Upload</string>
+  <string name="setting_files_page_auto_cleanup_title">Auto-clean old images</string>
+  <string name="setting_files_page_auto_cleanup_desc">Delete images older than the selected days on app start. Images in old chats will no longer display.</string>
+  <string name="setting_files_page_auto_cleanup_off">Off</string>
+  <string name="setting_files_page_auto_cleanup_days">%1$d days</string>
+  <string name="setting_files_page_auto_cleanup_done">Cleaned %1$d files, freed %2$d KB</string>
   <string name="setting_files_page_no_files">No Files</string>
   <string name="setting_files_page_title">File Management</string>
   <string name="setting_mcp_page_add_header">Add Header</string>


### PR DESCRIPTION
背景/动机
---------
聊天上传的图片保存在 filesDir/upload 并被无限期保留，长期使用占用大量存储。目前只有"一键清空全部"，无法按时间维度控制：要么全删、要么不动。

改动
-----
1. `Settings` 新增 `autoCleanupImageDays`（0=关闭，可选 7/30/60/90 天）并持久化。
2. `FilesManager` 新增 `deleteOlderThan(days)`：按 created_at 删除 upload 目录中超过 N 天的文件及其数据库记录。
3. 文件管理页新增"自动清理"设置项：选择天数后立即执行一次并保存。
4. App 启动时自动执行一次清理。

说明
-----
- 被清理的图片在旧聊天记录中将无法显示（与现有"一键清空"行为一致），因此默认关闭，由用户主动开启。

测试
-----
已通过 GitHub Actions assembleRelease 编译验证（fork 临时 workflow，未包含在本 PR）。