### PR TITLE
fix(openai): avoid replaying plaintext with encrypted reasoning

### DIFF
--- a/ai/src/main/java/me/rerere/ai/provider/providers/openai/ResponseAPI.kt
+++ b/ai/src/main/java/me/rerere/ai/provider/providers/openai/ResponseAPI.kt
@@ -356,10 +356,11 @@ class ResponseAPI(
                                                 })
                                             }
                                     })
+                                    val encryptedContent = reasoningMetadata?.encryptedContent
                                     val content = reasoningParts
                                         .filter { it.reasoningType == ReasoningType.REASONING_TEXT }
                                         .filter { it.reasoning.isNotEmpty() }
-                                    if (content.isNotEmpty()) {
+                                    if (encryptedContent == null && content.isNotEmpty()) {
                                         put("content", buildJsonArray {
                                             content.forEach {
                                                 add(buildJsonObject {
@@ -369,7 +370,7 @@ class ResponseAPI(
                                             }
                                         })
                                     }
-                                    reasoningMetadata?.encryptedContent?.let {
+                                    encryptedContent?.let {
                                         put("encrypted_content", it)
                                     }
                                 })

--- a/ai/src/test/java/me/rerere/ai/provider/providers/openai/ResponseApiRequestMessageTest.kt
+++ b/ai/src/test/java/me/rerere/ai/provider/providers/openai/ResponseApiRequestMessageTest.kt
@@ -16,11 +16,13 @@ import me.rerere.ai.provider.Model
 import me.rerere.ai.provider.ModelAbility
 import me.rerere.ai.provider.ProviderSetting
 import me.rerere.ai.provider.TextGenerationParams
-import me.rerere.ai.ui.UIMessage
-import me.rerere.ai.ui.UIMessagePart
+import me.rerere.ai.ui.OpenAIReasoningMetadata
+import me.rerere.ai.ui.ReasoningType
 import me.rerere.ai.ui.ServerToolMetadata
 import me.rerere.ai.ui.ServerToolProtocol
 import me.rerere.ai.ui.ServerToolStatus
+import me.rerere.ai.ui.UIMessage
+import me.rerere.ai.ui.UIMessagePart
 import me.rerere.ai.ui.toMetadata
 import okhttp3.OkHttpClient
 import org.junit.Assert.assertEquals
@@ -322,6 +324,50 @@ class ResponseApiRequestMessageTest {
                 lastCallIndex = i
             }
         }
+    }
+
+    @Test
+    fun `encrypted reasoning should not replay plaintext content`() {
+        val reasoningItem = invokeBuildMessages(listOf(
+            UIMessage(
+                role = MessageRole.ASSISTANT,
+                parts = listOf(UIMessagePart.Reasoning(
+                    reasoning = "plaintext reasoning",
+                    metadata = OpenAIReasoningMetadata(
+                        reasoningId = "rs_1",
+                        encryptedContent = "encrypted",
+                    ).toMetadata(),
+                    reasoningType = ReasoningType.REASONING_TEXT,
+                )),
+            ),
+        )).single().jsonObject
+
+        assertEquals("reasoning", reasoningItem["type"]?.jsonPrimitive?.content)
+        assertEquals("rs_1", reasoningItem["id"]?.jsonPrimitive?.content)
+        assertEquals("encrypted", reasoningItem["encrypted_content"]?.jsonPrimitive?.content)
+        assertFalse(reasoningItem.containsKey("content"))
+    }
+
+    @Test
+    fun `unencrypted reasoning should replay plaintext content`() {
+        val reasoningItem = invokeBuildMessages(listOf(
+            UIMessage(
+                role = MessageRole.ASSISTANT,
+                parts = listOf(UIMessagePart.Reasoning(
+                    reasoning = "plaintext reasoning",
+                    metadata = OpenAIReasoningMetadata(reasoningId = "rs_1").toMetadata(),
+                    reasoningType = ReasoningType.REASONING_TEXT,
+                )),
+            ),
+        )).single().jsonObject
+
+        val content = reasoningItem["content"]?.jsonArray
+        assertEquals(1, content?.size)
+        assertEquals(
+            "plaintext reasoning",
+            content?.single()?.jsonObject?.get("text")?.jsonPrimitive?.content,
+        )
+        assertFalse(reasoningItem.containsKey("encrypted_content"))
     }
 
     @Test


### PR DESCRIPTION
## Problem

When replaying historical reasoning items through the OpenAI Responses API, RikkaHub could serialize both `encrypted_content` and a non-empty `content` array containing `reasoning_text`.

CPA/Codex rejects this payload because Responses reasoning items with `encrypted_content` must not contain plaintext reasoning content:

```text
Invalid 'input[n].content': array too long.
Expected an array with maximum length 0, but got an array with length 1 instead.
```

This breaks subsequent turns of existing conversations using Codex/Responses models.

## Fix

- When `encrypted_content` is present, omit the plaintext `content` field.
- When `encrypted_content` is absent, preserve the existing plaintext reasoning replay behavior.

## Tests

- Added regression test for encrypted reasoning: verifies `content` is omitted.
- Added regression test for unencrypted reasoning: verifies plaintext `content` is preserved.
- `git diff --check` passes.
- Built and tested the release APK through GitHub Actions.
- Verified on-device with an existing multi-turn CPA/Codex conversation using `gpt-5.6-sol`; historical reasoning replay and subsequent Responses requests succeeded, including prompt cache usage.

Based on commit `1dcfbc28d53161bea61a09b83b391d28346a204d` from the author's fork.