### PR TITLE
修复：Responses API 回传跨供应商历史推理导致对话失败

### DIFF
--- a/ai/src/main/java/me/rerere/ai/provider/providers/openai/ResponseAPI.kt
+++ b/ai/src/main/java/me/rerere/ai/provider/providers/openai/ResponseAPI.kt
@@ -228,7 +228,13 @@ class ResponseAPI(
             }
 
             // messages
-            put("input", buildMessages(messages))
+            put(
+                "input",
+                buildMessages(
+                    messages = messages,
+                    includeHistoryReasoning = providerSetting.includeHistoryReasoning,
+                )
+            )
 
             // reasoning
             if (params.model.abilities.contains(ModelAbility.REASONING)) {
@@ -294,26 +300,33 @@ class ResponseAPI(
         }.mergeCustomBody(params.customBody)
     }
 
-    internal fun buildMessages(messages: List<UIMessage>) = buildJsonArray {
+    internal fun buildMessages(
+        messages: List<UIMessage>,
+        includeHistoryReasoning: Boolean = true,
+    ) = buildJsonArray {
         messages
             .filter { message ->
                 message.role != MessageRole.SYSTEM && (
                     message.isValidToUpload() || message.parts.any { part ->
-                        part is UIMessagePart.Reasoning &&
+                        includeHistoryReasoning &&
+                            part is UIMessagePart.Reasoning &&
                             part.metadataAs<OpenAIReasoningMetadata>()?.encryptedContent != null
                     }
                 )
             }
             .forEach { message ->
                 if (message.role == MessageRole.ASSISTANT) {
-                    addAssistantItems(message)
+                    addAssistantItems(message, includeHistoryReasoning)
                 } else {
                     addUserItems(message)
                 }
             }
     }
 
-    private fun JsonArrayBuilder.addAssistantItems(message: UIMessage) {
+    private fun JsonArrayBuilder.addAssistantItems(
+        message: UIMessage,
+        includeHistoryReasoning: Boolean,
+    ) {
         val groups = groupPartsByToolBoundary(message.parts)
         val contentBuffer = mutableListOf<UIMessagePart>()
 
@@ -324,9 +337,10 @@ class ResponseAPI(
                     group.parts.forEach { part ->
                         when (part) {
                             is UIMessagePart.Reasoning -> {
+                                if (!includeHistoryReasoning) return@forEach
                                 val reasoningMetadata = part.metadataAs<OpenAIReasoningMetadata>()
-                                val reasoningId = reasoningMetadata?.reasoningId
-                                if (reasoningId != null && !emittedReasoningIds.add(reasoningId)) {
+                                val reasoningId = reasoningMetadata?.reasoningId ?: return@forEach
+                                if (!emittedReasoningIds.add(reasoningId)) {
                                     return@forEach
                                 }
                                 // 先输出累积的文本/图片内容
@@ -335,16 +349,12 @@ class ResponseAPI(
                                     contentBuffer.clear()
                                 }
                                 // 输出 reasoning item
-                                val reasoningParts = if (reasoningId == null) {
-                                    listOf(part)
-                                } else {
-                                    group.parts.filterIsInstance<UIMessagePart.Reasoning>().filter {
-                                        it.metadataAs<OpenAIReasoningMetadata>()?.reasoningId == reasoningId
-                                    }
+                                val reasoningParts = group.parts.filterIsInstance<UIMessagePart.Reasoning>().filter {
+                                    it.metadataAs<OpenAIReasoningMetadata>()?.reasoningId == reasoningId
                                 }
                                 add(buildJsonObject {
                                     put("type", "reasoning")
-                                    reasoningId?.let { put("id", it) }
+                                    put("id", reasoningId)
                                     put("summary", buildJsonArray {
                                         reasoningParts
                                             .filter { it.reasoningType == ReasoningType.SUMMARY_TEXT }

--- a/ai/src/test/java/me/rerere/ai/provider/providers/openai/ResponseApiRequestMessageTest.kt
+++ b/ai/src/test/java/me/rerere/ai/provider/providers/openai/ResponseApiRequestMessageTest.kt
@@ -57,9 +57,10 @@ class ResponseApiRequestMessageTest {
     private fun invokeBuildRequestBody(
         providerSetting: ProviderSetting.OpenAI,
         params: TextGenerationParams,
-        stream: Boolean = false
+        stream: Boolean = false,
+        messages: List<UIMessage> = listOf(UIMessage.user("hello")),
     ): JsonObject {
-        return api.buildRequestBody(providerSetting, listOf(UIMessage.user("hello")), params, stream)
+        return api.buildRequestBody(providerSetting, messages, params, stream)
     }
 
     private fun createReasoningParams(reasoningLevel: ReasoningLevel = ReasoningLevel.OFF): TextGenerationParams {
@@ -368,6 +369,59 @@ class ResponseApiRequestMessageTest {
             content?.single()?.jsonObject?.get("text")?.jsonPrimitive?.content,
         )
         assertFalse(reasoningItem.containsKey("encrypted_content"))
+    }
+
+    @Test
+    fun `reasoning from another provider should not be replayed`() {
+        val result = invokeBuildMessages(listOf(
+            UIMessage(
+                role = MessageRole.ASSISTANT,
+                parts = listOf(
+                    UIMessagePart.Reasoning(reasoning = "foreign reasoning"),
+                    UIMessagePart.Text("final answer"),
+                ),
+            ),
+        ))
+
+        assertFalse(result.any {
+            it.jsonObject["type"]?.jsonPrimitive?.content == "reasoning"
+        })
+        assertEquals(
+            "final answer",
+            result.single().jsonObject["content"]?.jsonPrimitive?.content,
+        )
+    }
+
+    @Test
+    fun `history reasoning disabled should omit native Responses reasoning`() {
+        val requestBody = invokeBuildRequestBody(
+            providerSetting = ProviderSetting.OpenAI(
+                baseUrl = "https://api.openai.com/v1",
+                includeHistoryReasoning = false,
+            ),
+            params = createReasoningParams(),
+            messages = listOf(
+                UIMessage(
+                    role = MessageRole.ASSISTANT,
+                    parts = listOf(
+                        UIMessagePart.Reasoning(
+                            reasoning = "native reasoning",
+                            metadata = OpenAIReasoningMetadata(
+                                reasoningId = "rs_1",
+                                encryptedContent = "encrypted",
+                            ).toMetadata(),
+                        ),
+                        UIMessagePart.Text("final answer"),
+                    ),
+                ),
+            ),
+        )
+        val result = requestBody["input"]?.jsonArray ?: error("input not found")
+
+        assertFalse(result.any {
+            it.jsonObject["type"]?.jsonPrimitive?.content == "reasoning"
+        })
+        assertEquals(1, result.size)
     }
 
     @Test

--- a/ai/src/test/java/me/rerere/ai/provider/providers/openai/ResponseApiStreamDecoderTest.kt
+++ b/ai/src/test/java/me/rerere/ai/provider/providers/openai/ResponseApiStreamDecoderTest.kt
@@ -197,11 +197,7 @@ class ResponseApiStreamDecoderTest {
             reasoningItem["summary"]?.jsonArray?.single()?.jsonObject
                 ?.get("text")?.jsonPrimitive?.content,
         )
-        assertEquals(
-            "raw",
-            reasoningItem["content"]?.jsonArray?.single()?.jsonObject
-                ?.get("text")?.jsonPrimitive?.content,
-        )
+        assertFalse(reasoningItem.containsKey("content"))
     }
 
     @Test


### PR DESCRIPTION
修复 #1723

这个问题与 #1719 有关，但 #1719 没有覆盖 #1723 中切换供应商或模型后的历史消息场景。

#1719 仅处理了存在 `encrypted_content` 时仍重复回传明文内容的问题；对于其他供应商生成的历史 reasoning，由于没有 OpenAI Responses API 所需的 `reasoningId`，当前仍会被当作普通内容回传，部分兼容服务会因此拒绝请求并报错。

本修改在 Responses API 回传历史消息时，只保留带有效 `reasoningId` 的 OpenAI 原生推理内容。其他供应商生成的 reasoning 不再回传，但助手最终回复文本会继续保留，不影响上下文中的正常对话内容。

同时使“回传历史思考过程”设置对 Responses API 生效：关闭时不回传任何历史推理内容。

已验证：
- 非 OpenAI 的历史 reasoning 会被过滤，助手回复文本仍会保留
- OpenAI 原生 reasoning 仍可正常回传
- 关闭历史思考回传后，请求中不包含历史 reasoning
- AI 模块单元测试通过