### PR TITLE
修复：Responses API 安全回传跨供应商历史推理

### DIFF
--- a/ai/src/main/java/me/rerere/ai/provider/providers/openai/ResponseAPI.kt
+++ b/ai/src/main/java/me/rerere/ai/provider/providers/openai/ResponseAPI.kt
@@ -228,7 +228,13 @@ class ResponseAPI(
             }
 
             // messages
-            put("input", buildMessages(messages))
+            put(
+                "input",
+                buildMessages(
+                    messages = messages,
+                    includeHistoryReasoning = providerSetting.includeHistoryReasoning,
+                )
+            )
 
             // reasoning
             if (params.model.abilities.contains(ModelAbility.REASONING)) {
@@ -294,26 +300,33 @@ class ResponseAPI(
         }.mergeCustomBody(params.customBody)
     }
 
-    internal fun buildMessages(messages: List<UIMessage>) = buildJsonArray {
+    internal fun buildMessages(
+        messages: List<UIMessage>,
+        includeHistoryReasoning: Boolean = true,
+    ) = buildJsonArray {
         messages
             .filter { message ->
                 message.role != MessageRole.SYSTEM && (
                     message.isValidToUpload() || message.parts.any { part ->
-                        part is UIMessagePart.Reasoning &&
+                        includeHistoryReasoning &&
+                            part is UIMessagePart.Reasoning &&
                             part.metadataAs<OpenAIReasoningMetadata>()?.encryptedContent != null
                     }
                 )
             }
             .forEach { message ->
                 if (message.role == MessageRole.ASSISTANT) {
-                    addAssistantItems(message)
+                    addAssistantItems(message, includeHistoryReasoning)
                 } else {
                     addUserItems(message)
                 }
             }
     }
 
-    private fun JsonArrayBuilder.addAssistantItems(message: UIMessage) {
+    private fun JsonArrayBuilder.addAssistantItems(
+        message: UIMessage,
+        includeHistoryReasoning: Boolean,
+    ) {
         val groups = groupPartsByToolBoundary(message.parts)
         val contentBuffer = mutableListOf<UIMessagePart>()
 
@@ -324,9 +337,16 @@ class ResponseAPI(
                     group.parts.forEach { part ->
                         when (part) {
                             is UIMessagePart.Reasoning -> {
+                                if (!includeHistoryReasoning) return@forEach
                                 val reasoningMetadata = part.metadataAs<OpenAIReasoningMetadata>()
                                 val reasoningId = reasoningMetadata?.reasoningId
-                                if (reasoningId != null && !emittedReasoningIds.add(reasoningId)) {
+                                if (reasoningId == null) {
+                                    if (part.reasoning.isNotEmpty()) {
+                                        contentBuffer.add(UIMessagePart.Text(part.reasoning))
+                                    }
+                                    return@forEach
+                                }
+                                if (!emittedReasoningIds.add(reasoningId)) {
                                     return@forEach
                                 }
                                 // 先输出累积的文本/图片内容
@@ -335,16 +355,12 @@ class ResponseAPI(
                                     contentBuffer.clear()
                                 }
                                 // 输出 reasoning item
-                                val reasoningParts = if (reasoningId == null) {
-                                    listOf(part)
-                                } else {
-                                    group.parts.filterIsInstance<UIMessagePart.Reasoning>().filter {
-                                        it.metadataAs<OpenAIReasoningMetadata>()?.reasoningId == reasoningId
-                                    }
+                                val reasoningParts = group.parts.filterIsInstance<UIMessagePart.Reasoning>().filter {
+                                    it.metadataAs<OpenAIReasoningMetadata>()?.reasoningId == reasoningId
                                 }
                                 add(buildJsonObject {
                                     put("type", "reasoning")
-                                    reasoningId?.let { put("id", it) }
+                                    put("id", reasoningId)
                                     put("summary", buildJsonArray {
                                         reasoningParts
                                             .filter { it.reasoningType == ReasoningType.SUMMARY_TEXT }
@@ -356,7 +372,7 @@ class ResponseAPI(
                                                 })
                                             }
                                     })
-                                    val encryptedContent = reasoningMetadata?.encryptedContent
+                                    val encryptedContent = reasoningMetadata.encryptedContent
                                     val content = reasoningParts
                                         .filter { it.reasoningType == ReasoningType.REASONING_TEXT }
                                         .filter { it.reasoning.isNotEmpty() }

--- a/ai/src/test/java/me/rerere/ai/provider/providers/openai/ResponseApiRequestMessageTest.kt
+++ b/ai/src/test/java/me/rerere/ai/provider/providers/openai/ResponseApiRequestMessageTest.kt
@@ -57,9 +57,10 @@ class ResponseApiRequestMessageTest {
     private fun invokeBuildRequestBody(
         providerSetting: ProviderSetting.OpenAI,
         params: TextGenerationParams,
-        stream: Boolean = false
+        stream: Boolean = false,
+        messages: List<UIMessage> = listOf(UIMessage.user("hello")),
     ): JsonObject {
-        return api.buildRequestBody(providerSetting, listOf(UIMessage.user("hello")), params, stream)
+        return api.buildRequestBody(providerSetting, messages, params, stream)
     }
 
     private fun createReasoningParams(reasoningLevel: ReasoningLevel = ReasoningLevel.OFF): TextGenerationParams {
@@ -368,6 +369,74 @@ class ResponseApiRequestMessageTest {
             content?.single()?.jsonObject?.get("text")?.jsonPrimitive?.content,
         )
         assertFalse(reasoningItem.containsKey("encrypted_content"))
+    }
+
+    @Test
+    fun `reasoning from another provider should replay as assistant text`() {
+        val result = invokeBuildMessages(listOf(
+            UIMessage(
+                role = MessageRole.ASSISTANT,
+                parts = listOf(
+                    UIMessagePart.Reasoning(reasoning = "foreign reasoning"),
+                    UIMessagePart.Text("final answer"),
+                ),
+            ),
+        ))
+
+        assertFalse(result.any {
+            it.jsonObject["type"]?.jsonPrimitive?.content == "reasoning"
+        })
+        val content = result.single().jsonObject["content"]?.jsonArray ?: error("content not found")
+        assertEquals(2, content.size)
+        assertTrue(content.all { it.jsonObject["type"]?.jsonPrimitive?.content == "output_text" })
+        assertEquals("foreign reasoning", content[0].jsonObject["text"]?.jsonPrimitive?.content)
+        assertEquals("final answer", content[1].jsonObject["text"]?.jsonPrimitive?.content)
+    }
+
+    @Test
+    fun `reasoning only message from another provider should replay as assistant text`() {
+        val result = invokeBuildMessages(listOf(
+            UIMessage(
+                role = MessageRole.ASSISTANT,
+                parts = listOf(UIMessagePart.Reasoning(reasoning = "foreign reasoning")),
+            ),
+        ))
+
+        assertEquals("assistant", result.single().jsonObject["role"]?.jsonPrimitive?.content)
+        assertEquals("foreign reasoning", result.single().jsonObject["content"]?.jsonPrimitive?.content)
+    }
+
+    @Test
+    fun `history reasoning disabled should omit native Responses reasoning`() {
+        val requestBody = invokeBuildRequestBody(
+            providerSetting = ProviderSetting.OpenAI(
+                baseUrl = "https://api.openai.com/v1",
+                includeHistoryReasoning = false,
+            ),
+            params = createReasoningParams(),
+            messages = listOf(
+                UIMessage(
+                    role = MessageRole.ASSISTANT,
+                    parts = listOf(
+                        UIMessagePart.Reasoning(
+                            reasoning = "native reasoning",
+                            metadata = OpenAIReasoningMetadata(
+                                reasoningId = "rs_1",
+                                encryptedContent = "encrypted",
+                            ).toMetadata(),
+                        ),
+                        UIMessagePart.Reasoning(reasoning = "foreign reasoning"),
+                        UIMessagePart.Text("final answer"),
+                    ),
+                ),
+            ),
+        )
+        val result = requestBody["input"]?.jsonArray ?: error("input not found")
+
+        assertFalse(result.any {
+            it.jsonObject["type"]?.jsonPrimitive?.content == "reasoning"
+        })
+        assertEquals(1, result.size)
     }
 
     @Test

--- a/ai/src/test/java/me/rerere/ai/provider/providers/openai/ResponseApiStreamDecoderTest.kt
+++ b/ai/src/test/java/me/rerere/ai/provider/providers/openai/ResponseApiStreamDecoderTest.kt
@@ -197,11 +197,7 @@ class ResponseApiStreamDecoderTest {
             reasoningItem["summary"]?.jsonArray?.single()?.jsonObject
                 ?.get("text")?.jsonPrimitive?.content,
         )
-        assertEquals(
-            "raw",
-            reasoningItem["content"]?.jsonArray?.single()?.jsonObject
-                ?.get("text")?.jsonPrimitive?.content,
-        )
+        assertFalse(reasoningItem.containsKey("content"))
     }
 
     @Test


### PR DESCRIPTION
修复 #1723

这个问题与 #1719 有关，但 #1719 没有覆盖切换供应商或协议后的历史推理场景。

引入 reasoning type 后，没有 Responses `reasoningId` 的通用历史推理会被编码到 reasoning item 的 `content` 中。部分兼容服务不接受这种缺少原生推理状态的输入，因此返回 `input[n].content` 长度必须为 0 的错误。

直接丢弃这些历史推理虽然能避免报错，但会破坏跨供应商、跨协议对话的推理连续性。本修改采用以下规则：

- 带有效 `reasoningId` 的 Responses 原生推理继续按 reasoning item 回传
- 不带 `reasoningId` 的通用推理降级为普通助手文本，并保持它与最终回复的原始顺序
- 关闭“回传历史思考过程”后，原生与通用历史推理均不回传
- 存在 `encrypted_content` 时仍不重复回传明文 reasoning content

这样既不会构造非法的 Responses reasoning item，也不会丢失其他模型需要的历史推理上下文。

已验证：
- 跨供应商推理以 `output_text` 回传，最终回复保持原顺序
- 仅包含推理的历史助手消息仍能作为普通助手文本回传
- Responses 原生推理继续按 `reasoningId` 回传
- 关闭历史思考回传后，请求不包含任何历史推理
- AI 模块单元测试通过