### PR TITLE
fix(web): preserve JWT parser in release builds

### DIFF
--- a/app/src/main/keepRules/rikkahub.keep
+++ b/app/src/main/keepRules/rikkahub.keep
@@ -22,5 +22,9 @@
 -keepattributes Signature,InnerClasses,EnclosingMethod
 -keep,allowobfuscation class * extends com.fasterxml.jackson.core.type.TypeReference
 
+# Auth0 java-jwt parses JWT headers and payloads through Jackson reflection.
+-keep class com.fasterxml.jackson.** { *; }
+-keep class com.auth0.jwt.** { *; }
+
 # Keep JlatexMath
 -keep class org.scilab.forge.jlatexmath.** { *; }


### PR DESCRIPTION
## Summary

Restore the Auth0 java-jwt and Jackson R8 keep rules required by Web JWT verification in release builds.

Fixes #1725. #1740 reports the same regression.

## Root cause

`de3399ba` removed these rules while simplifying the release keep configuration:

```proguard
-keep class com.fasterxml.jackson.** { *; }
-keep class com.auth0.jwt.** { *; }
```

`java-jwt` can still sign a token after shrinking, but verification decodes its header and payload through Jackson. In the affected release build, an immediately generated token fails `JWTVerifier.verify()` with `IllegalArgumentException` before it is sent to the browser. The Web UI therefore receives a token from `/api/auth/token`, reloads, and every protected API request returns 401.

This PR restores only the two keep rules that were present in the previously working configuration.

## Verification

- Reproduced on the 2.4.10 release path: correct password -> token issued -> protected API returns 401.
- An issue-specific self-verification probe confirmed the generated token already fails inside the Android process with `IllegalArgumentException`.
- The minimal branch changes one file by four lines.
- Fork `Daily Build` check and release build completed successfully: https://github.com/Photalia/rikkahub/actions/runs/32024484949
