### PR TITLE
fix(search): improve search providers and add DuckDuckGo

### DIFF
--- a/ai/src/main/java/me/rerere/ai/provider/ProviderSetting.kt
+++ b/ai/src/main/java/me/rerere/ai/provider/ProviderSetting.kt
@@ -65,6 +65,8 @@ sealed class ProviderSetting {
         var chatCompletionsPath: String = "/chat/completions",
         var useResponseApi: Boolean = false,
         var includeHistoryReasoning: Boolean = true,
+        var authHeaderPrefix: String = "Bearer",
+        var authHeaderName: String = "Authorization",
     ) : ProviderSetting() {
         override fun addModel(model: Model): ProviderSetting {
             return copy(models = models + model)

--- a/ai/src/main/java/me/rerere/ai/provider/providers/openai/ChatCompletionsAPI.kt
+++ b/ai/src/main/java/me/rerere/ai/provider/providers/openai/ChatCompletionsAPI.kt
@@ -87,11 +87,17 @@ class ChatCompletionsAPI(
                 providerSetting = providerSetting
             )
 
+        val apiKey = keyRoulette.next(providerSetting.apiKey, providerSetting.id.toString())
+        val authValue = if (providerSetting.authHeaderPrefix.isBlank()) {
+            apiKey
+        } else {
+            "${providerSetting.authHeaderPrefix} $apiKey"
+        }
         val request = Request.Builder()
             .url("${providerSetting.baseUrl}${providerSetting.chatCompletionsPath}")
             .headers(params.customHeaders.toHeaders())
             .post(json.encodeToString(requestBody).toRequestBody("application/json".toMediaType()))
-            .addHeader("Authorization", "Bearer ${keyRoulette.next(providerSetting.apiKey, providerSetting.id.toString())}")
+            .addHeader(providerSetting.authHeaderName, authValue)
             .configureReferHeaders(providerSetting.baseUrl)
             .build()
 
@@ -138,11 +144,17 @@ class ChatCompletionsAPI(
             stream = true,
         )
 
+        val apiKey = keyRoulette.next(providerSetting.apiKey, providerSetting.id.toString())
+        val authValue = if (providerSetting.authHeaderPrefix.isBlank()) {
+            apiKey
+        } else {
+            "${providerSetting.authHeaderPrefix} $apiKey"
+        }
         val request = Request.Builder()
             .url("${providerSetting.baseUrl}${providerSetting.chatCompletionsPath}")
             .headers(params.customHeaders.toHeaders())
             .post(json.encodeToString(requestBody).toRequestBody("application/json".toMediaType()))
-            .addHeader("Authorization", "Bearer ${keyRoulette.next(providerSetting.apiKey, providerSetting.id.toString())}")
+            .addHeader(providerSetting.authHeaderName, authValue)
             .addHeader("Content-Type", "application/json")
             .configureReferHeaders(providerSetting.baseUrl)
             .build()

--- a/ai/src/main/java/me/rerere/ai/provider/providers/openai/OpenAIProvider.kt
+++ b/ai/src/main/java/me/rerere/ai/provider/providers/openai/OpenAIProvider.kt
@@ -54,13 +54,21 @@ class OpenAIProvider(
     private val chatCompletionsAPI = ChatCompletionsAPI(client = client, keyRoulette = keyRoulette)
     private val responseAPI = ResponseAPI(client = client, keyRoulette = keyRoulette)
 
+    private fun authHeaderValue(providerSetting: ProviderSetting.OpenAI, apiKey: String): String {
+        return if (providerSetting.authHeaderPrefix.isBlank()) {
+            apiKey
+        } else {
+            "${providerSetting.authHeaderPrefix} $apiKey"
+        }
+    }
+
 
     override suspend fun listModels(providerSetting: ProviderSetting.OpenAI): List<Model> =
         withContext(Dispatchers.IO) {
             val key = keyRoulette.next(providerSetting.apiKey, providerSetting.id.toString())
             val request = Request.Builder()
                 .url("${providerSetting.baseUrl}/models")
-                .addHeader("Authorization", "Bearer $key")
+                .addHeader(providerSetting.authHeaderName, authHeaderValue(providerSetting, key))
                 .get()
                 .build()
 
@@ -93,7 +101,7 @@ class OpenAIProvider(
         }
         val request = Request.Builder()
             .url(url)
-            .addHeader("Authorization", "Bearer $key")
+            .addHeader(providerSetting.authHeaderName, authHeaderValue(providerSetting, key))
             .get()
             .build()
         val response = client.newCall(request).await()
@@ -172,7 +180,7 @@ class OpenAIProvider(
         val request = Request.Builder()
             .url("${providerSetting.baseUrl}/embeddings")
             .headers(params.customHeaders.toHeaders())
-            .addHeader("Authorization", "Bearer $key")
+            .addHeader(providerSetting.authHeaderName, authHeaderValue(providerSetting, key))
             .addHeader("Content-Type", "application/json")
             .post(requestBody.toRequestBody("application/json".toMediaType()))
             .build()
@@ -230,7 +238,7 @@ class OpenAIProvider(
         val request = Request.Builder()
             .url("${providerSetting.baseUrl}/images/generations")
             .headers(params.customHeaders.toHeaders())
-            .addHeader("Authorization", "Bearer $key")
+            .addHeader(providerSetting.authHeaderName, authHeaderValue(providerSetting, key))
             .addHeader("Content-Type", "application/json")
             .post(requestBody.toRequestBody("application/json".toMediaType()))
             .configureReferHeaders(providerSetting.baseUrl)
@@ -295,7 +303,7 @@ class OpenAIProvider(
         val request = Request.Builder()
             .url("${providerSetting.baseUrl}/images/edits")
             .headers(params.customHeaders.toHeaders())
-            .addHeader("Authorization", "Bearer $key")
+            .addHeader(providerSetting.authHeaderName, authHeaderValue(providerSetting, key))
             .post(bodyBuilder.build())
             .configureReferHeaders(providerSetting.baseUrl)
             .build()

--- a/ai/src/main/java/me/rerere/ai/provider/providers/openai/ResponseAPI.kt
+++ b/ai/src/main/java/me/rerere/ai/provider/providers/openai/ResponseAPI.kt
@@ -84,14 +84,17 @@ class ResponseAPI(
             params = params,
             stream = false,
         )
+        val apiKey = keyRoulette.next(providerSetting.apiKey, providerSetting.id.toString())
+        val authValue = if (providerSetting.authHeaderPrefix.isBlank()) {
+            apiKey
+        } else {
+            "${providerSetting.authHeaderPrefix} $apiKey"
+        }
         val request = Request.Builder()
             .url("${providerSetting.baseUrl}/responses")
             .headers(params.customHeaders.toHeaders())
             .post(json.encodeToString(requestBody).toRequestBody("application/json".toMediaType()))
-            .addHeader(
-                "Authorization",
-                "Bearer ${keyRoulette.next(providerSetting.apiKey, providerSetting.id.toString())}"
-            )
+            .addHeader(providerSetting.authHeaderName, authValue)
             .addHeader("Content-Type", "application/json")
             .configureReferHeaders(providerSetting.baseUrl)
             .build()
@@ -122,14 +125,17 @@ class ResponseAPI(
             params = params,
             stream = true,
         )
+        val apiKey = keyRoulette.next(providerSetting.apiKey, providerSetting.id.toString())
+        val authValue = if (providerSetting.authHeaderPrefix.isBlank()) {
+            apiKey
+        } else {
+            "${providerSetting.authHeaderPrefix} $apiKey"
+        }
         val request = Request.Builder()
             .url("${providerSetting.baseUrl}/responses")
             .headers(params.customHeaders.toHeaders())
             .post(json.encodeToString(requestBody).toRequestBody("application/json".toMediaType()))
-            .addHeader(
-                "Authorization",
-                "Bearer ${keyRoulette.next(providerSetting.apiKey, providerSetting.id.toString())}"
-            )
+            .addHeader(providerSetting.authHeaderName, authValue)
             .configureReferHeaders(providerSetting.baseUrl)
             .build()
 

--- a/app/src/main/java/me/rerere/rikkahub/ui/components/ui/UpdateCard.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/ui/UpdateCard.kt
@@ -56,27 +56,6 @@ fun UpdateCard(vm: ChatVM) {
     val state by vm.updateState.collectAsStateWithLifecycle()
     val context = LocalContext.current
     val toaster = LocalToaster.current
-    state.onError {
-        Card {
-            Column(
-                modifier = Modifier
-                    .padding(8.dp)
-                    .fillMaxWidth(),
-                verticalArrangement = Arrangement.spacedBy(8.dp)
-            ) {
-                Text(
-                    text = stringResource(R.string.update_card_check_failed),
-                    style = MaterialTheme.typography.titleMedium,
-                    color = MaterialTheme.colorScheme.error
-                )
-                Text(
-                    text = it.message ?: stringResource(R.string.update_card_unknown_error),
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.error
-                )
-            }
-        }
-    }
     state.onSuccess { info ->
         var showDetail by remember { mutableStateOf(false) }
         var dismissed by remember { mutableStateOf(false) }

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingSearchDetailPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingSearchDetailPage.kt
@@ -202,6 +202,7 @@ private fun SearchServiceOptionsEditor(
             PerplexityOptions(options) { onUpdateOptions(it) }
         }
         is SearchServiceOptions.BingLocalOptions -> {}
+        is SearchServiceOptions.DuckDuckGoOptions -> {}
         is SearchServiceOptions.FirecrawlOptions -> {
             FirecrawlOptions(options) { onUpdateOptions(it) }
         }

--- a/search/src/main/java/me/rerere/search/BingSearchService.kt
+++ b/search/src/main/java/me/rerere/search/BingSearchService.kt
@@ -47,7 +47,7 @@ object BingSearchService : SearchService<SearchServiceOptions.BingLocalOptions> 
             val locale = Locale.getDefault()
             val acceptLanguage = "${locale.language}-${locale.country},${locale.language}"
             val doc = Jsoup.connect(url)
-                .userAgent("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36")
+                .userAgent("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/141.0.0.0 Safari/537.36")
                 .header(
                     "Accept",
                     "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8"
@@ -58,14 +58,13 @@ object BingSearchService : SearchService<SearchServiceOptions.BingLocalOptions> 
                 .header("Connection", "keep-alive")
                 .referrer("https://www.bing.com/")
                 .cookie("SRCHHPGUSR", "ULSR=1")
-                .timeout(5000)
+                .timeout(10000)
                 .get()
 
-            // 解析搜索结果
             val results = doc.select("li.b_algo").map { element ->
                 val title = element.select("h2").text()
                 val link = element.select("h2 > a").attr("href")
-                val snippet = element.select(".b_caption p").text()
+                val snippet = element.select(".b_caption p, p.b_algoSlug").text()
                 SearchResultItem(
                     title = title,
                     url = link,
@@ -73,11 +72,21 @@ object BingSearchService : SearchService<SearchServiceOptions.BingLocalOptions> 
                 )
             }
 
-            require(results.isNotEmpty()) {
-                "Search failed: no results found"
+            if (results.isEmpty()) {
+                val fallbackResults = doc.select(".b_algo, .b_ans").map { element ->
+                    val title = element.select("h2, .b_algoheader a").text()
+                    val link = element.select("h2 a, .b_algoheader a").attr("href")
+                    val snippet = element.select("p, .b_caption p, .b_snippet").text()
+                    SearchResultItem(
+                        title = title,
+                        url = link,
+                        text = snippet
+                    )
+                }
+                SearchResult(items = fallbackResults)
+            } else {
+                SearchResult(items = results)
             }
-
-            SearchResult(items = results)
         }
     }
 

--- a/search/src/main/java/me/rerere/search/BochaSearchService.kt
+++ b/search/src/main/java/me/rerere/search/BochaSearchService.kt
@@ -56,6 +56,10 @@ object BochaSearchService : SearchService<SearchServiceOptions.BochaOptions> {
         serviceOptions: SearchServiceOptions.BochaOptions
     ): Result<SearchResult> = withContext(Dispatchers.IO) {
         runCatching {
+            if (serviceOptions.apiKey.isBlank()) {
+                error("Bocha API key is required")
+            }
+
             val query = params["query"]?.jsonPrimitive?.content ?: error("query is required")
 
             val body = buildJsonObject {
@@ -98,8 +102,8 @@ object BochaSearchService : SearchService<SearchServiceOptions.BochaOptions> {
                     )
                 )
             } else {
-                println(response.body.string())
-                error("response failed #${response.code}")
+                val errorBody = response.body?.string() ?: response.message
+                error("Bocha search failed with code ${response.code}: $errorBody")
             }
         }
     }

--- a/search/src/main/java/me/rerere/search/BraveSearchService.kt
+++ b/search/src/main/java/me/rerere/search/BraveSearchService.kt
@@ -54,6 +54,10 @@ object BraveSearchService : SearchService<SearchServiceOptions.BraveOptions> {
         serviceOptions: SearchServiceOptions.BraveOptions
     ): Result<SearchResult> = withContext(Dispatchers.IO) {
         runCatching {
+            if (serviceOptions.apiKey.isBlank()) {
+                error("Brave API key is required")
+            }
+
             val query = params["query"]?.jsonPrimitive?.content ?: error("query is required")
             val url = "https://api.search.brave.com/res/v1/web/search" +
                     "?q=${java.net.URLEncoder.encode(query, "UTF-8")}" +
@@ -85,7 +89,8 @@ object BraveSearchService : SearchService<SearchServiceOptions.BraveOptions> {
                     )
                 )
             } else {
-                error("Brave search failed with code ${response.code}: ${response.message}")
+                val errorBody = response.body?.string() ?: response.message
+                error("Brave search failed with code ${response.code}: $errorBody")
             }
         }
     }

--- a/search/src/main/java/me/rerere/search/DoubaoSearchService.kt
+++ b/search/src/main/java/me/rerere/search/DoubaoSearchService.kt
@@ -53,6 +53,11 @@ object DoubaoSearchService : SearchService<SearchServiceOptions.DoubaoOptions> {
         serviceOptions: SearchServiceOptions.DoubaoOptions
     ): Result<SearchResult> = withContext(Dispatchers.IO) {
         runCatching {
+            val apiKey = keyRoulette.next(serviceOptions.apiKey, serviceOptions.id.toString())
+            if (apiKey.isBlank()) {
+                error("Doubao API key is required")
+            }
+
             val query = params["query"]?.jsonPrimitive?.content ?: error("query is required")
             val body = when (serviceOptions.mode) {
                 DoubaoSearchMode.GLOBAL -> buildJsonObject {
@@ -75,7 +80,6 @@ object DoubaoSearchService : SearchService<SearchServiceOptions.DoubaoOptions> {
                 DoubaoSearchMode.GLOBAL -> "global_search"
                 DoubaoSearchMode.CUSTOM -> "web_search"
             }
-            val apiKey = keyRoulette.next(serviceOptions.apiKey, serviceOptions.id.toString())
             val request = Request.Builder()
                 .url("https://open.feedcoopapi.com/search_api/$endpoint")
                 .post(json.encodeToString(body).toRequestBody(JSON_MEDIA_TYPE))

--- a/search/src/main/java/me/rerere/search/DuckDuckGoSearchService.kt
+++ b/search/src/main/java/me/rerere/search/DuckDuckGoSearchService.kt
@@ -1,0 +1,89 @@
+package me.rerere.search
+
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+import me.rerere.ai.core.InputSchema
+import me.rerere.search.SearchResult.SearchResultItem
+import org.jsoup.Jsoup
+import java.net.URLEncoder
+
+object DuckDuckGoSearchService : SearchService<SearchServiceOptions.DuckDuckGoOptions> {
+    override val name: String = "DuckDuckGo"
+
+    @Composable
+    override fun Description() {
+        Text("Privacy-focused search engine based in Europe")
+    }
+
+    override fun parameters(options: SearchServiceOptions.DuckDuckGoOptions): InputSchema? =
+        InputSchema.Obj(
+            properties = buildJsonObject {
+                put("query", buildJsonObject {
+                    put("type", "string")
+                    put("description", "search keyword")
+                })
+            },
+            required = listOf("query")
+        )
+
+    override fun scrapingParameters(options: SearchServiceOptions.DuckDuckGoOptions): InputSchema? = null
+
+    override suspend fun search(
+        params: JsonObject,
+        commonOptions: SearchCommonOptions,
+        serviceOptions: SearchServiceOptions.DuckDuckGoOptions
+    ): Result<SearchResult> = withContext(Dispatchers.IO) {
+        runCatching {
+            val query = params["query"]?.jsonPrimitive?.content ?: error("query is required")
+            val url = "https://html.duckduckgo.com/html/?q=" + URLEncoder.encode(query, "UTF-8")
+
+            val doc = Jsoup.connect(url)
+                .userAgent("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/141.0.0.0 Safari/537.36")
+                .header("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8")
+                .header("Accept-Language", "en-US,en;q=0.9")
+                .timeout(15000)
+                .followRedirects(true)
+                .get()
+
+            var results = doc.select(".result").mapNotNull { element ->
+                val titleEl = element.select(".result__a").firstOrNull()
+                val title = titleEl?.text() ?: ""
+                var link = titleEl?.attr("href") ?: ""
+                if (link.startsWith("//")) link = "https:$link"
+                val snippet = element.select(".result__snippet").firstOrNull()?.text() ?: ""
+                if (title.isNotBlank() && link.isNotBlank()) {
+                    SearchResultItem(title = title, url = link, text = snippet)
+                } else null
+            }
+
+            if (results.isEmpty()) {
+                results = doc.select("article, .results_links, .links_main").mapNotNull { element ->
+                    val titleEl = element.select("a").firstOrNull()
+                    val title = titleEl?.text() ?: ""
+                    var link = titleEl?.attr("href") ?: ""
+                    if (link.startsWith("//")) link = "https:$link"
+                    val snippet = element.select("p, .snippet, .result__snippet").firstOrNull()?.text() ?: ""
+                    if (title.isNotBlank() && link.isNotBlank()) {
+                        SearchResultItem(title = title, url = link, text = snippet)
+                    } else null
+                }
+            }
+
+            SearchResult(items = results)
+        }
+    }
+
+    override suspend fun scrape(
+        params: JsonObject,
+        commonOptions: SearchCommonOptions,
+        serviceOptions: SearchServiceOptions.DuckDuckGoOptions
+    ): Result<ScrapedResult> {
+        return Result.failure(Exception("Scraping is not supported for DuckDuckGo"))
+    }
+}

--- a/search/src/main/java/me/rerere/search/ExaSearchService.kt
+++ b/search/src/main/java/me/rerere/search/ExaSearchService.kt
@@ -77,6 +77,11 @@ object ExaSearchService : SearchService<SearchServiceOptions.ExaOptions> {
         serviceOptions: SearchServiceOptions.ExaOptions
     ): Result<SearchResult> = withContext(Dispatchers.IO) {
         runCatching {
+            val apiKey = keyRoulette.next(serviceOptions.apiKey, serviceOptions.id.toString())
+            if (apiKey.isBlank()) {
+                error("Exa API key is required")
+            }
+
             val query = params["query"]?.jsonPrimitive?.content ?: error("query is required")
             val body = buildJsonObject {
                 put("query", JsonPrimitive(query))
@@ -86,7 +91,6 @@ object ExaSearchService : SearchService<SearchServiceOptions.ExaOptions> {
                     put("text", JsonPrimitive(true))
                 })
             }
-            val apiKey = keyRoulette.next(serviceOptions.apiKey, serviceOptions.id.toString())
 
             val request = Request.Builder()
                 .url("https://api.exa.ai/search")
@@ -118,8 +122,8 @@ object ExaSearchService : SearchService<SearchServiceOptions.ExaOptions> {
                         images = response.results.mapNotNull { it.image?.takeIf { url -> url.isNotBlank() } },
                     ))
             } else {
-                println(response.body.string())
-                error("response failed #${response.code}")
+                val errorBody = response.body?.string() ?: response.message
+                error("Exa search failed with code ${response.code}: $errorBody")
             }
         }
     }
@@ -130,6 +134,11 @@ object ExaSearchService : SearchService<SearchServiceOptions.ExaOptions> {
         serviceOptions: SearchServiceOptions.ExaOptions
     ): Result<ScrapedResult> = withContext(Dispatchers.IO) {
         runCatching {
+            val apiKey = keyRoulette.next(serviceOptions.apiKey, serviceOptions.id.toString())
+            if (apiKey.isBlank()) {
+                error("Exa API key is required")
+            }
+
             val url = params["url"]?.jsonPrimitive?.content ?: error("url is required")
             val body = buildJsonObject {
                 put("urls", buildJsonArray {
@@ -137,7 +146,6 @@ object ExaSearchService : SearchService<SearchServiceOptions.ExaOptions> {
                 })
                 put("text", JsonPrimitive(true))
             }
-            val apiKey = keyRoulette.next(serviceOptions.apiKey, serviceOptions.id.toString())
 
             val request = Request.Builder()
                 .url("https://api.exa.ai/contents")
@@ -170,8 +178,8 @@ object ExaSearchService : SearchService<SearchServiceOptions.ExaOptions> {
                     )
                 )
             } else {
-                println(response.body.string())
-                error("response failed #${response.code}")
+                val errorBody = response.body?.string() ?: response.message
+                error("Exa scrape failed with code ${response.code}: $errorBody")
             }
         }
     }

--- a/search/src/main/java/me/rerere/search/FirecrawlSearchService.kt
+++ b/search/src/main/java/me/rerere/search/FirecrawlSearchService.kt
@@ -124,7 +124,8 @@ object FirecrawlSearchService : SearchService<SearchServiceOptions.FirecrawlOpti
 
             val response = httpClient.newCall(request).await()
             if (!response.isSuccessful) {
-                error("response failed #${response.code}")
+                val errorBody = response.body?.string() ?: response.message
+                error("Firecrawl search failed with code ${response.code}: $errorBody")
             }
 
             val bodyString = response.body.string()
@@ -187,7 +188,8 @@ object FirecrawlSearchService : SearchService<SearchServiceOptions.FirecrawlOpti
 
             val response = httpClient.newCall(request).await()
             if (!response.isSuccessful) {
-                error("response failed #${response.code}")
+                val errorBody = response.body?.string() ?: response.message
+                error("Firecrawl scrape failed with code ${response.code}: $errorBody")
             }
 
             val bodyString = response.body.string()
@@ -195,7 +197,7 @@ object FirecrawlSearchService : SearchService<SearchServiceOptions.FirecrawlOpti
 
             val success = payload["success"]?.jsonPrimitive?.contentOrNull?.toBoolean() ?: false
             if (!success) {
-                error("scrape request failed")
+                error("Firecrawl scrape request failed: $bodyString")
             }
 
             val data = payload["data"]?.jsonObject ?: error("empty response data")

--- a/search/src/main/java/me/rerere/search/JinaSearchService.kt
+++ b/search/src/main/java/me/rerere/search/JinaSearchService.kt
@@ -65,6 +65,10 @@ object JinaSearchService : SearchService<SearchServiceOptions.JinaOptions> {
         serviceOptions: SearchServiceOptions.JinaOptions
     ): Result<SearchResult> = withContext(Dispatchers.IO) {
         runCatching {
+            if (serviceOptions.apiKey.isBlank()) {
+                error("Jina API key is required")
+            }
+
             val query = params["query"]?.jsonPrimitive?.content ?: error("query is required")
 
             val body = buildJsonObject {
@@ -99,7 +103,8 @@ object JinaSearchService : SearchService<SearchServiceOptions.JinaOptions> {
                     )
                 )
             } else {
-                error("response failed #${response.code}")
+                val errorBody = response.body?.string() ?: response.message
+                error("Jina search failed with code ${response.code}: $errorBody")
             }
         }
     }
@@ -110,6 +115,10 @@ object JinaSearchService : SearchService<SearchServiceOptions.JinaOptions> {
         serviceOptions: SearchServiceOptions.JinaOptions
     ): Result<ScrapedResult> = withContext(Dispatchers.IO) {
         runCatching {
+            if (serviceOptions.apiKey.isBlank()) {
+                error("Jina API key is required")
+            }
+
             val url = params["url"]?.jsonPrimitive?.content ?: error("urls is required")
 
             val body = buildJsonObject {
@@ -129,7 +138,8 @@ object JinaSearchService : SearchService<SearchServiceOptions.JinaOptions> {
 
             val response = httpClient.newCall(request).await()
             if (!response.isSuccessful) {
-                error("response failed for url $url #${response.code}")
+                val errorBody = response.body?.string() ?: response.message
+                error("Jina scrape failed for url $url #${response.code}: $errorBody")
             }
             val responseData = response.body.string().let {
                 json.decodeFromString<JinaScrapeResponse>(it)

--- a/search/src/main/java/me/rerere/search/MetasoSearchService.kt
+++ b/search/src/main/java/me/rerere/search/MetasoSearchService.kt
@@ -54,6 +54,10 @@ object MetasoSearchService : SearchService<SearchServiceOptions.MetasoOptions> {
         serviceOptions: SearchServiceOptions.MetasoOptions
     ): Result<SearchResult> = withContext(Dispatchers.IO) {
         runCatching {
+            if (serviceOptions.apiKey.isBlank()) {
+                error("Metaso API key is required")
+            }
+
             val query = params["query"]?.jsonPrimitive?.content ?: error("query is required")
 
             val requestBody = buildJsonObject {

--- a/search/src/main/java/me/rerere/search/OllamaSearchService.kt
+++ b/search/src/main/java/me/rerere/search/OllamaSearchService.kt
@@ -61,6 +61,10 @@ object OllamaSearchService : SearchService<SearchServiceOptions.OllamaOptions> {
         serviceOptions: SearchServiceOptions.OllamaOptions
     ): Result<SearchResult> = withContext(Dispatchers.IO) {
         runCatching {
+            if (serviceOptions.apiKey.isBlank()) {
+                error("Ollama API key is required")
+            }
+
             val query = params["query"]?.jsonPrimitive?.content ?: error("query is required")
 
             val body = buildJsonObject {
@@ -91,7 +95,8 @@ object OllamaSearchService : SearchService<SearchServiceOptions.OllamaOptions> {
                     )
                 )
             } else {
-                error("Ollama search failed with code ${response.code}: ${response.message}")
+                val errorBody = response.body?.string() ?: response.message
+                error("Ollama search failed with code ${response.code}: $errorBody")
             }
         }
     }
@@ -102,6 +107,10 @@ object OllamaSearchService : SearchService<SearchServiceOptions.OllamaOptions> {
         serviceOptions: SearchServiceOptions.OllamaOptions
     ): Result<ScrapedResult> = withContext(Dispatchers.IO) {
         runCatching {
+            if (serviceOptions.apiKey.isBlank()) {
+                error("Ollama API key is required")
+            }
+
             val url = params["url"]?.jsonPrimitive?.content ?: error("url is required")
 
             val body = buildJsonObject {
@@ -116,7 +125,8 @@ object OllamaSearchService : SearchService<SearchServiceOptions.OllamaOptions> {
 
             val response = httpClient.newCall(request).await()
             if (!response.isSuccessful) {
-                error("response failed for url $url #${response.code}")
+                val errorBody = response.body?.string() ?: response.message
+                error("Ollama scrape failed for url $url #${response.code}: $errorBody")
             }
             val responseData = response.body.string().let {
                 json.decodeFromString<OllamaScrapeResponse>(it)

--- a/search/src/main/java/me/rerere/search/RikkaHubSearchService.kt
+++ b/search/src/main/java/me/rerere/search/RikkaHubSearchService.kt
@@ -46,6 +46,10 @@ object RikkaHubSearchService : SearchService<SearchServiceOptions.RikkaHubOption
         serviceOptions: SearchServiceOptions.RikkaHubOptions
     ): Result<SearchResult> = withContext(Dispatchers.IO) {
         runCatching {
+            if (serviceOptions.apiKey.isBlank()) {
+                error("RikkaHub API key is required")
+            }
+
             val query = params["query"]?.jsonPrimitive?.content ?: error("query is required")
             val body = buildJsonObject {
                 put("q", JsonPrimitive(query))

--- a/search/src/main/java/me/rerere/search/SearchService.kt
+++ b/search/src/main/java/me/rerere/search/SearchService.kt
@@ -50,6 +50,7 @@ interface SearchService<T : SearchServiceOptions> {
                 is SearchServiceOptions.ZhipuOptions -> ZhipuSearchService
                 is SearchServiceOptions.DoubaoOptions -> DoubaoSearchService
                 is SearchServiceOptions.BingLocalOptions -> BingSearchService
+                is SearchServiceOptions.DuckDuckGoOptions -> DuckDuckGoSearchService
                 is SearchServiceOptions.SearXNGOptions -> SearXNGService
                 is SearchServiceOptions.LinkUpOptions -> LinkUpService
                 is SearchServiceOptions.BraveOptions -> BraveSearchService
@@ -142,6 +143,7 @@ sealed class SearchServiceOptions {
 
         val TYPES = mapOf(
             BingLocalOptions::class to "Bing",
+            DuckDuckGoOptions::class to "DuckDuckGo",
             RikkaHubOptions::class to "RikkaHub",
             ZhipuOptions::class to "智谱",
             DoubaoOptions::class to "豆包",
@@ -166,6 +168,12 @@ sealed class SearchServiceOptions {
     @Serializable
     @SerialName("bing_local")
     class BingLocalOptions(
+        override val id: Uuid = Uuid.random()
+    ) : SearchServiceOptions()
+
+    @Serializable
+    @SerialName("duckduckgo")
+    class DuckDuckGoOptions(
         override val id: Uuid = Uuid.random()
     ) : SearchServiceOptions()
 

--- a/search/src/main/java/me/rerere/search/SerperSearchService.kt
+++ b/search/src/main/java/me/rerere/search/SerperSearchService.kt
@@ -63,6 +63,9 @@ object SerperSearchService : SearchService<SearchServiceOptions.SerperOptions> {
                 put("num", commonOptions.resultSize)
             }
             val apiKey = keyRoulette.next(serviceOptions.apiKey, serviceOptions.id.toString())
+            if (apiKey.isBlank()) {
+                error("Serper API key is required")
+            }
 
             val request = Request.Builder()
                 .url("https://google.serper.dev/search")
@@ -94,7 +97,8 @@ object SerperSearchService : SearchService<SearchServiceOptions.SerperOptions> {
                     )
                 )
             } else {
-                error("Serper search failed with code ${response.code}: ${response.message}")
+                val errorBody = response.body?.string() ?: response.message
+                error("Serper search failed with code ${response.code}: $errorBody")
             }
         }
     }

--- a/search/src/main/java/me/rerere/search/TavilySearchService.kt
+++ b/search/src/main/java/me/rerere/search/TavilySearchService.kt
@@ -79,6 +79,11 @@ object TavilySearchService : SearchService<SearchServiceOptions.TavilyOptions> {
         serviceOptions: SearchServiceOptions.TavilyOptions
     ): Result<SearchResult> = withContext(Dispatchers.IO) {
         runCatching {
+            val apiKey = keyRoulette.next(serviceOptions.apiKey, serviceOptions.id.toString())
+            if (apiKey.isBlank()) {
+                error("Tavily API key is required")
+            }
+
             val query = params["query"]?.jsonPrimitive?.content ?: error("query is required")
             val topic = params["topic"]?.jsonPrimitive?.contentOrNull ?: "general"
 
@@ -95,7 +100,6 @@ object TavilySearchService : SearchService<SearchServiceOptions.TavilyOptions> {
                 put("include_answer", "advanced")
                 put("include_images", true)
             }
-            val apiKey = keyRoulette.next(serviceOptions.apiKey, serviceOptions.id.toString())
 
             val request = Request.Builder()
                 .url("https://api.tavily.com/search")
@@ -121,7 +125,8 @@ object TavilySearchService : SearchService<SearchServiceOptions.TavilyOptions> {
                         images = response.images,
                     ))
             } else {
-                error("response failed #${response.code}")
+                val errorBody = response.body?.string() ?: response.message
+                error("Tavily search failed with code ${response.code}: $errorBody")
             }
         }
     }
@@ -132,13 +137,17 @@ object TavilySearchService : SearchService<SearchServiceOptions.TavilyOptions> {
         serviceOptions: SearchServiceOptions.TavilyOptions
     ): Result<ScrapedResult> = withContext(Dispatchers.IO) {
         runCatching {
+            val apiKey = keyRoulette.next(serviceOptions.apiKey, serviceOptions.id.toString())
+            if (apiKey.isBlank()) {
+                error("Tavily API key is required")
+            }
+
             val url = params["url"]?.jsonPrimitive?.content ?: error("url is required")
             val body = buildJsonObject {
                 put("urls", buildJsonArray {
                     add(url)
                 })
             }
-            val apiKey = keyRoulette.next(serviceOptions.apiKey, serviceOptions.id.toString())
             val request = Request.Builder()
                 .url("https://api.tavily.com/extract")
                 .post(body.toString().toRequestBody())
@@ -160,7 +169,8 @@ object TavilySearchService : SearchService<SearchServiceOptions.TavilyOptions> {
                     )
                 )
             } else {
-                error("response failed #${response.code}")
+                val errorBody = response.body?.string() ?: response.message
+                error("Tavily scrape failed with code ${response.code}: $errorBody")
             }
         }
     }

--- a/search/src/main/java/me/rerere/search/TinyfishSearchService.kt
+++ b/search/src/main/java/me/rerere/search/TinyfishSearchService.kt
@@ -64,6 +64,10 @@ object TinyfishSearchService : SearchService<SearchServiceOptions.TinyfishOption
         serviceOptions: SearchServiceOptions.TinyfishOptions
     ): Result<SearchResult> = withContext(Dispatchers.IO) {
         runCatching {
+            if (serviceOptions.apiKey.isBlank()) {
+                error("Tinyfish API key is required")
+            }
+
             val query = params["query"]?.jsonPrimitive?.content ?: error("query is required")
             val url = "https://api.search.tinyfish.ai" +
                     "?query=${java.net.URLEncoder.encode(query, "UTF-8")}"
@@ -93,7 +97,8 @@ object TinyfishSearchService : SearchService<SearchServiceOptions.TinyfishOption
                     )
                 )
             } else {
-                error("Tinyfish search failed with code ${response.code}: ${response.message}")
+                val errorBody = response.body?.string() ?: response.message
+                error("Tinyfish search failed with code ${response.code}: $errorBody")
             }
         }
     }
@@ -104,6 +109,10 @@ object TinyfishSearchService : SearchService<SearchServiceOptions.TinyfishOption
         serviceOptions: SearchServiceOptions.TinyfishOptions
     ): Result<ScrapedResult> = withContext(Dispatchers.IO) {
         runCatching {
+            if (serviceOptions.apiKey.isBlank()) {
+                error("Tinyfish API key is required")
+            }
+
             val url = params["url"]?.jsonPrimitive?.content ?: error("url is required")
             val body = buildJsonObject {
                 put("urls", kotlinx.serialization.json.buildJsonArray {
@@ -139,7 +148,8 @@ object TinyfishSearchService : SearchService<SearchServiceOptions.TinyfishOption
                     )
                 )
             } else {
-                error("Tinyfish fetch failed with code ${response.code}: ${response.message}")
+                val errorBody = response.body?.string() ?: response.message
+                error("Tinyfish fetch failed with code ${response.code}: $errorBody")
             }
         }
     }

--- a/search/src/main/java/me/rerere/search/ZhipuSearchService.kt
+++ b/search/src/main/java/me/rerere/search/ZhipuSearchService.kt
@@ -56,6 +56,10 @@ object ZhipuSearchService : SearchService<SearchServiceOptions.ZhipuOptions> {
         serviceOptions: SearchServiceOptions.ZhipuOptions
     ): Result<SearchResult> = withContext(Dispatchers.IO) {
         runCatching {
+            if (serviceOptions.apiKey.isBlank()) {
+                error("Zhipu API key is required")
+            }
+
             val query = params["query"]?.jsonPrimitive?.content ?: error("query is required")
 
             val body = buildJsonObject {
@@ -92,8 +96,8 @@ object ZhipuSearchService : SearchService<SearchServiceOptions.ZhipuOptions> {
                         }
                     ))
             } else {
-                println(response.body?.string())
-                error("response failed #${response.code}")
+                val errorBody = response.body?.string() ?: response.message
+                error("Zhipu search failed with code ${response.code}: $errorBody")
             }
         }
     }


### PR DESCRIPTION
概述
改进搜索提供者稳定性，添加 DuckDuckGo 搜索支持，并增加自定义认证头配置以兼容小米 MiMo 等第三方 OpenAI 兼容 API。

主要改进
- 为 13 个搜索提供者添加 API Key 校验和详细错误报告（Brave、Serper、Bocha、Exa、Firecrawl、Jina、Metaso、Ollama、RikkaHub、Tinyfish、Zhipu、豆包、Tavily）
- 修复 Bing 搜索选择器，优雅处理空结果情况
- 新增 DuckDuckGo 搜索提供者（无需 API Key，隐私优先）
- 添加自定义认证头配置（authHeaderPrefix、authHeaderName），修复小米 MiMo 等提供者的认证问题
- 静默处理更新检查失败，不再显示错误卡片

背景与根因
多个搜索提供者在 API Key 为空时发送请求会导致服务器返回难以理解的错误（如 Brave 返回 402）。Bing 搜索的 CSS 选择器过时导致无法解析结果。小米 MiMo 等提供者使用非标准认证方式（非 Bearer Token），导致认证失败。

用户影响
- 搜索失败时会显示更清晰的错误信息，包含服务器返回的具体错误内容
- Bing 搜索更稳定，无结果时不再崩溃
- 可使用 DuckDuckGo 作为无需 API Key 的搜索选项
- 小米 MiMo 等提供者可通过自定义认证头配置正常使用

已验证
- 各搜索提供者 API Key 校验测试
- Bing 搜索结果解析测试
- DuckDuckGo 搜索功能测试
- 自定义认证头配置测试
- assembleDebug 构建通过