### PR TITLE
feat(workspace): workspace_shell 执行期间流式输出实时渲染

### DIFF
--- a/app/src/main/java/me/rerere/rikkahub/RouteActivity.kt
+++ b/app/src/main/java/me/rerere/rikkahub/RouteActivity.kt
@@ -250,6 +250,7 @@ class RouteActivity : ComponentActivity() {
                     is AppEvent.McpOAuthCallback -> Unit // 由 McpManager 消费
                     is AppEvent.ChatGenerationUpdate -> Unit // 由 ChatNotificationManager 消费
                     is AppEvent.ChatGenerationEnded -> Unit // 由 ChatNotificationManager 消费
+                    is AppEvent.ToolStreamOutput -> Unit // 由 ChatVM 消费(workspace shell 实时输出)
                 }
             }
         }

--- a/app/src/main/java/me/rerere/rikkahub/data/ai/tools/WorkspaceTools.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/ai/tools/WorkspaceTools.kt
@@ -37,6 +37,7 @@ suspend fun createWorkspaceTools(
     workspaceId: String?,
     workspaceRepository: WorkspaceRepository,
     cwd: String? = null,
+    onOutput: ((kind: String, text: String) -> Unit)? = null,
 ): List<Tool> {
     if (workspaceId.isNullOrBlank()) return emptyList()
     val approvalOverrides = workspaceRepository.getById(workspaceId)?.toolApprovalOverrides().orEmpty()
@@ -48,7 +49,7 @@ suspend fun createWorkspaceTools(
         createReadFileTool(workspaceId, ::needsApproval, workspaceRepository),
         createWriteFileTool(workspaceId, ::needsApproval, workspaceRepository),
         createEditFileTool(workspaceId, ::needsApproval, workspaceRepository),
-        createShellTool(workspaceId, ::needsApproval, workspaceRepository, shellCwd),
+        createShellTool(workspaceId, ::needsApproval, workspaceRepository, shellCwd, onOutput),
     )
 }
 
@@ -205,6 +206,7 @@ private fun createShellTool(
     needsApproval: (String) -> Boolean,
     workspaceRepository: WorkspaceRepository,
     defaultCwd: String? = null,
+    onOutput: ((kind: String, text: String) -> Unit)? = null,
 ) = Tool(
     name = "workspace_shell",
     description = buildString {
@@ -254,7 +256,13 @@ private fun createShellTool(
             ?.coerceIn(1L, SHELL_TIMEOUT_MAX_SECONDS)
             ?.times(1_000L)
             ?: WorkspaceManager.DEFAULT_COMMAND_TIMEOUT_MS
-        val result = workspaceRepository.executeCommand(workspaceId, command, cwd, timeoutMillis)
+        val result = workspaceRepository.executeCommand(
+            workspaceId,
+            command,
+            cwd,
+            timeoutMillis,
+            onOutput = onOutput,
+        )
         listOf(
             UIMessagePart.Text(
                 buildJsonObject {

--- a/app/src/main/java/me/rerere/rikkahub/data/event/AppEvent.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/event/AppEvent.kt
@@ -14,6 +14,16 @@ sealed class AppEvent {
         val error: String?,
     ) : AppEvent()
 
+    /**
+     * workspace_shell 工具执行期间的流式输出增量。
+     * kind 为 "stdout" / "stderr"，由 UI 侧按会话聚合渲染实时执行状态。
+     */
+    data class ToolStreamOutput(
+        val conversationId: Uuid,
+        val kind: String,
+        val chunk: String,
+    ) : AppEvent()
+
     /** 聊天生成过程中的流式更新，由 ChatNotificationManager 消费用于 Live Update 通知。 */
     data class ChatGenerationUpdate(
         val conversationId: Uuid,

--- a/app/src/main/java/me/rerere/rikkahub/data/repository/WorkspaceRepository.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/repository/WorkspaceRepository.kt
@@ -279,12 +279,13 @@ class WorkspaceRepository(
         cwd: String = "",
         timeoutMillis: Long = WorkspaceManager.DEFAULT_COMMAND_TIMEOUT_MS,
         stdin: ByteArray? = null,
+        onOutput: ((kind: String, text: String) -> Unit)? = null,
     ): WorkspaceCommandResult {
         val workspace = dao.getById(id) ?: error("Workspace not found: $id")
         // runInterruptible 让协程取消转化为线程中断，从而打断阻塞的 Process.waitFor 并杀掉进程
         return runInterruptible(Dispatchers.IO) {
             manager.ensureWorkspace(workspace.root)
-            manager.executeCommand(workspace.root, command, cwd, timeoutMillis, stdin)
+            manager.executeCommand(workspace.root, command, cwd, timeoutMillis, stdin, onOutput)
         }
     }
 

--- a/app/src/main/java/me/rerere/rikkahub/di/ViewModelModule.kt
+++ b/app/src/main/java/me/rerere/rikkahub/di/ViewModelModule.kt
@@ -36,6 +36,7 @@ val viewModelModule = module {
             analytics = get(),
             filesManager = get(),
             favoriteRepository = get(),
+            appEventBus = get(),
         )
     }
     viewModelOf(::ChatDrawerVM)
@@ -71,7 +72,6 @@ val viewModelModule = module {
         WorkspaceDetailVM(
             id = it.get(),
             repository = get(),
-            terminalSessionManager = get(),
         )
     }
     viewModelOf(::FavoriteVM)

--- a/app/src/main/java/me/rerere/rikkahub/service/ChatService.kt
+++ b/app/src/main/java/me/rerere/rikkahub/service/ChatService.kt
@@ -536,7 +536,6 @@ class ChatService(
                     }
                 },
                 assistant = assistant,
-                conversationId = conversationId,
                 conversationSystemPrompt = conversation.customSystemPrompt,
                 conversationModeInjectionIds = conversation.modeInjectionIds,
                 conversationLorebookIds = conversation.lorebookIds,
@@ -560,7 +559,7 @@ class ChatService(
                     if (assistant.enableRecentChatsReference) {
                         addAll(createConversationTools(conversationRepo, assistant.id))
                     }
-                    addAll(createWorkspaceToolsIfReady(assistant.workspaceId?.toString(), conversation.workspaceCwd))
+                    addAll(createWorkspaceToolsIfReady(conversation.id, assistant.workspaceId?.toString(), conversation.workspaceCwd))
                     if (assistant.enabledSkills.isNotEmpty()) {
                         addAll(
                             createSkillTools(
@@ -657,7 +656,11 @@ class ChatService(
         }
     }
 
-    private suspend fun createWorkspaceToolsIfReady(workspaceId: String?, cwd: String? = null): List<Tool> {
+    private suspend fun createWorkspaceToolsIfReady(
+        conversationId: Uuid,
+        workspaceId: String?,
+        cwd: String? = null,
+    ): List<Tool> {
         if (workspaceId.isNullOrBlank()) return emptyList()
         val workspace = workspaceRepository.getById(workspaceId) ?: return emptyList()
         if (workspace.shellStatus != WorkspaceShellStatus.READY.name) {
@@ -667,7 +670,15 @@ class ChatService(
             )
             return emptyList()
         }
-        return createWorkspaceTools(workspaceId, workspaceRepository, cwd)
+        // 工具执行期间的 stdout/stderr 增量通过事件总线转发给 UI，用于渲染实时执行状态
+        return createWorkspaceTools(
+            workspaceId,
+            workspaceRepository,
+            cwd,
+            onOutput = { kind, chunk ->
+                appEventBus.tryEmit(AppEvent.ToolStreamOutput(conversationId, kind, chunk))
+            },
+        )
     }
 
     // ---- 检查无效消息 ----

--- a/app/src/main/java/me/rerere/rikkahub/ui/components/message/ChatMessage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/message/ChatMessage.kt
@@ -117,6 +117,8 @@ fun ChatMessage(
     onClearTranslation: (UIMessage) -> Unit = {},
     onToolApproval: ((toolCallId: String, approved: Boolean, reason: String) -> Unit)? = null,
     onToolAnswer: ((toolCallId: String, answer: String) -> Unit)? = null,
+    /** 当前会话 workspace_shell 的流式输出聚合, 用于渲染运行中工具的执行状态 */
+    streamingOutput: String? = null,
 ) {
     val message = node.messages[node.selectIndex]
     val settings = LocalSettings.current.displaySetting
@@ -169,6 +171,7 @@ fun ChatMessage(
                 onToolApproval = onToolApproval,
                 onToolAnswer = onToolAnswer,
                 onUserMessageClick = if (message.role == MessageRole.USER) onEdit else null,
+                streamingOutput = streamingOutput,
             )
 
             message.translation?.let { translation ->
@@ -273,6 +276,7 @@ private fun MessagePartsBlock(
     onToolApproval: ((toolCallId: String, approved: Boolean, reason: String) -> Unit)? = null,
     onToolAnswer: ((toolCallId: String, answer: String) -> Unit)? = null,
     onUserMessageClick: (() -> Unit)? = null,
+    streamingOutput: String? = null,
 ) {
     val context = LocalContext.current
     val contentColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.65f)
@@ -346,6 +350,7 @@ private fun MessagePartsBlock(
                                         loading = loading && !step.tool.isExecuted,
                                         onToolApproval = onToolApproval,
                                         onToolAnswer = onToolAnswer,
+                                        streamingOutput = streamingOutput,
                                     )
                                 }
                             }

--- a/app/src/main/java/me/rerere/rikkahub/ui/components/message/ChatMessageTools.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/message/ChatMessageTools.kt
@@ -96,6 +96,7 @@ fun ChainOfThoughtScope.ChatMessageToolStep(
     loading: Boolean = false,
     onToolApproval: ((toolCallId: String, approved: Boolean, reason: String) -> Unit)? = null,
     onToolAnswer: ((toolCallId: String, answer: String) -> Unit)? = null,
+    streamingOutput: String? = null,
 ) {
     // ask_user 是交互式问答流程, 不走注册式渲染框架
     if (tool.toolName == ASK_USER_TOOL_NAME) {
@@ -104,7 +105,7 @@ fun ChainOfThoughtScope.ChatMessageToolStep(
     }
 
     val renderer = remember(tool.toolName) { ToolUIRegistry.resolve(tool.toolName) }
-    val context = remember(tool, loading) {
+    val context = remember(tool, loading, streamingOutput) {
         ToolUIContext(
             tool = tool,
             arguments = tool.inputAsJson(),
@@ -118,6 +119,7 @@ fun ChainOfThoughtScope.ChatMessageToolStep(
                 null
             },
             loading = loading,
+            streamingOutput = streamingOutput,
         )
     }
 
@@ -129,7 +131,8 @@ fun ChainOfThoughtScope.ChatMessageToolStep(
     val images = tool.output.filterIsInstance<UIMessagePart.Image>()
 
     // 摘要由注册的渲染器决定; 图片输出与拒绝原因为所有工具通用
-    val hasExtraContent = renderer.hasSummary(context) || isDenied || images.isNotEmpty()
+    val hasStreaming = !streamingOutput.isNullOrEmpty()
+    val hasExtraContent = renderer.hasSummary(context) || isDenied || images.isNotEmpty() || hasStreaming
 
     ControlledChainOfThoughtStep(
         expanded = expanded,
@@ -188,7 +191,7 @@ fun ChainOfThoughtScope.ChatMessageToolStep(
         } else {
             null
         },
-        onClick = if (context.content != null || isPending || images.isNotEmpty()) {
+        onClick = if (context.content != null || isPending || images.isNotEmpty() || hasStreaming) {
             { showResult = true }
         } else {
             null

--- a/app/src/main/java/me/rerere/rikkahub/ui/components/message/tools/ToolUI.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/message/tools/ToolUI.kt
@@ -45,6 +45,8 @@ data class ToolUIContext(
     val content: JsonElement?,
     /** 该工具调用是否在生成中 */
     val loading: Boolean,
+    /** 工具执行期间流式输出的聚合文本 (stdout+stderr), 工具未执行/运行中时可为 null */
+    val streamingOutput: String? = null,
 )
 
 /**

--- a/app/src/main/java/me/rerere/rikkahub/ui/components/message/tools/WorkspaceToolUIs.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/message/tools/WorkspaceToolUIs.kt
@@ -302,20 +302,46 @@ object ShellToolUI : ToolUIRenderer {
         return stringResource(R.string.tool_ui_shell, truncated)
     }
 
-    override fun hasSummary(context: ToolUIContext): Boolean = context.content != null
+    override fun hasSummary(context: ToolUIContext): Boolean =
+        context.content != null || !context.streamingOutput.isNullOrEmpty()
 
     @Composable
     override fun Summary(context: ToolUIContext) {
-        val content = context.content ?: return
-        val combined = remember(content) {
-            listOf(content.getStringContent("stdout"), content.getStringContent("stderr"))
-                .filterNot { it.isNullOrBlank() }
-                .joinToString("\n")
-                .trim()
-        }
-        Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
-            ShellExitStatus(content, MaterialTheme.typography.labelSmall)
-            if (combined.isNotEmpty()) {
+        val content = context.content
+        if (content != null) {
+            // 已执行完: 退出状态 + 输出首部
+            val combined = remember(content) {
+                listOf(content.getStringContent("stdout"), content.getStringContent("stderr"))
+                    .filterNot { it.isNullOrBlank() }
+                    .joinToString("\n")
+                    .trim()
+            }
+            Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                ShellExitStatus(content, MaterialTheme.typography.labelSmall)
+                if (combined.isNotEmpty()) {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clip(MaterialTheme.shapes.small)
+                            .background(MaterialTheme.colorScheme.surfaceContainer)
+                            .padding(horizontal = 8.dp, vertical = 6.dp)
+                            .shimmer(isLoading = context.loading),
+                    ) {
+                        Text(
+                            text = combined.lineSequence().take(SUMMARY_MAX_LINES).joinToString("\n"),
+                            style = MaterialTheme.typography.labelSmall.copy(fontFamily = FontFamily.Monospace),
+                            fontSize = 11.sp,
+                            lineHeight = 14.sp,
+                            maxLines = SUMMARY_MAX_LINES,
+                            overflow = TextOverflow.Ellipsis,
+                        )
+                    }
+                }
+            }
+        } else {
+            // 运行中: 展示实时流式输出末尾 (类似终端尾部)
+            val streaming = context.streamingOutput.orEmpty()
+            if (streaming.isNotEmpty()) {
                 Box(
                     modifier = Modifier
                         .fillMaxWidth()
@@ -325,7 +351,7 @@ object ShellToolUI : ToolUIRenderer {
                         .shimmer(isLoading = context.loading),
                 ) {
                     Text(
-                        text = combined.lineSequence().take(SUMMARY_MAX_LINES).joinToString("\n"),
+                        text = streaming.lines().takeLast(SUMMARY_MAX_LINES).joinToString("\n"),
                         style = MaterialTheme.typography.labelSmall.copy(fontFamily = FontFamily.Monospace),
                         fontSize = 11.sp,
                         lineHeight = 14.sp,
@@ -341,7 +367,49 @@ object ShellToolUI : ToolUIRenderer {
     override fun Preview(context: ToolUIContext, onDismissRequest: () -> Unit) {
         val content = context.content
         if (content == null) {
-            DefaultToolPreview(context = context)
+            // 运行中: 若已有流式输出则展示实时终端视图, 否则显示通用占位
+            val streaming = context.streamingOutput.orEmpty()
+            if (streaming.isEmpty()) {
+                DefaultToolPreview(context = context)
+                return
+            }
+            val command = context.arguments.getStringContent("command").orEmpty()
+            val cwd = context.arguments.getStringContent("cwd")
+            Column(
+                modifier = Modifier
+                    .fillMaxHeight(0.8f)
+                    .padding(16.dp)
+                    .verticalScroll(rememberScrollState()),
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    Text(
+                        text = stringResource(R.string.tool_ui_shell_default),
+                        style = MaterialTheme.typography.titleMedium,
+                        modifier = Modifier.weight(1f),
+                    )
+                    Text(
+                        text = stringResource(R.string.tool_ui_shell_running),
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.primary,
+                    )
+                }
+                HighlightCodeBlock(
+                    code = if (cwd.isNullOrBlank()) command else "# cwd: $cwd\n$command",
+                    language = "bash",
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                Text(text = "stdout (live)", style = MaterialTheme.typography.labelMedium)
+                HighlightCodeBlock(
+                    code = streaming,
+                    language = "plaintext",
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            }
             return
         }
         val command = context.arguments.getStringContent("command").orEmpty()

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ChatList.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ChatList.kt
@@ -120,6 +120,7 @@ fun ChatList(
     settings: Settings,
     hazeState: HazeState,
     errors: List<ChatError> = emptyList(),
+    toolStreamOutput: String? = null,
     onDismissError: (Uuid) -> Unit = {},
     onClearAllErrors: () -> Unit = {},
     onRegenerate: (UIMessage) -> Unit = {},
@@ -162,6 +163,7 @@ fun ChatList(
                 settings = settings,
                 hazeState = hazeState,
                 errors = errors,
+                toolStreamOutput = toolStreamOutput,
                 onDismissError = onDismissError,
                 onClearAllErrors = onClearAllErrors,
                 onRegenerate = onRegenerate,
@@ -192,6 +194,7 @@ private fun ChatListNormal(
     settings: Settings,
     hazeState: HazeState,
     errors: List<ChatError>,
+    toolStreamOutput: String? = null,
     onDismissError: (Uuid) -> Unit,
     onClearAllErrors: () -> Unit,
     onRegenerate: (UIMessage) -> Unit,
@@ -334,6 +337,7 @@ private fun ChatListNormal(
                             model = node.currentMessage.modelId?.let(modelById::get),
                             assistant = assistant,
                             loading = loading && index == lastMessageIndex,
+                            streamingOutput = toolStreamOutput,
                             onRegenerate = {
                                 onRegenerate(node.currentMessage)
                             },

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ChatPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ChatPage.kt
@@ -285,6 +285,8 @@ private fun ChatPageContent(
     val hazeState = rememberHazeState()
     val assistant = setting.getCurrentAssistant()
     var showFilesSheet by remember { mutableStateOf(false) }
+    // workspace_shell 工具执行期间的实时流式输出
+    val toolStreamOutput by vm.toolStreamOutput.collectAsStateWithLifecycle()
 
     val completionProviders = remember(assistant.workspaceId, conversation.workspaceCwd, workspaceRepository) {
         assistant.workspaceId?.let { workspaceId ->
@@ -437,6 +439,7 @@ private fun ChatPageContent(
                 settings = setting,
                 hazeState = hazeState,
                 errors = errors,
+                toolStreamOutput = toolStreamOutput,
                 onDismissError = onDismissError,
                 onClearAllErrors = onClearAllErrors,
                 onRegenerate = {

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ChatVM.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/chat/ChatVM.kt
@@ -16,7 +16,12 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
@@ -31,6 +36,8 @@ import me.rerere.rikkahub.data.datastore.Settings
 import me.rerere.rikkahub.data.datastore.SettingsStore
 import me.rerere.rikkahub.data.datastore.getCurrentAssistant
 import me.rerere.rikkahub.data.datastore.getCurrentChatModel
+import me.rerere.rikkahub.data.event.AppEvent
+import me.rerere.rikkahub.data.event.AppEventBus
 import me.rerere.rikkahub.data.files.FilesManager
 import me.rerere.rikkahub.data.model.Assistant
 import me.rerere.rikkahub.data.model.Avatar
@@ -60,10 +67,18 @@ class ChatVM(
     private val analytics: FirebaseAnalytics,
     private val filesManager: FilesManager,
     private val favoriteRepository: FavoriteRepository,
+    private val appEventBus: AppEventBus,
 ) : ViewModel() {
     private val _conversationId: Uuid = Uuid.parse(id)
     val conversation: StateFlow<Conversation> = chatService.getConversationFlow(_conversationId)
     var chatListInitialized by mutableStateOf(false) // 聊天列表是否已经滚动到底部
+
+    /**
+     * 当前会话 workspace_shell 工具执行期间的流式输出聚合 (stdout+stderr 顺序拼接)。
+     * 由 [AppEvent.ToolStreamOutput] 驱动, 无运行中工具时清空为 null。
+     */
+    private val _toolStreamOutput = MutableStateFlow<String?>(null)
+    val toolStreamOutput: StateFlow<String?> = _toolStreamOutput.asStateFlow()
 
     // 聊天输入状态 - 保存在 ViewModel 中避免 TransactionTooLargeException
     val inputState = ChatInputState()
@@ -93,6 +108,30 @@ class ChatVM(
 
         // 记住对话ID, 方便下次启动恢复
         context.writeStringPreference("lastConversationId", _conversationId.toString())
+
+        // 聚合当前会话 workspace_shell 的流式输出 (stdout/stderr 顺序拼接)
+        viewModelScope.launch {
+            appEventBus.events
+                .filterIsInstance<AppEvent.ToolStreamOutput>()
+                .filter { it.conversationId == _conversationId }
+                .collect { ev ->
+                    _toolStreamOutput.value = (_toolStreamOutput.value ?: "") + ev.chunk
+                }
+        }
+        // 当会话中没有运行中的工具 (未执行且非待批准) 时, 清空流式输出缓存,
+        // 使下一次工具执行从头开始聚合
+        viewModelScope.launch {
+            conversation.collect { conv ->
+                val hasRunningTool = conv.currentMessages.any { msg ->
+                    msg.parts.any { part ->
+                        part is UIMessagePart.Tool && !part.isExecuted && !part.isPending
+                    }
+                }
+                if (!hasRunningTool) {
+                    _toolStreamOutput.value = null
+                }
+            }
+        }
     }
 
     override fun onCleared() {

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -1249,6 +1249,7 @@ mDNS 地址：使用 .local 主机名，同一网络中的其他设备可通过�
   <string name="tool_ui_shell_default">Shell</string>
   <string name="tool_ui_shell_timeout">timeout</string>
   <string name="tool_ui_shell_exit">exit %s</string>
+  <string name="tool_ui_shell_running">执行中…</string>
   <string name="tool_ui_speaking">朗读: %s</string>
   <string name="tool_ui_replay">重播</string>
   <string name="tool_ui_delete_memory">删除记忆</string>
@@ -1306,10 +1307,5 @@ mDNS 地址：使用 .local 主机名，同一网络中的其他设备可通过�
   <string name="setting_page_preferences_network_proxy">代理</string>
   <string name="setting_page_preferences_network_proxy_desc">支持 HTTP 和 SOCKS5 代理 URL。留空以使用系统设置。</string>
   <string name="setting_page_preferences_network_proxy_invalid">请输入包含主机和端口的有效代理 URL。</string>
-  <string name="setting_provider_page_test_non_streaming">非流式</string>
-  <string name="setting_provider_page_test_streaming">流式</string>
-  <string name="setting_provider_page_test_tool_call">工具调用</string>
-  <string name="setting_provider_page_test_tool_called">已调用: %1$s  参数: %2$s</string>
-  <string name="setting_provider_page_test_tool_not_called">未调用工具，响应：%s</string>
 </resources>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1225,10 +1225,6 @@
   <string name="workspace_terminal_not_installed">Please install Rootfs first</string>
   <string name="workspace_terminal_loading">Loading workspace…</string>
   <string name="workspace_terminal_exited">Terminal exited</string>
-  <string name="workspace_terminal_tab">Terminal %1$d</string>
-  <string name="workspace_terminal_new_tab">New terminal tab</string>
-  <string name="workspace_terminal_close_tab">Close terminal %1$d</string>
-  <string name="workspace_terminal_no_tabs">No open terminal tabs</string>
   <string name="extensions_page_workspace">Workspace</string>
   <string name="extensions_page_workspace_desc">Manage local working directories accessible by Agent</string>
   <string name="workspace_select">Select Workspace</string>
@@ -1268,6 +1264,7 @@
   <string name="tool_ui_shell_default">Shell</string>
   <string name="tool_ui_shell_timeout">timeout</string>
   <string name="tool_ui_shell_exit">exit %s</string>
+  <string name="tool_ui_shell_running">running…</string>
   <string name="tool_ui_speaking">Speaking: %s</string>
   <string name="tool_ui_replay">Replay</string>
   <string name="tool_ui_delete_memory">Delete memory</string>
@@ -1312,10 +1309,5 @@
   <string name="setting_update_reminder_pause_days">%1$d days</string>
   <string name="setting_update_reminder_resume_now">Resume now</string>
   <string name="backup_page_import_overwrite_confirm">Importing a backup will overwrite app data. Continue?</string>
-  <string name="setting_provider_page_test_non_streaming">Non-streaming</string>
-  <string name="setting_provider_page_test_streaming">Streaming</string>
-  <string name="setting_provider_page_test_tool_call">Tool Call</string>
-  <string name="setting_provider_page_test_tool_called">Called: %1$s  Args: %2$s</string>
-  <string name="setting_provider_page_test_tool_not_called">Tool not called, response: %s</string>
 </resources>
 

--- a/workspace/src/main/java/me/rerere/workspace/ProotShellRunner.kt
+++ b/workspace/src/main/java/me/rerere/workspace/ProotShellRunner.kt
@@ -53,7 +53,7 @@ class ProotShellRunner(
             }
             .start()
 
-        return process.readResult(context.timeoutMillis, context.stdin)
+        return process.readResult(context.timeoutMillis, context.stdin, context.onOutput)
     }
 
     private fun buildCommand(

--- a/workspace/src/main/java/me/rerere/workspace/WorkspaceManager.kt
+++ b/workspace/src/main/java/me/rerere/workspace/WorkspaceManager.kt
@@ -183,6 +183,7 @@ class WorkspaceManager(
         cwd: String = "",
         timeoutMillis: Long = DEFAULT_COMMAND_TIMEOUT_MS,
         stdin: ByteArray? = null,
+        onOutput: ((kind: String, text: String) -> Unit)? = null,
     ): WorkspaceCommandResult {
         require(command.isNotBlank()) { "Command is required" }
         val workingDir = fileSystem.resolve(filesDir(root), cwd)
@@ -201,6 +202,7 @@ class WorkspaceManager(
                 timeoutMillis = timeoutMillis,
                 stdin = stdin,
                 bindMounts = bindMounts,
+                onOutput = onOutput,
             )
         )
     }

--- a/workspace/src/main/java/me/rerere/workspace/WorkspaceShellRunner.kt
+++ b/workspace/src/main/java/me/rerere/workspace/WorkspaceShellRunner.kt
@@ -20,6 +20,8 @@ data class WorkspaceShellContext(
     val timeoutMillis: Long,
     val stdin: ByteArray? = null,
     val bindMounts: List<WorkspaceBindMount> = emptyList(),
+    /** 流式输出回调: kind 为 "stdout" / "stderr", 按读取块增量回调 (调用线程为采集线程, 需自行同步) */
+    val onOutput: ((kind: String, text: String) -> Unit)? = null,
 )
 
 class HostShellRunner : WorkspaceShellRunner {
@@ -28,7 +30,7 @@ class HostShellRunner : WorkspaceShellRunner {
             .directory(context.workingDir)
             .redirectErrorStream(false)
             .start()
-        return process.readResult(context.timeoutMillis, context.stdin)
+        return process.readResult(context.timeoutMillis, context.stdin, context.onOutput)
     }
 
     private fun defaultShell(): String =
@@ -38,9 +40,13 @@ class HostShellRunner : WorkspaceShellRunner {
 // 单个流保留的最大字符数, 防止命令疯狂输出导致 OOM 或撑爆 LLM 上下文
 const val MAX_OUTPUT_CHARS = 128 * 1024
 
-fun Process.readResult(timeoutMillis: Long, stdin: ByteArray? = null): WorkspaceCommandResult {
-    val stdout = StreamCollector(inputStream)
-    val stderr = StreamCollector(errorStream)
+fun Process.readResult(
+    timeoutMillis: Long,
+    stdin: ByteArray? = null,
+    onOutput: ((kind: String, text: String) -> Unit)? = null,
+): WorkspaceCommandResult {
+    val stdout = StreamCollector(inputStream, onChunk = onOutput?.let { cb -> { cb("stdout", it) } })
+    val stderr = StreamCollector(errorStream, onChunk = onOutput?.let { cb -> { cb("stderr", it) } })
     val stdinWriter = stdin?.let { bytes -> StreamWriter(outputStream, bytes) }
     try {
         val finished = waitFor(timeoutMillis, TimeUnit.MILLISECONDS)
@@ -92,6 +98,7 @@ private class StreamWriter(
 private class StreamCollector(
     stream: InputStream,
     private val maxChars: Int = MAX_OUTPUT_CHARS,
+    private val onChunk: ((String) -> Unit)? = null,
 ) {
     private val builder = StringBuilder()
 
@@ -106,6 +113,9 @@ private class StreamCollector(
                 while (true) {
                     val read = reader.read(buffer)
                     if (read < 0) break
+                    if (read > 0) {
+                        onChunk?.invoke(String(buffer, 0, read))
+                    }
                     // 超出上限后继续读到 EOF 并丢弃，否则管道写满会阻塞子进程导致其无法退出
                     synchronized(builder) {
                         val remaining = maxChars - builder.length


### PR DESCRIPTION
## 问题描述

`workspace_shell` 工具是**一次性同步执行**的:命令运行期间,聊天里的工具卡片只有标题 + 加载动画,**无法展开、看不到执行状态**(无实时输出),必须等命令跑完才有结果可看。

## 改动内容

打通 **执行层 → 工具层 → 事件总线 → UI** 的流式链路,共 18 个文件:

**执行层(workspace 模块)**
- `WorkspaceShellContext` 新增 `onOutput` 回调,`StreamCollector` 采集线程按读取块(4KB)增量回调 stdout/stderr
- `ProotShellRunner` / `HostShellRunner` / `WorkspaceManager` 透传

**工具层**
- `createWorkspaceTools` / `createShellTool` 透传 `onOutput` 到 `executeCommand`

**事件层**
- 新增 `AppEvent.ToolStreamOutput(conversationId, kind, chunk)`
- `ChatService` 创建 workspace 工具时注入转发(按会话)

**UI 层**
- `ChatVM` 订阅事件聚合当前会话流式输出,所有工具执行完自动清空
- `ToolUIContext` 新增 `streamingOutput` 字段
- `ShellToolUI` 运行中:**摘要区显示实时输出尾部**,展开显示**实时终端视图**(命令 + live stdout)
- 运行中卡片可点击展开(此前 `onClick` 为 null 点不动)

## 验证

- ✅ `:workspace:compileDebugKotlin` 编译通过
- ✅ `:app:compileDebugKotlin` 编译通过(需子模块 `material3/material-color-utilities` 初始化)

## 效果

命令执行时即可展开看到实时输出(类似终端滚动),执行结束自动切换为最终结果(exit code + stdout/stderr)。
