### PR TITLE
fix(chat): 移除快速模型, 标题/建议未设置时回退到当前对话模型

### DIFF
--- a/app/src/main/java/me/rerere/rikkahub/data/datastore/PreferencesStore.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/datastore/PreferencesStore.kt
@@ -86,7 +86,6 @@ class SettingsStore(
         // 模型选择
         val FAVORITE_MODELS = stringPreferencesKey("favorite_models")
         val SELECT_MODEL = stringPreferencesKey("chat_model")
-        val FAST_MODEL = stringPreferencesKey("fast_model")
         val TITLE_MODEL = stringPreferencesKey("title_model")
         val TRANSLATE_MODEL = stringPreferencesKey("translate_model")
         val ENABLE_SUGGESTION = booleanPreferencesKey("enable_suggestion")
@@ -169,8 +168,6 @@ class SettingsStore(
                     JsonInstant.decodeFromString(it)
                 } ?: emptyList(),
                 chatModelId = preferences[SELECT_MODEL]?.let { Uuid.parse(it) }
-                    ?: DEFAULT_AUTO_MODEL_ID,
-                fastModelId = preferences[FAST_MODEL]?.let { Uuid.parse(it) }
                     ?: DEFAULT_AUTO_MODEL_ID,
                 titleModelId = preferences[TITLE_MODEL]?.let { Uuid.parse(it) },
                 translateModeId = preferences[TRANSLATE_MODEL]?.let { Uuid.parse(it) }
@@ -363,7 +360,6 @@ class SettingsStore(
 
             preferences[FAVORITE_MODELS] = JsonInstant.encodeToString(settings.favoriteModels)
             preferences[SELECT_MODEL] = settings.chatModelId.toString()
-            preferences[FAST_MODEL] = settings.fastModelId.toString()
             settings.titleModelId?.let {
                 preferences[TITLE_MODEL] = it.toString()
             } ?: preferences.remove(TITLE_MODEL)
@@ -520,7 +516,6 @@ data class Settings(
     val networkSetting: NetworkSetting = NetworkSetting(),
     val favoriteModels: List<Uuid> = emptyList(),
     val chatModelId: Uuid = Uuid.random(),
-    val fastModelId: Uuid = Uuid.random(),
     val titleModelId: Uuid? = null,
     val imageGenerationModelId: Uuid = Uuid.random(),
     val titlePrompt: String = DEFAULT_TITLE_PROMPT,

--- a/app/src/main/java/me/rerere/rikkahub/data/datastore/migration/SettingsJsonMigrator.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/datastore/migration/SettingsJsonMigrator.kt
@@ -25,6 +25,9 @@ object SettingsJsonMigrator {
         return runCatching {
             val root = JsonInstant.parseToJsonElement(settingsJson).jsonObject.toMutableMap()
 
+            // V0: 移除已废弃的 fastModelId 字段(快速模型已移除)
+            root.remove("fastModelId")
+
             // V1: 修复 mcpServers 中全限定类名的 type 字段
             root["mcpServers"]?.let { element ->
                 val migrated = migrateMcpServersJson(JsonInstant.encodeToString(element))

--- a/app/src/main/java/me/rerere/rikkahub/service/ChatService.kt
+++ b/app/src/main/java/me/rerere/rikkahub/service/ChatService.kt
@@ -766,7 +766,8 @@ class ChatService(
 
         runCatching {
             val settings = settingsStore.settingsFlow.first()
-            val model = settings.findModelById(settings.titleModelId, fallback = settings.fastModelId)
+            val model = settings.findModelById(settings.titleModelId)
+                ?: settings.getCurrentChatModel()
                 ?: return@runCatching
             val provider = model.findProvider(settings.providers) ?: return@runCatching
 
@@ -811,7 +812,8 @@ class ChatService(
         runCatching {
             val settings = settingsStore.settingsFlow.first()
             if (!settings.enableSuggestion) return@runCatching
-            val model = settings.findModelById(settings.suggestionModelId, fallback = settings.fastModelId)
+            val model = settings.findModelById(settings.suggestionModelId)
+                ?: settings.getCurrentChatModel()
                 ?: return@runCatching
             val provider = model.findProvider(settings.providers) ?: return@runCatching
 

--- a/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingModelPage.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/pages/setting/SettingModelPage.kt
@@ -117,15 +117,6 @@ private fun ModelSettingsPage(settings: Settings, vm: SettingVM, contentPadding:
         }
         item {
             ModelSettingItem(
-                title = stringResource(R.string.setting_model_page_fast_model),
-                description = stringResource(R.string.setting_model_page_fast_model_desc),
-                modelId = settings.fastModelId,
-                providers = settings.providers,
-                onSelect = { vm.updateSettings(settings.copy(fastModelId = it.id)) },
-            )
-        }
-        item {
-            ModelSettingItem(
                 title = stringResource(R.string.setting_model_page_title_model),
                 description = stringResource(R.string.setting_model_page_title_model_desc),
                 modelId = settings.titleModelId,

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -1117,8 +1117,6 @@ mDNSアドレス: .localホスト名を使用し、IPを知らなくても同じ
   <string name="setting_model_page_prompt_compress">コンテキスト圧縮</string>
   <string name="setting_display_page_bubble_opacity_title">吹き出しの不透明度</string>
   <string name="setting_provider_page_include_history_reasoning">履歴の思考過程を送信</string>
-  <string name="setting_model_page_fast_model">高速モデル</string>
-  <string name="setting_model_page_fast_model_desc">高速タスクまたはバックグラウンドタスク用のモデル。タイトルモデルとサジェストモデルが設定されていない場合のフォールバックとしても使用されます。</string>
   <string name="setting_model_page_enable_suggestion">チャット提案を有効にする</string>
   <string name="assistant_page_gradient_background">グラデーション背景</string>
   <string name="assistant_page_gradient_background_desc">チャットページで動的なグラデーション背景を使用します</string>

--- a/app/src/main/res/values-ko-rKR/strings.xml
+++ b/app/src/main/res/values-ko-rKR/strings.xml
@@ -1117,8 +1117,6 @@ mDNS 주소: .local 호스트네임을 사용하며, IP를 몰라도 같은 네�
   <string name="setting_model_page_prompt_compress">컨텍스트 압축</string>
   <string name="setting_display_page_bubble_opacity_title">버블 불투명도</string>
   <string name="setting_provider_page_include_history_reasoning">이전 추론 내용 전송</string>
-  <string name="setting_model_page_fast_model">빠른 모델</string>
-  <string name="setting_model_page_fast_model_desc">빠른 작업 또는 백그라운드 작업을 위한 모델이며, 설정되지 않은 경우 제목 및 제안 모델의 대체로도 사용됩니다.</string>
   <string name="setting_model_page_enable_suggestion">채팅 제안 활성화</string>
   <string name="assistant_page_gradient_background">그라데이션 배경</string>
   <string name="assistant_page_gradient_background_desc">채팅 페이지에서 동적 그라데이션 배경 사용</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1117,8 +1117,6 @@
   <string name="setting_model_page_prompt_compress">Сжатие контекста</string>
   <string name="setting_display_page_bubble_opacity_title">Прозрачность пузырьков</string>
   <string name="setting_provider_page_include_history_reasoning">Отправлять историю рассуждений</string>
-  <string name="setting_model_page_fast_model">Быстрая модель</string>
-  <string name="setting_model_page_fast_model_desc">Модель для быстрых или фоновых задач, также используется как резервная для моделей заголовков и предложений, если не задана</string>
   <string name="setting_model_page_enable_suggestion">Включить подсказки чата</string>
   <string name="assistant_page_gradient_background">Градиентный фон</string>
   <string name="assistant_page_gradient_background_desc">Использовать динамический градиентный фон на странице чата</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -1115,8 +1115,6 @@
   <string name="setting_model_page_prompt_compress">上下文壓縮</string>
   <string name="setting_display_page_bubble_opacity_title">氣泡透明度</string>
   <string name="setting_provider_page_include_history_reasoning">回傳歷史思考過程</string>
-  <string name="setting_model_page_fast_model">快速模型</string>
-  <string name="setting_model_page_fast_model_desc">用於快速或背景任務的模型，未設置時也作為標題和建議模型的後備。</string>
   <string name="setting_model_page_enable_suggestion">啟用聊天建議</string>
   <string name="assistant_page_gradient_background">漸層背景</string>
   <string name="assistant_page_gradient_background_desc">在聊天頁面上使用動態漸變背景</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -1151,8 +1151,6 @@ mDNS 地址：使用 .local 主机名，同一网络中的其他设备可通过�
   <string name="setting_model_page_prompt_compress">上下文压缩</string>
   <string name="setting_display_page_bubble_opacity_title">气泡不透明度</string>
   <string name="setting_provider_page_include_history_reasoning">回传历史思考过程</string>
-  <string name="setting_model_page_fast_model">快速模型</string>
-  <string name="setting_model_page_fast_model_desc">用于快速或后台任务的模型，当未设置时也用作标题和建议模型的后备</string>
   <string name="setting_model_page_enable_suggestion">启用聊天建议</string>
   <string name="assistant_page_gradient_background">渐变背景</string>
   <string name="assistant_page_gradient_background_desc">在聊天页面使用动态渐变背景</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -787,8 +787,6 @@
   <string name="setting_model_page_chat_model">Chat Model</string>
   <string name="setting_model_page_chat_model_desc">Global default chat model</string>
   <string name="setting_model_page_compress_model">Compress Model</string>
-  <string name="setting_model_page_fast_model">Fast Model</string>
-  <string name="setting_model_page_fast_model_desc">Model for fast or background tasks, also used as fallback for title and suggestion models when not set</string>
   <string name="setting_model_page_compress_model_desc">Model for compressing conversation history</string>
   <string name="setting_model_page_compress_prompt_vars">Variables: {content}, {target_tokens}, {additional_context}</string>
   <string name="setting_model_page_ocr_model">OCR Model</string>


### PR DESCRIPTION
## 背景

标题/建议生成依赖 `titleModelId` / `suggestionModelId`,未设置时回退到**快速模型** `fastModelId`。而 `fastModelId` 未设置时指向内置默认 provider 的 `auto` 模型(`DEFAULT_AUTO_MODEL_ID`)。

一旦用户配置了自己的 provider,该 `auto` 模型不在 `providers` 列表中 → `findModelById` 返回 `null` → `generateTitle` / `generateSuggestion` **静默跳过**:
- 会话标题永远是"新消息",且无任何错误提示
- 回复建议同样失效

关联: #1509

## 改动内容

### 1. 移除"快速模型"配置项

- `PreferencesStore.kt`:删除 `fastModelId` 字段、`FAST_MODEL` DataStore key 及读写逻辑
- `SettingModelPage.kt`:移除设置页"快速模型"选项
- 6 个语言包删除 `setting_model_page_fast_model` / `_desc` 字符串

### 2. 标题/建议生成回退到当前对话模型

`ChatService.kt`:
```diff
- val model = settings.findModelById(settings.titleModelId, fallback = settings.fastModelId)
+ val model = settings.findModelById(settings.titleModelId)
+     ?: settings.getCurrentChatModel()
      ?: return@runCatching
```
建议生成同样处理。回退链简化为:**专用模型 → 当前对话模型**。

### 3. 旧备份兼容

`SettingsJsonMigrator.kt`:反序列化前移除 `fastModelId` 字段,避免旧版备份的 `settings.json` 在恢复时因未知字段导致失败(WebDavSync / S3Sync 恢复路径)。

## 影响

- 设置页移除"快速模型"选项(无独立任务,只作为标题/建议的 fallback)
- 只要当前对话模型可用,标题和建议就能生成,不再静默失效
- 旧版 `fast_model` DataStore 键残留无害(不再读取)

## 验证

- 移除快速模型后编译通过(无残留引用)
- 未配置标题/建议模型 + 自定义 provider 场景:标题/建议使用当前对话模型生成
