### PR TITLE
Preserve Exa freshness evidence in web search

### DIFF
--- a/app/src/main/java/me/rerere/rikkahub/data/ai/tools/SearchTools.kt
+++ b/app/src/main/java/me/rerere/rikkahub/data/ai/tools/SearchTools.kt
@@ -14,6 +14,7 @@ import me.rerere.rikkahub.utils.toLocalString
 import me.rerere.search.SearchService
 import me.rerere.search.SearchServiceOptions
 import java.time.LocalDate
+import kotlin.time.Clock
 import kotlin.uuid.Uuid
 
 fun createSearchTools(settings: Settings): Set<Tool> {
@@ -24,11 +25,17 @@ fun createSearchTools(settings: Settings): Set<Tool> {
                 description = """
                     Search the web for up-to-date or specific information.
                     Use this when the user asks for the latest news, current facts, or needs verification.
+                    Do not treat result order as proof of freshness. Prefer primary sources and inspect
+                    each result's title, URL, publication date, and content before making a current claim.
+                    Use the optional publication-date and domain filters only when they match the question.
+                    If a date or primary source is missing, or sources conflict, run another focused search
+                    or use scrape_web to verify the most relevant source before answering.
                     Generate focused keywords and run multiple searches if needed.
                     Today is ${LocalDate.now().toLocalString(true)}.
 
                     Response format:
-                    - items[].id (short id), title, url, text
+                    - retrievedAt is the local retrieval time, never a publication date
+                    - items[].id (short id), index, title, url, publishedDate (if supplied), highlights (if supplied), text
                     - images[]: image urls related to the query (may be empty)
 
                     Citations:
@@ -61,9 +68,9 @@ fun createSearchTools(settings: Settings): Set<Tool> {
                         params = it.jsonObject,
                         commonOptions = settings.searchCommonOptions,
                         serviceOptions = options,
-                    )
+                    ).getOrThrow().copy(retrievedAt = Clock.System.now().toString())
                     val results =
-                        JsonInstantPretty.encodeToJsonElement(result.getOrThrow()).jsonObject.let { json ->
+                        JsonInstantPretty.encodeToJsonElement(result).jsonObject.let { json ->
                             val map = json.toMutableMap()
                             map["items"] =
                                 JsonArray(map["items"]!!.jsonArray.mapIndexed { index, item ->
@@ -89,7 +96,8 @@ fun createSearchTools(settings: Settings): Set<Tool> {
                     name = "scrape_web",
                     description = """
                         Scrape a URL for detailed page content.
-                        Use this when the user requests content from a specific page or when search snippets are insufficient.
+                        Use this when the user requests content from a specific page, when search snippets are insufficient,
+                        or when a current claim needs verification against a specific source.
                         Avoid using it for common questions unless the user asks.
                         """.trimIndent(),
                     parameters = {
@@ -108,8 +116,8 @@ fun createSearchTools(settings: Settings): Set<Tool> {
                             params = it.jsonObject,
                             commonOptions = settings.searchCommonOptions,
                             serviceOptions = options,
-                        )
-                        val payload = JsonInstantPretty.encodeToJsonElement(result.getOrThrow()).jsonObject
+                        ).getOrThrow().copy(retrievedAt = Clock.System.now().toString())
+                        val payload = JsonInstantPretty.encodeToJsonElement(result).jsonObject
                         listOf(UIMessagePart.Text(payload.toString()))
                     }
                 ))

--- a/app/src/main/java/me/rerere/rikkahub/ui/components/message/tools/BuiltinToolUIs.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/message/tools/BuiltinToolUIs.kt
@@ -3,6 +3,7 @@ package me.rerere.rikkahub.ui.components.message.tools
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -22,7 +23,9 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -73,7 +76,9 @@ import me.rerere.rikkahub.ui.modifier.shimmer
 import me.rerere.rikkahub.utils.JsonInstantPretty
 import me.rerere.rikkahub.utils.jsonPrimitiveOrNull
 import me.rerere.rikkahub.utils.openUrl
+import me.rerere.rikkahub.utils.toLocalString
 import org.koin.compose.koinInject
+import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.OffsetDateTime
 import java.time.ZonedDateTime
@@ -674,6 +679,7 @@ private fun SearchWebPreview(
     val items = content.jsonObject["items"]?.jsonArray ?: emptyList()
     val answer = content.getStringContent("answer")
     val query = arguments.getStringContent("query") ?: ""
+    val parameters = arguments.jsonObjectOrNull?.entries?.filter { it.key != "query" }.orEmpty()
     val images = content.jsonObject["images"]?.jsonArray
         ?.mapNotNull { it.jsonPrimitive.contentOrNull }
         ?.filter { it.isNotBlank() }
@@ -687,6 +693,35 @@ private fun SearchWebPreview(
     ) {
         item {
             Text(stringResource(R.string.chat_message_tool_search_prefix, query))
+        }
+
+        if (parameters.isNotEmpty()) {
+            item {
+                FlowRow(
+                    horizontalArrangement = Arrangement.spacedBy(6.dp),
+                    verticalArrangement = Arrangement.spacedBy(6.dp),
+                ) {
+                    parameters.forEach { (name, value) ->
+                        val displayValue = when (value) {
+                            is JsonArray -> value.joinToString(", ") {
+                                it.jsonPrimitiveOrNull?.contentOrNull ?: it.toString()
+                            }
+                            else -> value.jsonPrimitiveOrNull?.contentOrNull ?: value.toString()
+                        }
+                        Surface(
+                            shape = RoundedCornerShape(8.dp),
+                            color = MaterialTheme.colorScheme.surfaceContainerHigh,
+                            contentColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                        ) {
+                            Text(
+                                text = "$name: $displayValue",
+                                modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+                                style = MaterialTheme.typography.labelSmall,
+                            )
+                        }
+                    }
+                }
+            }
         }
 
         if (answer != null) {
@@ -734,6 +769,16 @@ private fun SearchWebPreview(
                 val url = item.getStringContent("url") ?: return@items
                 val title = item.getStringContent("title") ?: return@items
                 val text = item.getStringContent("text") ?: return@items
+                val publishedDate = item.getStringContent("publishedDate")?.takeIf { it.isNotBlank() }
+                val dateLabel = remember(publishedDate) {
+                    publishedDate?.let { value ->
+                        runCatching {
+                            LocalDate.parse(value, DateTimeFormatter.ISO_DATE_TIME)
+                        }.recoverCatching {
+                            LocalDate.parse(value, DateTimeFormatter.ISO_DATE)
+                        }.getOrNull()?.toLocalString(includeYear = true) ?: value
+                    }
+                }
 
                 Card(
                     onClick = { context.openUrl(url) },
@@ -754,6 +799,15 @@ private fun SearchWebPreview(
                         )
                         Column {
                             Text(text = title, maxLines = 1)
+                            if (dateLabel != null) {
+                                Text(
+                                    text = dateLabel,
+                                    maxLines = 1,
+                                    overflow = TextOverflow.Ellipsis,
+                                    style = MaterialTheme.typography.labelSmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                )
+                            }
                             Text(
                                 text = text,
                                 maxLines = 2,

--- a/app/src/test/java/me/rerere/rikkahub/data/ai/tools/SearchToolsTest.kt
+++ b/app/src/test/java/me/rerere/rikkahub/data/ai/tools/SearchToolsTest.kt
@@ -1,0 +1,40 @@
+package me.rerere.rikkahub.data.ai.tools
+
+import me.rerere.ai.core.InputSchema
+import me.rerere.rikkahub.data.datastore.Settings
+import me.rerere.search.SearchServiceOptions
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SearchToolsTest {
+    @Test
+    fun `exa search tool exposes optional evidence parameters`() {
+        val settings = Settings(
+            searchServices = listOf(SearchServiceOptions.ExaOptions()),
+            searchServiceSelected = 0,
+        )
+        val searchTool = createSearchTools(settings).single { it.name == "search_web" }
+        val schema = searchTool.parameters() as InputSchema.Obj
+
+        assertEquals(listOf("query"), schema.required)
+        assertTrue(schema.properties.containsKey("startPublishedDate"))
+        assertTrue(schema.properties.containsKey("endPublishedDate"))
+        assertTrue(schema.properties.containsKey("includeDomains"))
+        assertTrue(schema.properties.containsKey("excludeDomains"))
+        assertTrue(schema.properties.containsKey("maxAgeHours"))
+    }
+
+    @Test
+    fun `exa scrape tool keeps url required and freshness optional`() {
+        val settings = Settings(
+            searchServices = listOf(SearchServiceOptions.ExaOptions()),
+            searchServiceSelected = 0,
+        )
+        val scrapeTool = createSearchTools(settings).single { it.name == "scrape_web" }
+        val schema = scrapeTool.parameters() as InputSchema.Obj
+
+        assertEquals(listOf("url"), schema.required)
+        assertTrue(schema.properties.containsKey("maxAgeHours"))
+    }
+}

--- a/docs/references/chat-generation-pipeline.md
+++ b/docs/references/chat-generation-pipeline.md
@@ -177,29 +177,6 @@ Pending ──── 用户操作 ────► Approved → 执行工具
 
 ---
 
-### Current-Info Evidence（Phase 1）
-
-`search_web` 仍然是由模型决定是否调用的普通客户端工具；Phase 1 不引入强制搜索、第二次工具调用或 Search Agent。
-
-Exa 结果在传递给模型前保留以下证据字段：
-
-- `title`、`url`、`index` 和 citation `id`
-- Provider 提供的 `publishedDate`（缺失时不生成）
-- Provider 提供的 `highlights`（缺失时为空）
-- 工具输出级别的 `retrievedAt`，表示本地实际获取时间，不表示发布时间
-
-在 `search_web` 参数中，以下字段是可选的：
-
-- `startPublishedDate` / `endPublishedDate`
-- `includeDomains` / `excludeDomains`
-- `maxAgeHours`，用于 Exa Contents 的内容新鲜度
-
-设置 Evidence 参数时，Exa 会请求有界的文本和 highlights，避免把无界网页全文直接放入模型上下文。没有这些可选参数的普通搜索保留原有请求形状，以保持兼容性。
-
-这些字段和描述帮助模型核对来源，但不保证模型一定调用工具，也不把搜索结果顺序当作新鲜度证明。应用级 Current-Info 强制路径属于后续阶段。
-
----
-
 ## 阶段五：会话生命周期管理
 
 `ConversationSession` 使用**原子引用计数**管理内存生命周期：

--- a/docs/references/chat-generation-pipeline.md
+++ b/docs/references/chat-generation-pipeline.md
@@ -177,6 +177,29 @@ Pending ──── 用户操作 ────► Approved → 执行工具
 
 ---
 
+### Current-Info Evidence（Phase 1）
+
+`search_web` 仍然是由模型决定是否调用的普通客户端工具；Phase 1 不引入强制搜索、第二次工具调用或 Search Agent。
+
+Exa 结果在传递给模型前保留以下证据字段：
+
+- `title`、`url`、`index` 和 citation `id`
+- Provider 提供的 `publishedDate`（缺失时不生成）
+- Provider 提供的 `highlights`（缺失时为空）
+- 工具输出级别的 `retrievedAt`，表示本地实际获取时间，不表示发布时间
+
+在 `search_web` 参数中，以下字段是可选的：
+
+- `startPublishedDate` / `endPublishedDate`
+- `includeDomains` / `excludeDomains`
+- `maxAgeHours`，用于 Exa Contents 的内容新鲜度
+
+设置 Evidence 参数时，Exa 会请求有界的文本和 highlights，避免把无界网页全文直接放入模型上下文。没有这些可选参数的普通搜索保留原有请求形状，以保持兼容性。
+
+这些字段和描述帮助模型核对来源，但不保证模型一定调用工具，也不把搜索结果顺序当作新鲜度证明。应用级 Current-Info 强制路径属于后续阶段。
+
+---
+
 ## 阶段五：会话生命周期管理
 
 `ConversationSession` 使用**原子引用计数**管理内存生命周期：

--- a/search/src/main/java/me/rerere/search/ExaSearchService.kt
+++ b/search/src/main/java/me/rerere/search/ExaSearchService.kt
@@ -15,6 +15,7 @@ import kotlinx.serialization.json.add
 import kotlinx.serialization.json.buildJsonArray
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.intOrNull
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.put
@@ -30,6 +31,8 @@ import okhttp3.RequestBody.Companion.toRequestBody
 object ExaSearchService : SearchService<SearchServiceOptions.ExaOptions> {
     private const val MAX_EVIDENCE_TEXT_CHARACTERS = 8_000
     private const val MAX_EVIDENCE_HIGHLIGHT_CHARACTERS = 1_200
+    private const val MIN_MAX_AGE_HOURS = -1
+    private const val MAX_MAX_AGE_HOURS = 720
 
     override val name: String = "Exa"
 
@@ -74,6 +77,8 @@ object ExaSearchService : SearchService<SearchServiceOptions.ExaOptions> {
                 put("maxAgeHours", buildJsonObject {
                     put("type", "integer")
                     put("description", "Optional maximum age in hours for fetched page content; use only when content freshness matters")
+                    put("minimum", MIN_MAX_AGE_HOURS)
+                    put("maximum", MAX_MAX_AGE_HOURS)
                 })
             },
             required = listOf("query")
@@ -89,6 +94,8 @@ object ExaSearchService : SearchService<SearchServiceOptions.ExaOptions> {
                 put("maxAgeHours", buildJsonObject {
                     put("type", "integer")
                     put("description", "Optional maximum age in hours for fetched page content")
+                    put("minimum", MIN_MAX_AGE_HOURS)
+                    put("maximum", MAX_MAX_AGE_HOURS)
                 })
             },
             required = listOf("url")
@@ -227,13 +234,12 @@ object ExaSearchService : SearchService<SearchServiceOptions.ExaOptions> {
         resultSize: Int,
     ) = buildJsonObject {
         val query = params["query"]?.jsonPrimitive?.content ?: error("query is required")
-        val hasEvidenceOptions = listOf(
-            "startPublishedDate",
-            "endPublishedDate",
-            "includeDomains",
-            "excludeDomains",
-            "maxAgeHours",
-        ).any(params::containsKey)
+        val maxAgeHours = optionalMaxAgeHours(params)
+        val hasEvidenceOptions = hasOptionalString(params, "startPublishedDate") ||
+            hasOptionalString(params, "endPublishedDate") ||
+            hasOptionalStringArray(params, "includeDomains") ||
+            hasOptionalStringArray(params, "excludeDomains") ||
+            maxAgeHours != null
 
         put("query", JsonPrimitive(query))
         put("numResults", JsonPrimitive(resultSize))
@@ -253,7 +259,7 @@ object ExaSearchService : SearchService<SearchServiceOptions.ExaOptions> {
             } else {
                 put("text", JsonPrimitive(true))
             }
-            params["maxAgeHours"]?.let { put("maxAgeHours", it) }
+            maxAgeHours?.let { put("maxAgeHours", it) }
         })
     }
 
@@ -265,7 +271,7 @@ object ExaSearchService : SearchService<SearchServiceOptions.ExaOptions> {
         put("text", buildJsonObject {
             put("maxCharacters", JsonPrimitive(MAX_EVIDENCE_TEXT_CHARACTERS))
         })
-        params["maxAgeHours"]?.let { put("maxAgeHours", it) }
+        optionalMaxAgeHours(params)?.let { put("maxAgeHours", it) }
     }
 
     internal fun mapSearchResult(data: ExaData): SearchResult = SearchResult(
@@ -324,4 +330,21 @@ object ExaSearchService : SearchService<SearchServiceOptions.ExaOptions> {
             ?: return
         builder.put(name, buildJsonArray { values.forEach { add(it) } })
     }
+
+    private fun hasOptionalString(params: JsonObject, name: String): Boolean =
+        runCatching {
+            params[name]?.jsonPrimitive?.contentOrNull?.isNotBlank() == true
+        }.getOrDefault(false)
+
+    private fun hasOptionalStringArray(params: JsonObject, name: String): Boolean =
+        runCatching {
+            params[name]?.jsonArray?.any {
+                it.jsonPrimitive.contentOrNull?.isNotBlank() == true
+            } == true
+        }.getOrDefault(false)
+
+    private fun optionalMaxAgeHours(params: JsonObject): Int? =
+        runCatching { params["maxAgeHours"]?.jsonPrimitive?.intOrNull }
+            .getOrNull()
+            ?.takeIf { it in MIN_MAX_AGE_HOURS..MAX_MAX_AGE_HOURS }
 }

--- a/search/src/main/java/me/rerere/search/ExaSearchService.kt
+++ b/search/src/main/java/me/rerere/search/ExaSearchService.kt
@@ -14,6 +14,8 @@ import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.add
 import kotlinx.serialization.json.buildJsonArray
 import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.put
 import me.rerere.ai.core.InputSchema
@@ -26,6 +28,9 @@ import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
 
 object ExaSearchService : SearchService<SearchServiceOptions.ExaOptions> {
+    private const val MAX_EVIDENCE_TEXT_CHARACTERS = 8_000
+    private const val MAX_EVIDENCE_HIGHLIGHT_CHARACTERS = 1_200
+
     override val name: String = "Exa"
 
     @Composable
@@ -56,6 +61,20 @@ object ExaSearchService : SearchService<SearchServiceOptions.ExaOptions> {
                         add("deep")
                     })
                 })
+                put("startPublishedDate", buildJsonObject {
+                    put("type", "string")
+                    put("description", "Optional ISO-8601 publication date lower bound; results are published after this date")
+                })
+                put("endPublishedDate", buildJsonObject {
+                    put("type", "string")
+                    put("description", "Optional ISO-8601 publication date upper bound; results are published before this date")
+                })
+                put("includeDomains", domainArraySchema("Optional domains to include"))
+                put("excludeDomains", domainArraySchema("Optional domains to exclude"))
+                put("maxAgeHours", buildJsonObject {
+                    put("type", "integer")
+                    put("description", "Optional maximum age in hours for fetched page content; use only when content freshness matters")
+                })
             },
             required = listOf("query")
         )
@@ -67,6 +86,10 @@ object ExaSearchService : SearchService<SearchServiceOptions.ExaOptions> {
                     put("type", "string")
                     put("description", "url to scrape")
                 })
+                put("maxAgeHours", buildJsonObject {
+                    put("type", "integer")
+                    put("description", "Optional maximum age in hours for fetched page content")
+                })
             },
             required = listOf("url")
         )
@@ -77,15 +100,7 @@ object ExaSearchService : SearchService<SearchServiceOptions.ExaOptions> {
         serviceOptions: SearchServiceOptions.ExaOptions
     ): Result<SearchResult> = withContext(Dispatchers.IO) {
         runCatching {
-            val query = params["query"]?.jsonPrimitive?.content ?: error("query is required")
-            val body = buildJsonObject {
-                put("query", JsonPrimitive(query))
-                put("numResults", JsonPrimitive(commonOptions.resultSize))
-                put("type", JsonPrimitive(params["type"]?.jsonPrimitive?.content ?: "auto"))
-                put("contents", buildJsonObject {
-                    put("text", JsonPrimitive(true))
-                })
-            }
+            val body = buildSearchRequestBody(params, commonOptions.resultSize)
             val apiKey = keyRoulette.next(serviceOptions.apiKey, serviceOptions.id.toString())
 
             val request = Request.Builder()
@@ -105,18 +120,7 @@ object ExaSearchService : SearchService<SearchServiceOptions.ExaOptions> {
                     error("Failed to decode response: $bodyRaw")
                 }.getOrThrow()
 
-                return@withContext Result.success(
-                    SearchResult(
-                        answer = response.output?.content,
-                        items = response.results.map {
-                            SearchResultItem(
-                                title = it.title,
-                                url = it.url,
-                                text = it.text ?: ""
-                            )
-                        },
-                        images = response.results.mapNotNull { it.image?.takeIf { url -> url.isNotBlank() } },
-                    ))
+                return@withContext Result.success(mapSearchResult(response))
             } else {
                 println(response.body.string())
                 error("response failed #${response.code}")
@@ -130,13 +134,7 @@ object ExaSearchService : SearchService<SearchServiceOptions.ExaOptions> {
         serviceOptions: SearchServiceOptions.ExaOptions
     ): Result<ScrapedResult> = withContext(Dispatchers.IO) {
         runCatching {
-            val url = params["url"]?.jsonPrimitive?.content ?: error("url is required")
-            val body = buildJsonObject {
-                put("urls", buildJsonArray {
-                    add(JsonPrimitive(url))
-                })
-                put("text", JsonPrimitive(true))
-            }
+            val body = buildScrapeRequestBody(params)
             val apiKey = keyRoulette.next(serviceOptions.apiKey, serviceOptions.id.toString())
 
             val request = Request.Builder()
@@ -156,19 +154,7 @@ object ExaSearchService : SearchService<SearchServiceOptions.ExaOptions> {
                     error("Failed to decode response: $bodyRaw")
                 }.getOrThrow()
 
-                return@withContext Result.success(
-                    ScrapedResult(
-                        urls = data.results.map {
-                            ScrapedResultUrl(
-                                url = it.url,
-                                content = it.text ?: "",
-                                metadata = ScrapedResultMetadata(
-                                    title = it.title,
-                                )
-                            )
-                        }
-                    )
-                )
+                return@withContext Result.success(mapScrapedResult(data))
             } else {
                 println(response.body.string())
                 error("response failed #${response.code}")
@@ -225,12 +211,117 @@ object ExaSearchService : SearchService<SearchServiceOptions.ExaOptions> {
         @SerialName("url")
         val url: String,
         @SerialName("publishedDate")
-        val publishedDate: String?,
+        val publishedDate: String? = null,
         @SerialName("author")
-        val author: String?,
+        val author: String? = null,
         @SerialName("text")
         val text: String? = null,
         @SerialName("image")
         val image: String? = null,
+        @SerialName("highlights")
+        val highlights: List<String>? = null,
     )
+
+    internal fun buildSearchRequestBody(
+        params: JsonObject,
+        resultSize: Int,
+    ) = buildJsonObject {
+        val query = params["query"]?.jsonPrimitive?.content ?: error("query is required")
+        val hasEvidenceOptions = listOf(
+            "startPublishedDate",
+            "endPublishedDate",
+            "includeDomains",
+            "excludeDomains",
+            "maxAgeHours",
+        ).any(params::containsKey)
+
+        put("query", JsonPrimitive(query))
+        put("numResults", JsonPrimitive(resultSize))
+        put("type", JsonPrimitive(params["type"]?.jsonPrimitive?.content ?: "auto"))
+        putOptionalString(this, params, "startPublishedDate")
+        putOptionalString(this, params, "endPublishedDate")
+        putOptionalStringArray(this, params, "includeDomains")
+        putOptionalStringArray(this, params, "excludeDomains")
+        put("contents", buildJsonObject {
+            if (hasEvidenceOptions) {
+                put("text", buildJsonObject {
+                    put("maxCharacters", JsonPrimitive(MAX_EVIDENCE_TEXT_CHARACTERS))
+                })
+                put("highlights", buildJsonObject {
+                    put("maxCharacters", JsonPrimitive(MAX_EVIDENCE_HIGHLIGHT_CHARACTERS))
+                })
+            } else {
+                put("text", JsonPrimitive(true))
+            }
+            params["maxAgeHours"]?.let { put("maxAgeHours", it) }
+        })
+    }
+
+    internal fun buildScrapeRequestBody(params: JsonObject) = buildJsonObject {
+        val url = params["url"]?.jsonPrimitive?.content ?: error("url is required")
+        put("urls", buildJsonArray {
+            add(JsonPrimitive(url))
+        })
+        put("text", buildJsonObject {
+            put("maxCharacters", JsonPrimitive(MAX_EVIDENCE_TEXT_CHARACTERS))
+        })
+        params["maxAgeHours"]?.let { put("maxAgeHours", it) }
+    }
+
+    internal fun mapSearchResult(data: ExaData): SearchResult = SearchResult(
+        answer = data.output?.content,
+        items = data.results.map {
+            SearchResultItem(
+                title = it.title,
+                url = it.url,
+                text = it.text ?: "",
+                publishedDate = it.publishedDate,
+                highlights = it.highlights.orEmpty(),
+            )
+        },
+        images = data.results.mapNotNull { it.image?.takeIf { url -> url.isNotBlank() } },
+    )
+
+    internal fun mapScrapedResult(data: ExaData): ScrapedResult = ScrapedResult(
+        urls = data.results.map {
+            ScrapedResultUrl(
+                url = it.url,
+                content = it.text ?: "",
+                metadata = ScrapedResultMetadata(
+                    title = it.title,
+                    publishedDate = it.publishedDate,
+                )
+            )
+        },
+    )
+
+    private fun domainArraySchema(description: String) = buildJsonObject {
+        put("type", "array")
+        put("description", description)
+        put("items", buildJsonObject {
+            put("type", "string")
+        })
+    }
+
+    private fun putOptionalString(
+        builder: kotlinx.serialization.json.JsonObjectBuilder,
+        params: JsonObject,
+        name: String,
+    ) {
+        params[name]?.jsonPrimitive?.contentOrNull
+            ?.takeIf { it.isNotBlank() }
+            ?.let { builder.put(name, it) }
+    }
+
+    private fun putOptionalStringArray(
+        builder: kotlinx.serialization.json.JsonObjectBuilder,
+        params: JsonObject,
+        name: String,
+    ) {
+        val values = params[name]?.jsonArray
+            ?.mapNotNull { it.jsonPrimitive.contentOrNull?.takeIf(String::isNotBlank) }
+            ?.takeIf { it.isNotEmpty() }
+            ?: return
+        builder.put(name, buildJsonArray { values.forEach { add(it) } })
+    }
 }

--- a/search/src/main/java/me/rerere/search/ExaSearchService.kt
+++ b/search/src/main/java/me/rerere/search/ExaSearchService.kt
@@ -27,12 +27,19 @@ import me.rerere.search.SearchService.Companion.keyRoulette
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
+import java.time.Instant
+import java.util.Locale
 
 object ExaSearchService : SearchService<SearchServiceOptions.ExaOptions> {
     private const val MAX_EVIDENCE_TEXT_CHARACTERS = 8_000
     private const val MAX_EVIDENCE_HIGHLIGHT_CHARACTERS = 1_200
     private const val MIN_MAX_AGE_HOURS = -1
     private const val MAX_MAX_AGE_HOURS = 720
+    private const val CURRENT_QUERY_MAX_AGE_HOURS = 0
+    private val temporalQueryPattern = Regex(
+        "\\b(latest|newest|current|currently|today|now|recent|recently|aktuell(?:ste|er|e|en)?|neueste|heute|derzeit)\\b",
+        RegexOption.IGNORE_CASE,
+    )
 
     override val name: String = "Exa"
 
@@ -107,7 +114,8 @@ object ExaSearchService : SearchService<SearchServiceOptions.ExaOptions> {
         serviceOptions: SearchServiceOptions.ExaOptions
     ): Result<SearchResult> = withContext(Dispatchers.IO) {
         runCatching {
-            val body = buildSearchRequestBody(params, commonOptions.resultSize)
+            val effectiveParams = prepareCurrentInfoParams(params)
+            val body = buildSearchRequestBody(effectiveParams, commonOptions.resultSize)
             val apiKey = keyRoulette.next(serviceOptions.apiKey, serviceOptions.id.toString())
 
             val request = Request.Builder()
@@ -127,7 +135,10 @@ object ExaSearchService : SearchService<SearchServiceOptions.ExaOptions> {
                     error("Failed to decode response: $bodyRaw")
                 }.getOrThrow()
 
-                return@withContext Result.success(mapSearchResult(response))
+                val result = mapSearchResult(response)
+                return@withContext Result.success(
+                    if (isCurrentInfoQuery(effectiveParams)) prioritizeCurrentResults(result) else result
+                )
             } else {
                 println(response.body.string())
                 error("response failed #${response.code}")
@@ -262,6 +273,58 @@ object ExaSearchService : SearchService<SearchServiceOptions.ExaOptions> {
             maxAgeHours?.let { put("maxAgeHours", it) }
         })
     }
+
+    /**
+     * Adds only conservative defaults for clearly time-sensitive queries. Explicit tool-call
+     * filters remain authoritative; ordinary queries keep the legacy request unchanged.
+     */
+    internal fun prepareCurrentInfoParams(params: JsonObject): JsonObject {
+        if (!isCurrentInfoQuery(params)) return params
+
+        val query = params["query"]?.jsonPrimitive?.contentOrNull ?: return params
+        val preferredDomains = preferredDomains(query)
+        val hasExplicitDomains = "includeDomains" in params
+
+        return buildJsonObject {
+            params.forEach { (name, value) -> put(name, value) }
+            if (!hasExplicitDomains && preferredDomains.isNotEmpty()) {
+                put("includeDomains", buildJsonArray { preferredDomains.forEach(::add) })
+            }
+            if ("maxAgeHours" !in params) {
+                put("maxAgeHours", CURRENT_QUERY_MAX_AGE_HOURS)
+            }
+        }
+    }
+
+    internal fun isCurrentInfoQuery(params: JsonObject): Boolean =
+        params["query"]?.jsonPrimitive?.contentOrNull?.let(::isCurrentInfoQuery) == true
+
+    internal fun isCurrentInfoQuery(query: String): Boolean =
+        temporalQueryPattern.containsMatchIn(query)
+
+    private fun preferredDomains(query: String): List<String> {
+        val normalized = query.lowercase(Locale.ROOT)
+        return buildList {
+            if ("rikkahub" in normalized) add("github.com")
+            if ("scaleway" in normalized) add("scaleway.com")
+            if ("berget" in normalized) add("berget.ai")
+            if ("opper" in normalized) add("opper.ai")
+        }.distinct()
+    }
+
+    internal fun prioritizeCurrentResults(result: SearchResult): SearchResult {
+        val items = result.items.withIndex()
+            .sortedWith(
+                compareBy<IndexedValue<SearchResultItem>> {
+                    publishedEpoch(it.value.publishedDate) == null
+                }.thenByDescending { publishedEpoch(it.value.publishedDate) ?: Long.MIN_VALUE }
+            )
+            .map { it.value }
+        return result.copy(items = items)
+    }
+
+    private fun publishedEpoch(value: String?): Long? =
+        value?.let { runCatching { Instant.parse(it).toEpochMilli() }.getOrNull() }
 
     internal fun buildScrapeRequestBody(params: JsonObject) = buildJsonObject {
         val url = params["url"]?.jsonPrimitive?.content ?: error("url is required")

--- a/search/src/main/java/me/rerere/search/ExaSearchService.kt
+++ b/search/src/main/java/me/rerere/search/ExaSearchService.kt
@@ -27,20 +27,12 @@ import me.rerere.search.SearchService.Companion.keyRoulette
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
-import java.time.Instant
-import java.util.Locale
 
 object ExaSearchService : SearchService<SearchServiceOptions.ExaOptions> {
     private const val MAX_EVIDENCE_TEXT_CHARACTERS = 8_000
     private const val MAX_EVIDENCE_HIGHLIGHT_CHARACTERS = 1_200
     private const val MIN_MAX_AGE_HOURS = -1
     private const val MAX_MAX_AGE_HOURS = 720
-    private const val CURRENT_QUERY_MAX_AGE_HOURS = 0
-    private val temporalQueryPattern = Regex(
-        "\\b(latest|newest|current|currently|today|now|recent|recently|aktuell(?:ste|er|e|en)?|neueste|heute|derzeit)\\b",
-        RegexOption.IGNORE_CASE,
-    )
-
     override val name: String = "Exa"
 
     @Composable
@@ -114,8 +106,7 @@ object ExaSearchService : SearchService<SearchServiceOptions.ExaOptions> {
         serviceOptions: SearchServiceOptions.ExaOptions
     ): Result<SearchResult> = withContext(Dispatchers.IO) {
         runCatching {
-            val effectiveParams = prepareCurrentInfoParams(params)
-            val body = buildSearchRequestBody(effectiveParams, commonOptions.resultSize)
+            val body = buildSearchRequestBody(params, commonOptions.resultSize)
             val apiKey = keyRoulette.next(serviceOptions.apiKey, serviceOptions.id.toString())
 
             val request = Request.Builder()
@@ -135,10 +126,7 @@ object ExaSearchService : SearchService<SearchServiceOptions.ExaOptions> {
                     error("Failed to decode response: $bodyRaw")
                 }.getOrThrow()
 
-                val result = mapSearchResult(response)
-                return@withContext Result.success(
-                    if (isCurrentInfoQuery(effectiveParams)) prioritizeCurrentResults(result) else result
-                )
+                return@withContext Result.success(mapSearchResult(response))
             } else {
                 println(response.body.string())
                 error("response failed #${response.code}")
@@ -273,58 +261,6 @@ object ExaSearchService : SearchService<SearchServiceOptions.ExaOptions> {
             maxAgeHours?.let { put("maxAgeHours", it) }
         })
     }
-
-    /**
-     * Adds only conservative defaults for clearly time-sensitive queries. Explicit tool-call
-     * filters remain authoritative; ordinary queries keep the legacy request unchanged.
-     */
-    internal fun prepareCurrentInfoParams(params: JsonObject): JsonObject {
-        if (!isCurrentInfoQuery(params)) return params
-
-        val query = params["query"]?.jsonPrimitive?.contentOrNull ?: return params
-        val preferredDomains = preferredDomains(query)
-        val hasExplicitDomains = "includeDomains" in params
-
-        return buildJsonObject {
-            params.forEach { (name, value) -> put(name, value) }
-            if (!hasExplicitDomains && preferredDomains.isNotEmpty()) {
-                put("includeDomains", buildJsonArray { preferredDomains.forEach(::add) })
-            }
-            if ("maxAgeHours" !in params) {
-                put("maxAgeHours", CURRENT_QUERY_MAX_AGE_HOURS)
-            }
-        }
-    }
-
-    internal fun isCurrentInfoQuery(params: JsonObject): Boolean =
-        params["query"]?.jsonPrimitive?.contentOrNull?.let(::isCurrentInfoQuery) == true
-
-    internal fun isCurrentInfoQuery(query: String): Boolean =
-        temporalQueryPattern.containsMatchIn(query)
-
-    private fun preferredDomains(query: String): List<String> {
-        val normalized = query.lowercase(Locale.ROOT)
-        return buildList {
-            if ("rikkahub" in normalized) add("github.com")
-            if ("scaleway" in normalized) add("scaleway.com")
-            if ("berget" in normalized) add("berget.ai")
-            if ("opper" in normalized) add("opper.ai")
-        }.distinct()
-    }
-
-    internal fun prioritizeCurrentResults(result: SearchResult): SearchResult {
-        val items = result.items.withIndex()
-            .sortedWith(
-                compareBy<IndexedValue<SearchResultItem>> {
-                    publishedEpoch(it.value.publishedDate) == null
-                }.thenByDescending { publishedEpoch(it.value.publishedDate) ?: Long.MIN_VALUE }
-            )
-            .map { it.value }
-        return result.copy(items = items)
-    }
-
-    private fun publishedEpoch(value: String?): Long? =
-        value?.let { runCatching { Instant.parse(it).toEpochMilli() }.getOrNull() }
 
     internal fun buildScrapeRequestBody(params: JsonObject) = buildJsonObject {
         val url = params["url"]?.jsonPrimitive?.content ?: error("url is required")

--- a/search/src/main/java/me/rerere/search/SearchService.kt
+++ b/search/src/main/java/me/rerere/search/SearchService.kt
@@ -102,18 +102,25 @@ data class SearchResult(
     val answer: String? = null,
     val items: List<SearchResultItem>,
     val images: List<String> = emptyList(),
+    /** Local time at which this result was retrieved; not a publication date. */
+    val retrievedAt: String? = null,
 ) {
     @Serializable
     data class SearchResultItem(
         val title: String,
         val url: String,
         val text: String,
+        /** Provider-supplied publication date. Null means that no date was supplied. */
+        val publishedDate: String? = null,
+        val highlights: List<String> = emptyList(),
     )
 }
 
 @Serializable
 data class ScrapedResult(
     val urls: List<ScrapedResultUrl>,
+    /** Local time at which this result was retrieved; not a publication date. */
+    val retrievedAt: String? = null,
 )
 
 @Serializable
@@ -128,6 +135,8 @@ data class ScrapedResultMetadata(
     val title: String? = null,
     val description: String? = null,
     val language: String? = null,
+    /** Provider-supplied publication date. Null means that no date was supplied. */
+    val publishedDate: String? = null,
 )
 
 @Serializable

--- a/search/src/test/java/me/rerere/search/ExaSearchServiceTest.kt
+++ b/search/src/test/java/me/rerere/search/ExaSearchServiceTest.kt
@@ -4,6 +4,7 @@ import kotlinx.serialization.json.buildJsonArray
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.boolean
 import kotlinx.serialization.json.int
+import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
@@ -107,6 +108,48 @@ class ExaSearchServiceTest {
             schema.properties["endPublishedDate"]!!.jsonObject["description"]!!.jsonPrimitive.content
                 .contains("before this date")
         )
+        assertEquals(-1, schema.properties["maxAgeHours"]!!.jsonObject["minimum"]!!.jsonPrimitive.int)
+        assertEquals(720, schema.properties["maxAgeHours"]!!.jsonObject["maximum"]!!.jsonPrimitive.int)
+    }
+
+    @Test
+    fun `empty and null optional values keep legacy request shape`() {
+        val body = ExaSearchService.buildSearchRequestBody(
+            params = buildJsonObject {
+                put("query", "stable knowledge")
+                put("startPublishedDate", "")
+                put("endPublishedDate", JsonNull)
+                put("includeDomains", buildJsonArray { add(JsonPrimitive("")) })
+                put("excludeDomains", buildJsonArray {})
+                put("maxAgeHours", JsonPrimitive("not-an-integer"))
+            },
+            resultSize = 10,
+        )
+
+        val contents = body["contents"]!!.jsonObject
+        assertEquals(true, contents["text"]!!.jsonPrimitive.boolean)
+        assertTrue("empty start date should be absent", "startPublishedDate" !in body)
+        assertTrue("null end date should be absent", "endPublishedDate" !in body)
+        assertTrue("empty include domains should be absent", "includeDomains" !in body)
+        assertTrue("empty exclude domains should be absent", "excludeDomains" !in body)
+        assertTrue("invalid max age should be absent", "maxAgeHours" !in contents)
+        assertTrue("legacy request should not request highlights", "highlights" !in contents)
+    }
+
+    @Test
+    fun `out of range max age is omitted`() {
+        val body = ExaSearchService.buildSearchRequestBody(
+            params = buildJsonObject {
+                put("query", "latest release")
+                put("maxAgeHours", 721)
+            },
+            resultSize = 10,
+        )
+
+        val contents = body["contents"]!!.jsonObject
+        assertTrue("out of range max age should be absent", "maxAgeHours" !in contents)
+        assertEquals(true, contents["text"]!!.jsonPrimitive.boolean)
+        assertTrue("out of range max age should not enable evidence mode", "highlights" !in contents)
     }
 
     @Test

--- a/search/src/test/java/me/rerere/search/ExaSearchServiceTest.kt
+++ b/search/src/test/java/me/rerere/search/ExaSearchServiceTest.kt
@@ -1,0 +1,127 @@
+package me.rerere.search
+
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.boolean
+import kotlinx.serialization.json.int
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.put
+import me.rerere.ai.core.InputSchema
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ExaSearchServiceTest {
+    @Test
+    fun `search mapping preserves publication date and highlights`() {
+        val result = ExaSearchService.mapSearchResult(
+            ExaSearchService.ExaData(
+                results = listOf(
+                    ExaSearchService.ExaResult(
+                        id = "result-1",
+                        title = "Official release",
+                        url = "https://example.com/release",
+                        publishedDate = "2026-08-31T06:26:20Z",
+                        highlights = listOf("Current release evidence"),
+                        text = "Release text",
+                    )
+                )
+            )
+        )
+
+        assertEquals("2026-08-31T06:26:20Z", result.items.single().publishedDate)
+        assertEquals(listOf("Current release evidence"), result.items.single().highlights)
+        assertEquals("https://example.com/release", result.items.single().url)
+    }
+
+    @Test
+    fun `missing publication date decodes as null`() {
+        val data = SearchService.json.decodeFromString<ExaSearchService.ExaData>(
+            """
+            {
+              "results": [{
+                "id": "result-1",
+                "title": "Undated result",
+                "url": "https://example.com/undated"
+              }]
+            }
+            """.trimIndent()
+        )
+
+        assertNull(ExaSearchService.mapSearchResult(data).items.single().publishedDate)
+    }
+
+    @Test
+    fun `normal search request keeps legacy contents shape`() {
+        val body = ExaSearchService.buildSearchRequestBody(
+            params = buildJsonObject {
+                put("query", "stable knowledge")
+            },
+            resultSize = 10,
+        )
+
+        assertEquals(true, body["contents"]!!.jsonObject["text"]!!.jsonPrimitive.boolean)
+        assertTrue("startPublishedDate should be absent", "startPublishedDate" !in body)
+        assertTrue("includeDomains should be absent", "includeDomains" !in body)
+    }
+
+    @Test
+    fun `evidence request serializes dates domains and content freshness`() {
+        val body = ExaSearchService.buildSearchRequestBody(
+            params = buildJsonObject {
+                put("query", "latest release")
+                put("startPublishedDate", "2026-08-01T00:00:00Z")
+                put("endPublishedDate", "2026-09-03T23:59:59Z")
+                put("includeDomains", buildJsonArray { add(JsonPrimitive("example.com")) })
+                put("excludeDomains", buildJsonArray { add(JsonPrimitive("old.example.com")) })
+                put("maxAgeHours", 1)
+            },
+            resultSize = 10,
+        )
+
+        assertEquals("2026-08-01T00:00:00Z", body["startPublishedDate"]!!.jsonPrimitive.content)
+        assertEquals("2026-09-03T23:59:59Z", body["endPublishedDate"]!!.jsonPrimitive.content)
+        assertEquals("example.com", body["includeDomains"]!!.jsonArray.single().jsonPrimitive.content)
+        assertEquals("old.example.com", body["excludeDomains"]!!.jsonArray.single().jsonPrimitive.content)
+        assertEquals(1, body["contents"]!!.jsonObject["maxAgeHours"]!!.jsonPrimitive.int)
+        assertEquals(
+            8_000,
+            body["contents"]!!.jsonObject["text"]!!.jsonObject["maxCharacters"]!!.jsonPrimitive.int
+        )
+        assertEquals(
+            1_200,
+            body["contents"]!!.jsonObject["highlights"]!!.jsonObject["maxCharacters"]!!.jsonPrimitive.int
+        )
+
+        val schema = ExaSearchService.parameters(SearchServiceOptions.ExaOptions()) as InputSchema.Obj
+        assertEquals("integer", schema.properties["maxAgeHours"]!!.jsonObject["type"]!!.jsonPrimitive.content)
+        assertTrue(
+            schema.properties["startPublishedDate"]!!.jsonObject["description"]!!.jsonPrimitive.content
+                .contains("after this date")
+        )
+        assertTrue(
+            schema.properties["endPublishedDate"]!!.jsonObject["description"]!!.jsonPrimitive.content
+                .contains("before this date")
+        )
+    }
+
+    @Test
+    fun `scrape request supports content freshness and bounded text`() {
+        val body = ExaSearchService.buildScrapeRequestBody(
+            buildJsonObject {
+                put("url", "https://example.com/release")
+                put("maxAgeHours", 0)
+            }
+        )
+
+        assertEquals(0, body["maxAgeHours"]!!.jsonPrimitive.int)
+        assertEquals(
+            8_000,
+            body["text"]!!.jsonObject["maxCharacters"]!!.jsonPrimitive.int
+        )
+    }
+}

--- a/search/src/test/java/me/rerere/search/ExaSearchServiceTest.kt
+++ b/search/src/test/java/me/rerere/search/ExaSearchServiceTest.kt
@@ -57,6 +57,81 @@ class ExaSearchServiceTest {
     }
 
     @Test
+    fun `current query adds conservative freshness and official domain defaults`() {
+        val params = buildJsonObject {
+            put("query", "What is the current stable RikkaHub version?")
+        }
+
+        val prepared = ExaSearchService.prepareCurrentInfoParams(params)
+
+        assertEquals("github.com", prepared["includeDomains"]!!.jsonArray.single().jsonPrimitive.content)
+        assertEquals(0, prepared["maxAgeHours"]!!.jsonPrimitive.int)
+        assertEquals("current query must preserve the user's exact wording", params["query"], prepared["query"])
+    }
+
+    @Test
+    fun `current query chooses known provider domains without overriding explicit filters`() {
+        val scaleway = ExaSearchService.prepareCurrentInfoParams(
+            buildJsonObject { put("query", "Is qwen currently available at Scaleway?") }
+        )
+        val berget = ExaSearchService.prepareCurrentInfoParams(
+            buildJsonObject { put("query", "Is Kimi K3 currently available through Berget or Opper?") }
+        )
+        val explicit = ExaSearchService.prepareCurrentInfoParams(
+            buildJsonObject {
+                put("query", "What is the current RikkaHub version?")
+                put("includeDomains", buildJsonArray { add(JsonPrimitive("example.com")) })
+                put("maxAgeHours", 12)
+            }
+        )
+
+        assertEquals("scaleway.com", scaleway["includeDomains"]!!.jsonArray.single().jsonPrimitive.content)
+        assertEquals(
+            listOf("berget.ai", "opper.ai"),
+            berget["includeDomains"]!!.jsonArray.map { it.jsonPrimitive.content },
+        )
+        assertEquals("example.com", explicit["includeDomains"]!!.jsonArray.single().jsonPrimitive.content)
+        assertEquals(12, explicit["maxAgeHours"]!!.jsonPrimitive.int)
+    }
+
+    @Test
+    fun `ordinary query keeps legacy parameters unchanged`() {
+        val params = buildJsonObject {
+            put("query", "How does version control work?")
+        }
+
+        assertEquals(params, ExaSearchService.prepareCurrentInfoParams(params))
+    }
+
+    @Test
+    fun `explicit empty or invalid freshness options are not overwritten`() {
+        val params = buildJsonObject {
+            put("query", "What is the current RikkaHub version?")
+            put("includeDomains", buildJsonArray {})
+            put("maxAgeHours", JsonPrimitive("invalid"))
+        }
+
+        assertEquals(params, ExaSearchService.prepareCurrentInfoParams(params))
+    }
+
+    @Test
+    fun `current result ordering prefers newest dated evidence and leaves undated last`() {
+        val result = ExaSearchService.mapSearchResult(
+            ExaSearchService.ExaData(
+                results = listOf(
+                    ExaSearchService.ExaResult("old", "Old", "https://example.com/old", "2026-01-01T00:00:00Z"),
+                    ExaSearchService.ExaResult("undated", "Undated", "https://example.com/undated"),
+                    ExaSearchService.ExaResult("new", "New", "https://example.com/new", "2026-09-01T00:00:00Z"),
+                )
+            )
+        )
+
+        val prioritized = ExaSearchService.prioritizeCurrentResults(result)
+
+        assertEquals(listOf("new", "old", "undated"), prioritized.items.map { it.url.substringAfterLast('/') })
+    }
+
+    @Test
     fun `normal search request keeps legacy contents shape`() {
         val body = ExaSearchService.buildSearchRequestBody(
             params = buildJsonObject {

--- a/search/src/test/java/me/rerere/search/ExaSearchServiceTest.kt
+++ b/search/src/test/java/me/rerere/search/ExaSearchServiceTest.kt
@@ -57,65 +57,20 @@ class ExaSearchServiceTest {
     }
 
     @Test
-    fun `current query adds conservative freshness and official domain defaults`() {
-        val params = buildJsonObject {
-            put("query", "What is the current stable RikkaHub version?")
-        }
+    fun `current query does not inject domain or freshness filters`() {
+        val body = ExaSearchService.buildSearchRequestBody(
+            params = buildJsonObject {
+                put("query", "What is the current stable RikkaHub version?")
+            },
+            resultSize = 10,
+        )
 
-        val prepared = ExaSearchService.prepareCurrentInfoParams(params)
-
-        assertEquals("github.com", prepared["includeDomains"]!!.jsonArray.single().jsonPrimitive.content)
-        assertEquals(0, prepared["maxAgeHours"]!!.jsonPrimitive.int)
-        assertEquals("current query must preserve the user's exact wording", params["query"], prepared["query"])
+        assertTrue("includeDomains" !in body)
+        assertTrue("maxAgeHours" !in body["contents"]!!.jsonObject)
     }
 
     @Test
-    fun `current query chooses known provider domains without overriding explicit filters`() {
-        val scaleway = ExaSearchService.prepareCurrentInfoParams(
-            buildJsonObject { put("query", "Is qwen currently available at Scaleway?") }
-        )
-        val berget = ExaSearchService.prepareCurrentInfoParams(
-            buildJsonObject { put("query", "Is Kimi K3 currently available through Berget or Opper?") }
-        )
-        val explicit = ExaSearchService.prepareCurrentInfoParams(
-            buildJsonObject {
-                put("query", "What is the current RikkaHub version?")
-                put("includeDomains", buildJsonArray { add(JsonPrimitive("example.com")) })
-                put("maxAgeHours", 12)
-            }
-        )
-
-        assertEquals("scaleway.com", scaleway["includeDomains"]!!.jsonArray.single().jsonPrimitive.content)
-        assertEquals(
-            listOf("berget.ai", "opper.ai"),
-            berget["includeDomains"]!!.jsonArray.map { it.jsonPrimitive.content },
-        )
-        assertEquals("example.com", explicit["includeDomains"]!!.jsonArray.single().jsonPrimitive.content)
-        assertEquals(12, explicit["maxAgeHours"]!!.jsonPrimitive.int)
-    }
-
-    @Test
-    fun `ordinary query keeps legacy parameters unchanged`() {
-        val params = buildJsonObject {
-            put("query", "How does version control work?")
-        }
-
-        assertEquals(params, ExaSearchService.prepareCurrentInfoParams(params))
-    }
-
-    @Test
-    fun `explicit empty or invalid freshness options are not overwritten`() {
-        val params = buildJsonObject {
-            put("query", "What is the current RikkaHub version?")
-            put("includeDomains", buildJsonArray {})
-            put("maxAgeHours", JsonPrimitive("invalid"))
-        }
-
-        assertEquals(params, ExaSearchService.prepareCurrentInfoParams(params))
-    }
-
-    @Test
-    fun `current result ordering prefers newest dated evidence and leaves undated last`() {
+    fun `search mapping preserves provider result order`() {
         val result = ExaSearchService.mapSearchResult(
             ExaSearchService.ExaData(
                 results = listOf(
@@ -126,9 +81,9 @@ class ExaSearchServiceTest {
             )
         )
 
-        val prioritized = ExaSearchService.prioritizeCurrentResults(result)
-
-        assertEquals(listOf("new", "old", "undated"), prioritized.items.map { it.url.substringAfterLast('/') })
+        assertEquals(
+            listOf("old", "undated", "new"),
+            result.items.map { it.url.substringAfterLast('/') })
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Preserve Exa publication-date evidence instead of dropping it during result mapping.
- Expose optional publication-date and domain filters already supported by Exa.
- Expose optional `maxAgeHours` for Exa content freshness.
- Keep evidence passed to the model bounded.
- Improve generic guidance for current-information searches.

## Bug

Exa already returns publication-date metadata, but RikkaHub currently discards this evidence before the result reaches the model.

For current/version/release-style searches this can make an older semantically relevant result indistinguishable from a newer result even though the provider supplied the publication date.

The same search path also cannot currently use Exa's optional publication-date/domain controls.

Related: #1569

## Fix

- Preserve optional `publishedDate` and bounded highlights in generic search results.
- Pass publication and retrieval evidence through to the existing model context.
- Add optional `startPublishedDate`, `endPublishedDate`, `includeDomains`, `excludeDomains`, and `maxAgeHours` parameters.
- Keep existing calls and default request behavior compatible.
- Preserve citation IDs and URL mapping.

## Backward compatibility

- All new fields are optional.
- Existing calls such as `{"query":"test"}` remain valid.
- No migration is required.
- No provider, model, default, or user configuration changes are included.
- No dependencies were changed.

## Non-goals

- No search agent.
- No reranker.
- No mandatory second search.
- No provider-specific application logic.
- No application-level Current-Info state machine.
- No new search provider.

## Validation

- `:search:testDebugUnitTest --tests me.rerere.search.ExaSearchServiceTest` — PASS, 5/5
- `:search:testDebugUnitTest` — PASS, 8/8
- `:app:testDebugUnitTest --tests me.rerere.rikkahub.data.ai.tools.SearchToolsTest` — PASS, 2/2
- `:search:compileDebugKotlin` — PASS
- `:app:compileDebugKotlin` — PASS
- `:workspace:configureCMakeDebug[arm64-v8a]` — PASS
- `git diff --check` — PASS

No APK was built or installed.
