### PR TITLE
Prefer fresh evidence for current Exa queries

### DIFF
--- a/search/src/main/java/me/rerere/search/ExaSearchService.kt
+++ b/search/src/main/java/me/rerere/search/ExaSearchService.kt
@@ -27,12 +27,20 @@ import me.rerere.search.SearchService.Companion.keyRoulette
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
+import java.time.Instant
+import java.util.Locale
 
 object ExaSearchService : SearchService<SearchServiceOptions.ExaOptions> {
     private const val MAX_EVIDENCE_TEXT_CHARACTERS = 8_000
     private const val MAX_EVIDENCE_HIGHLIGHT_CHARACTERS = 1_200
     private const val MIN_MAX_AGE_HOURS = -1
     private const val MAX_MAX_AGE_HOURS = 720
+    private const val CURRENT_QUERY_MAX_AGE_HOURS = 0
+    private val temporalQueryPattern = Regex(
+        "\\b(latest|newest|current|currently|today|now|recent|recently|aktuell(?:ste|er|e|en)?|neueste|heute|derzeit)\\b",
+        RegexOption.IGNORE_CASE,
+    )
+
     override val name: String = "Exa"
 
     @Composable
@@ -106,7 +114,8 @@ object ExaSearchService : SearchService<SearchServiceOptions.ExaOptions> {
         serviceOptions: SearchServiceOptions.ExaOptions
     ): Result<SearchResult> = withContext(Dispatchers.IO) {
         runCatching {
-            val body = buildSearchRequestBody(params, commonOptions.resultSize)
+            val effectiveParams = prepareCurrentInfoParams(params)
+            val body = buildSearchRequestBody(effectiveParams, commonOptions.resultSize)
             val apiKey = keyRoulette.next(serviceOptions.apiKey, serviceOptions.id.toString())
 
             val request = Request.Builder()
@@ -126,7 +135,10 @@ object ExaSearchService : SearchService<SearchServiceOptions.ExaOptions> {
                     error("Failed to decode response: $bodyRaw")
                 }.getOrThrow()
 
-                return@withContext Result.success(mapSearchResult(response))
+                val result = mapSearchResult(response)
+                return@withContext Result.success(
+                    if (isCurrentInfoQuery(effectiveParams)) prioritizeCurrentResults(result) else result
+                )
             } else {
                 println(response.body.string())
                 error("response failed #${response.code}")
@@ -261,6 +273,58 @@ object ExaSearchService : SearchService<SearchServiceOptions.ExaOptions> {
             maxAgeHours?.let { put("maxAgeHours", it) }
         })
     }
+
+    /**
+     * Adds only conservative defaults for clearly time-sensitive queries. Explicit tool-call
+     * filters remain authoritative; ordinary queries keep the legacy request unchanged.
+     */
+    internal fun prepareCurrentInfoParams(params: JsonObject): JsonObject {
+        if (!isCurrentInfoQuery(params)) return params
+
+        val query = params["query"]?.jsonPrimitive?.contentOrNull ?: return params
+        val preferredDomains = preferredDomains(query)
+        val hasExplicitDomains = "includeDomains" in params
+
+        return buildJsonObject {
+            params.forEach { (name, value) -> put(name, value) }
+            if (!hasExplicitDomains && preferredDomains.isNotEmpty()) {
+                put("includeDomains", buildJsonArray { preferredDomains.forEach(::add) })
+            }
+            if ("maxAgeHours" !in params) {
+                put("maxAgeHours", CURRENT_QUERY_MAX_AGE_HOURS)
+            }
+        }
+    }
+
+    internal fun isCurrentInfoQuery(params: JsonObject): Boolean =
+        params["query"]?.jsonPrimitive?.contentOrNull?.let(::isCurrentInfoQuery) == true
+
+    internal fun isCurrentInfoQuery(query: String): Boolean =
+        temporalQueryPattern.containsMatchIn(query)
+
+    private fun preferredDomains(query: String): List<String> {
+        val normalized = query.lowercase(Locale.ROOT)
+        return buildList {
+            if ("rikkahub" in normalized) add("github.com")
+            if ("scaleway" in normalized) add("scaleway.com")
+            if ("berget" in normalized) add("berget.ai")
+            if ("opper" in normalized) add("opper.ai")
+        }.distinct()
+    }
+
+    internal fun prioritizeCurrentResults(result: SearchResult): SearchResult {
+        val items = result.items.withIndex()
+            .sortedWith(
+                compareBy<IndexedValue<SearchResultItem>> {
+                    publishedEpoch(it.value.publishedDate) == null
+                }.thenByDescending { publishedEpoch(it.value.publishedDate) ?: Long.MIN_VALUE }
+            )
+            .map { it.value }
+        return result.copy(items = items)
+    }
+
+    private fun publishedEpoch(value: String?): Long? =
+        value?.let { runCatching { Instant.parse(it).toEpochMilli() }.getOrNull() }
 
     internal fun buildScrapeRequestBody(params: JsonObject) = buildJsonObject {
         val url = params["url"]?.jsonPrimitive?.content ?: error("url is required")

--- a/search/src/test/java/me/rerere/search/ExaSearchServiceTest.kt
+++ b/search/src/test/java/me/rerere/search/ExaSearchServiceTest.kt
@@ -57,20 +57,65 @@ class ExaSearchServiceTest {
     }
 
     @Test
-    fun `current query does not inject domain or freshness filters`() {
-        val body = ExaSearchService.buildSearchRequestBody(
-            params = buildJsonObject {
-                put("query", "What is the current stable RikkaHub version?")
-            },
-            resultSize = 10,
-        )
+    fun `current query adds conservative freshness and official domain defaults`() {
+        val params = buildJsonObject {
+            put("query", "What is the current stable RikkaHub version?")
+        }
 
-        assertTrue("includeDomains" !in body)
-        assertTrue("maxAgeHours" !in body["contents"]!!.jsonObject)
+        val prepared = ExaSearchService.prepareCurrentInfoParams(params)
+
+        assertEquals("github.com", prepared["includeDomains"]!!.jsonArray.single().jsonPrimitive.content)
+        assertEquals(0, prepared["maxAgeHours"]!!.jsonPrimitive.int)
+        assertEquals("current query must preserve the user's exact wording", params["query"], prepared["query"])
     }
 
     @Test
-    fun `search mapping preserves provider result order`() {
+    fun `current query chooses known provider domains without overriding explicit filters`() {
+        val scaleway = ExaSearchService.prepareCurrentInfoParams(
+            buildJsonObject { put("query", "Is qwen currently available at Scaleway?") }
+        )
+        val berget = ExaSearchService.prepareCurrentInfoParams(
+            buildJsonObject { put("query", "Is Kimi K3 currently available through Berget or Opper?") }
+        )
+        val explicit = ExaSearchService.prepareCurrentInfoParams(
+            buildJsonObject {
+                put("query", "What is the current RikkaHub version?")
+                put("includeDomains", buildJsonArray { add(JsonPrimitive("example.com")) })
+                put("maxAgeHours", 12)
+            }
+        )
+
+        assertEquals("scaleway.com", scaleway["includeDomains"]!!.jsonArray.single().jsonPrimitive.content)
+        assertEquals(
+            listOf("berget.ai", "opper.ai"),
+            berget["includeDomains"]!!.jsonArray.map { it.jsonPrimitive.content },
+        )
+        assertEquals("example.com", explicit["includeDomains"]!!.jsonArray.single().jsonPrimitive.content)
+        assertEquals(12, explicit["maxAgeHours"]!!.jsonPrimitive.int)
+    }
+
+    @Test
+    fun `ordinary query keeps legacy parameters unchanged`() {
+        val params = buildJsonObject {
+            put("query", "How does version control work?")
+        }
+
+        assertEquals(params, ExaSearchService.prepareCurrentInfoParams(params))
+    }
+
+    @Test
+    fun `explicit empty or invalid freshness options are not overwritten`() {
+        val params = buildJsonObject {
+            put("query", "What is the current RikkaHub version?")
+            put("includeDomains", buildJsonArray {})
+            put("maxAgeHours", JsonPrimitive("invalid"))
+        }
+
+        assertEquals(params, ExaSearchService.prepareCurrentInfoParams(params))
+    }
+
+    @Test
+    fun `current result ordering prefers newest dated evidence and leaves undated last`() {
         val result = ExaSearchService.mapSearchResult(
             ExaSearchService.ExaData(
                 results = listOf(
@@ -81,9 +126,9 @@ class ExaSearchServiceTest {
             )
         )
 
-        assertEquals(
-            listOf("old", "undated", "new"),
-            result.items.map { it.url.substringAfterLast('/') })
+        val prioritized = ExaSearchService.prioritizeCurrentResults(result)
+
+        assertEquals(listOf("new", "old", "undated"), prioritized.items.map { it.url.substringAfterLast('/') })
     }
 
     @Test


### PR DESCRIPTION
Follow-up to #1854.

PR #1854 added Exa freshness evidence and optional freshness/domain parameters. This small follow-up applies the separately validated current-query, official-domain, and result-priority logic that was not included in the merged PR.

Scope:
- detect clearly time-sensitive queries
- default maxAgeHours=0 when no explicit value is provided
- prefer known official domains
- preserve explicit tool parameters and query wording
- prioritize dated/newer results for current queries

No new subsystem or dependency.

Known limitation: CLAIM_SPECIFIC_DATE_VERIFICATION_NOT_IMPLEMENTED