### PR TITLE
fix(web-ui): 修复选择模型弹窗厂商标签堆叠

### DIFF
--- a/web-ui/app/components/input/model-list.tsx
+++ b/web-ui/app/components/input/model-list.tsx
@@ -369,7 +369,7 @@ export function ModelList({ disabled = false, className, onChanged }: ModelListP
               </div>
             ) : (
               <div className="flex min-h-0 flex-col gap-2">
-                <ScrollArea className="max-h-20 w-full">
+                <ScrollArea className="max-h-20 w-full **:data-[slot=scroll-area-viewport]:max-h-20">
                   <div className="flex flex-wrap items-center gap-1.5 pb-1">
                     {favoriteModels.length > 0 && (
                       <button
@@ -414,7 +414,7 @@ export function ModelList({ disabled = false, className, onChanged }: ModelListP
                   </div>
                 </ScrollArea>
 
-                <ScrollArea className="h-auto max-h-64 [&_[data-slot=scroll-area-viewport]]:max-h-64">
+                <ScrollArea className="h-auto max-h-64 **:data-[slot=scroll-area-viewport]:max-h-64">
                   <div className="space-y-0.5">
                     {displayedModels.map((model) => (
                       <ModelOptionRow


### PR DESCRIPTION
Fixes #1870

## Problem

v2.5.0「选择模型」弹窗内厂商 chips 全部铺开堆叠、无法滚动，与模型列表区挤作一团。2.4.x 正常。

## Root Cause

在 f2f687f0 的重构中去掉外层固定高度 `h-[24rem]`。radix `ScrollArea` 的 Viewport 是 `height:100%`，没有外层固定高度撑着就退化成内容高度，导致 chips 区的 `max-h-20` 限不住 Viewport，所有 chips 铺开。模型列表区已加 viewport 兜底，chips 区漏了

## Change

仅 2 行 className，无逻辑变更

- chips 区补 viewport 兜底（修复核心）
- 顺带：两处 viewport 兜底统一为v4 简写，与项目其他组件一致，消除 Tailwind CSS lint hint

## Verification

dev server 注入 20 厂商 × 5 模型复现：

> v2.4.x 正常
<img width="1567" height="850" alt="08b495a1c9f207a64cab4e23dcceed54" src="https://github.com/user-attachments/assets/5ccd15b6-4a52-402b-b076-1772a65d70cb" />

> v2.5.0 bug
<img width="1566" height="855" alt="4b1b8e40dfb55a5feadcc915b48b2575" src="https://github.com/user-attachments/assets/24f4a9a4-db71-4ccf-9e1b-27464dc2bca9" />

> 修复后
<img width="1562" height="847" alt="e64ab0c3095c2a7ecf95f9cc512e9b4d" src="https://github.com/user-attachments/assets/563c4083-78e9-4648-a9aa-754d0d77e047" />
