### PR TITLE
fix(chat): don't crash when workspace_edit_file input is not a JSON object

### DIFF
--- a/app/src/main/java/me/rerere/rikkahub/ui/components/message/ChatMessageEditedFiles.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/message/ChatMessageEditedFiles.kt
@@ -36,7 +36,7 @@ import androidx.compose.ui.unit.dp
 import androidx.core.content.FileProvider
 import kotlinx.coroutines.launch
 import kotlinx.serialization.json.contentOrNull
-import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import me.rerere.ai.ui.UIMessagePart
 import me.rerere.hugeicons.HugeIcons
@@ -64,7 +64,7 @@ internal fun EditedFilesList(
         parts.filterIsInstance<UIMessagePart.Tool>()
             .filter { it.toolName in WORKSPACE_FILE_TOOL_NAMES && it.isExecuted }
             .mapNotNull { tool ->
-                tool.inputAsJson().jsonObject["path"]?.jsonPrimitive?.contentOrNull
+(tool.inputAsJson() as? JsonObject)?.get("path")?.jsonPrimitive?.contentOrNull
             }
             .distinct()
     }


### PR DESCRIPTION
## Problem

When a conversation contains a `workspace_edit_file` tool call whose stored arguments are a JSON array (e.g. produced by streaming tool-call merging through a third-party relay/proxy), reopening that conversation crashes the whole chat page:

```
java.lang.IllegalArgumentException:
Element class kotlinx.serialization.json.JsonArray is not a JsonObject
  at kotlinx.serialization.json.JsonElementKt.getJsonObject(...)
  at me.rerere.rikkahub.ui.components.message.ChatMessageEditedFilesKt.EditedFilesList(...)
```

Reproduced by the reporter in #1873: the malformed tool arguments are persisted in `message_node`, the JSON itself is valid, but `EditedFilesList` unconditionally calls `inputAsJson().jsonObject` to read the `path` field.

## Fix

Use a safe cast to `JsonObject` instead of the throwing `.jsonObject` accessor. Malformed tool inputs are now simply skipped when building the edited-files list, matching the expected behavior in the issue: ignore invalid tool parameters instead of crashing.

This is a UI-level defensive fix only; it does not attempt to validate/normalize tool arguments at execution or message-save time.

Fixes #1873