### PR TITLE
修复图片编辑确认耗时过长

### DIFF
--- a/app/src/main/java/me/rerere/rikkahub/ui/components/ai/CropLauncher.kt
+++ b/app/src/main/java/me/rerere/rikkahub/ui/components/ai/CropLauncher.kt
@@ -68,7 +68,11 @@ internal fun useCropLauncher(
             setAllowedGestures(
                 UCropActivity.SCALE, UCropActivity.ROTATE, UCropActivity.NONE
             )
-            setCompressionFormat(Bitmap.CompressFormat.PNG)
+            // Chat attachments are written to a .jpg output file. PNG encoding is
+            // particularly expensive for large camera/gallery images and provides
+            // no benefit for this flow, so use JPEG to keep confirmation responsive.
+            setCompressionFormat(Bitmap.CompressFormat.JPEG)
+            setCompressionQuality(90)
         }).withMaxResultSize(4096, 4096)
         aspectRatio?.let { (x, y) ->
             crop = crop.withAspectRatio(x, y)


### PR DESCRIPTION
从相册或拍照向聊天插入图片时，即使不做任何修改，点击右上角确定后仍需要等待较长时间。

原因是图片编辑流程将结果配置为 PNG 压缩，但输出文件后缀为 .jpg。对于大尺寸图片，PNG 编码耗时较长，生成的文件体积也可能较大。

修复： 将 UCrop 输出格式改为 JPEG，并设置压缩质量为 90

Closes #1891